### PR TITLE
Make region mandatory in the KEB schema

### DIFF
--- a/internal/appinfo/runtime_info.go
+++ b/internal/appinfo/runtime_info.go
@@ -157,7 +157,7 @@ func (h *RuntimeInfoHandler) planNameOrDefault(inst internal.InstanceWithOperati
 	if inst.ServicePlanName != "" {
 		return inst.ServicePlanName
 	}
-	return broker.Plans(h.plansConfig, "", false, false)[inst.ServicePlanID].Name
+	return broker.Plans(h.plansConfig, "", false, false, false)[inst.ServicePlanID].Name
 }
 
 func getIfNotZero(in time.Time) *time.Time {

--- a/internal/appinfo/runtime_info.go
+++ b/internal/appinfo/runtime_info.go
@@ -157,7 +157,7 @@ func (h *RuntimeInfoHandler) planNameOrDefault(inst internal.InstanceWithOperati
 	if inst.ServicePlanName != "" {
 		return inst.ServicePlanName
 	}
-	return broker.Plans(h.plansConfig, "", false, false, false)[inst.ServicePlanID].Name
+	return broker.Plans(h.plansConfig, "", false, false)[inst.ServicePlanID].Name
 }
 
 func getIfNotZero(in time.Time) *time.Time {

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -428,7 +428,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), !CallFromUI)
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -428,7 +428,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), false)
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -428,7 +428,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), false)
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -414,7 +414,7 @@ func (b *UpdateEndpoint) processExpirationParam(instance *internal.Instance, det
 }
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), !CallFromUI)
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -414,7 +414,7 @@ func (b *UpdateEndpoint) processExpirationParam(instance *internal.Instance, det
 }
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), false)
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -414,7 +414,7 @@ func (b *UpdateEndpoint) processExpirationParam(instance *internal.Instance, det
 }
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), false)
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -219,20 +219,15 @@ func OwnClusterSchema(update bool) *map[string]interface{} {
 	}
 
 	if update {
-		return createSchemaForOwnCluster(properties.UpdateProperties, update)
+		return createSchemaWith(properties.UpdateProperties, update, []string{"name", "kubeconfig", "shootName", "shootDomain"})
 	} else {
-		return createSchemaForOwnCluster(properties, update)
+		return createSchemaWith(properties, update, []string{"name", "kubeconfig", "shootName", "shootDomain"})
 	}
 }
 
 func empty() *map[string]interface{} {
 	empty := make(map[string]interface{}, 0)
 	return &empty
-}
-
-func createSchema(machineTypesDisplay map[string]string, machineTypes, regions []string, additionalParams, update bool, required []string) *map[string]interface{} {
-	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, regions, update)
-	return createSchemaWithProperties(properties, additionalParams, update, required)
 }
 
 func createSchemaWithProperties(properties ProvisioningProperties, additionalParams, update bool, requiered []string) *map[string]interface{} {
@@ -247,32 +242,8 @@ func createSchemaWithProperties(properties ProvisioningProperties, additionalPar
 	}
 }
 
-func createTrialSchemaWithProperties(properties ProvisioningProperties, additionalParams, update bool) *map[string]interface{} {
-	if additionalParams {
-		properties.IncludeAdditional()
-	}
-
-	if update {
-		return createTrialSchemaWith(properties.UpdateProperties, update)
-	} else {
-		return createTrialSchemaWith(properties, update)
-	}
-}
-
 func createSchemaWith(properties interface{}, update bool, required []string) *map[string]interface{} {
 	schema := NewSchema(properties, update, required)
-
-	return unmarshalSchema(schema)
-}
-
-func createTrialSchemaWith(properties interface{}, update bool) *map[string]interface{} {
-	schema := NewSchemaWithOnlyNameAndRegionRequired(properties, update)
-
-	return unmarshalSchema(schema)
-}
-
-func createSchemaForOwnCluster(properties interface{}, update bool) *map[string]interface{} {
-	schema := NewSchemaForOwnCluster(properties, update, []string{"name", "kubeconfig", "shootName", "shootDomain"})
 
 	return unmarshalSchema(schema)
 }

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -113,6 +113,18 @@ func OpenStackRegions() []string {
 	return []string{"eu-de-1", "ap-sa-1"}
 }
 
+func requiredSchemaProperties() []string {
+	return []string{"name, region"}
+}
+
+func requiredTrialSchemaProperties() []string {
+	return []string{"name"}
+}
+
+func requiredOwnClusterSchemaProperties() []string {
+	return []string{"name", "kubeconfig", "shootName", "shootDomain"}
+}
+
 func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
@@ -121,7 +133,7 @@ func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMax.Default = 8
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -130,7 +142,7 @@ func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string,
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
 	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
@@ -138,7 +150,7 @@ func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = GCPRegions()[0]
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -146,7 +158,7 @@ func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -154,7 +166,7 @@ func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, a
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -167,7 +179,7 @@ func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMin.Default = 2
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -193,7 +205,7 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 	}
 	properties.Region.Default = regions[0]
 
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func TrialSchema(additionalParams, update bool) *map[string]interface{} {
@@ -205,7 +217,7 @@ func TrialSchema(additionalParams, update bool) *map[string]interface{} {
 		return empty()
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update, []string{"name"})
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
 func OwnClusterSchema(update bool) *map[string]interface{} {
@@ -219,9 +231,9 @@ func OwnClusterSchema(update bool) *map[string]interface{} {
 	}
 
 	if update {
-		return createSchemaWith(properties.UpdateProperties, update, []string{"name", "kubeconfig", "shootName", "shootDomain"})
+		return createSchemaWith(properties.UpdateProperties, update, requiredOwnClusterSchemaProperties())
 	} else {
-		return createSchemaWith(properties, update, []string{"name", "kubeconfig", "shootName", "shootDomain"})
+		return createSchemaWith(properties, update, requiredOwnClusterSchemaProperties())
 	}
 }
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -110,7 +110,7 @@ func AWSRegions(euRestrictedAccess bool) []string {
 }
 
 func OpenStackRegions() []string {
-	return []string{"eu-de-1", "ap-sa-1"}
+	return []string{"eu-de-2", "eu-de-1", "ap-sa-1"}
 }
 
 func requiredSchemaProperties() []string {

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -215,6 +215,10 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 			Enum: ToInterfaceSlice(regions),
 		},
 	}
+	if !update {
+		properties.Networking = NewNetworkingSchema()
+	}
+
 	properties.Region.Default = defaultRegion
 
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -116,6 +116,7 @@ func OpenStackRegions() []string {
 func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
+	properties.Region.Default = OpenStackRegions()[0]
 	if !update {
 		properties.AutoScalerMax.Default = 8
 	}
@@ -128,6 +129,7 @@ func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string,
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
+	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
@@ -135,6 +137,7 @@ func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, GCPRegions(), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
+	properties.Region.Default = GCPRegions()[0]
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
@@ -142,6 +145,7 @@ func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
+	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
@@ -149,12 +153,14 @@ func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, a
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
+	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
 func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Maximum = 40
+	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
 
 	if !update {
 		properties.AutoScalerMax.Default = 10
@@ -185,9 +191,7 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 			Enum: ToInterfaceSlice(regions),
 		},
 	}
-	if !update {
-		properties.Networking = NewNetworkingSchema()
-	}
+	properties.Region.Default = regions[0]
 
 	return createSchemaWithProperties(properties, additionalParams, update)
 }

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -31,6 +31,14 @@ const (
 	OwnClusterPlanName = "own_cluster"
 	PreviewPlanID      = "5cb3d976-b85c-42ea-a636-79cadda109a9"
 	PreviewPlanName    = "preview"
+
+	DefaultAWSRegion           = "eu-central-1"
+	DefaultAWSTrialRegion      = "eu-west-1"
+	DefaultEuAccessAWSRegion   = "eu-central-1"
+	DefaultAzureRegion         = "eastus"
+	DefaultEuAccessAzureRegion = "switzerlandnorth"
+	DefaultGCPRegion           = "europe-west3"
+	DefaultOpenStackRegion     = "eu-de-2"
 )
 
 var PlanNamesMapping = map[string]string{
@@ -141,7 +149,7 @@ func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string,
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
-	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
+	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
@@ -149,7 +157,7 @@ func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, GCPRegions(), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
-	properties.Region.Default = GCPRegions()[0]
+	properties.Region.Default = getDefaultGCPRegion()
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
@@ -157,7 +165,7 @@ func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
-	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
+	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
@@ -165,14 +173,14 @@ func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, a
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
-	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
+	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Maximum = 40
-	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
+	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
 
 	if !update {
 		properties.AutoScalerMax.Default = 10
@@ -188,13 +196,17 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 	}
 
 	var regions []string
+	var defaultRegion string
 	switch provider {
 	case internal.AWS:
 		regions = AWSRegions(euAccessRestricted)
+		defaultRegion = getDefaultAWSRegion(euAccessRestricted)
 	case internal.Azure:
 		regions = AzureRegions(euAccessRestricted)
+		defaultRegion = getDefaultAzureRegion(euAccessRestricted)
 	default:
 		regions = AWSRegions(euAccessRestricted)
+		defaultRegion = getDefaultAWSRegion(euAccessRestricted)
 	}
 	properties := ProvisioningProperties{
 		Name: NameProperty(),
@@ -203,7 +215,7 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 			Enum: ToInterfaceSlice(regions),
 		},
 	}
-	properties.Region.Default = regions[0]
+	properties.Region.Default = defaultRegion
 
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
@@ -455,4 +467,26 @@ func filter(items *[]interface{}, included map[string]interface{}) interface{} {
 	}
 
 	return output
+}
+
+func getDefaultOpenStackRegion() string {
+	return DefaultOpenStackRegion
+}
+
+func getDefaultAWSRegion(euAccessRestricted bool) string {
+	if euAccessRestricted {
+		return DefaultEuAccessAWSRegion
+	}
+	return DefaultAWSRegion
+}
+
+func getDefaultGCPRegion() string {
+	return DefaultGCPRegion
+}
+
+func getDefaultAzureRegion(euAccessRestricted bool) string {
+	if euAccessRestricted {
+		return DefaultEuAccessAzureRegion
+	}
+	return DefaultAzureRegion
 }

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -121,7 +121,7 @@ func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMax.Default = 8
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -130,7 +130,7 @@ func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string,
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
 	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
@@ -138,7 +138,7 @@ func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = GCPRegions()[0]
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -146,7 +146,7 @@ func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, add
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = AWSRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -154,7 +154,7 @@ func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, a
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = AzureRegions(euAccessRestricted)[0]
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -167,7 +167,7 @@ func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMin.Default = 2
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
@@ -193,7 +193,7 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 	}
 	properties.Region.Default = regions[0]
 
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name, region"})
 }
 
 func TrialSchema(additionalParams, update bool) *map[string]interface{} {
@@ -205,7 +205,7 @@ func TrialSchema(additionalParams, update bool) *map[string]interface{} {
 		return empty()
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, []string{"name"})
 }
 
 func OwnClusterSchema(update bool) *map[string]interface{} {
@@ -230,25 +230,43 @@ func empty() *map[string]interface{} {
 	return &empty
 }
 
-func createSchema(machineTypesDisplay map[string]string, machineTypes, regions []string, additionalParams, update bool) *map[string]interface{} {
+func createSchema(machineTypesDisplay map[string]string, machineTypes, regions []string, additionalParams, update bool, required []string) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, regions, update)
-	return createSchemaWithProperties(properties, additionalParams, update)
+	return createSchemaWithProperties(properties, additionalParams, update, required)
 }
 
-func createSchemaWithProperties(properties ProvisioningProperties, additionalParams, update bool) *map[string]interface{} {
+func createSchemaWithProperties(properties ProvisioningProperties, additionalParams, update bool, requiered []string) *map[string]interface{} {
 	if additionalParams {
 		properties.IncludeAdditional()
 	}
 
 	if update {
-		return createSchemaWith(properties.UpdateProperties, update)
+		return createSchemaWith(properties.UpdateProperties, update, requiered)
 	} else {
-		return createSchemaWith(properties, update)
+		return createSchemaWith(properties, update, requiered)
 	}
 }
 
-func createSchemaWith(properties interface{}, update bool) *map[string]interface{} {
-	schema := NewSchemaWithOnlyNameRequired(properties, update)
+func createTrialSchemaWithProperties(properties ProvisioningProperties, additionalParams, update bool) *map[string]interface{} {
+	if additionalParams {
+		properties.IncludeAdditional()
+	}
+
+	if update {
+		return createTrialSchemaWith(properties.UpdateProperties, update)
+	} else {
+		return createTrialSchemaWith(properties, update)
+	}
+}
+
+func createSchemaWith(properties interface{}, update bool, required []string) *map[string]interface{} {
+	schema := NewSchema(properties, update, required)
+
+	return unmarshalSchema(schema)
+}
+
+func createTrialSchemaWith(properties interface{}, update bool) *map[string]interface{} {
+	schema := NewSchemaWithOnlyNameAndRegionRequired(properties, update)
 
 	return unmarshalSchema(schema)
 }

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -133,51 +133,65 @@ func requiredOwnClusterSchemaProperties() []string {
 	return []string{"name", "kubeconfig", "shootName", "shootDomain"}
 }
 
-func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
 	properties.Region.Default = getDefaultOpenStackRegion()
 	if !update {
 		properties.AutoScalerMax.Default = 8
 	}
-
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
+func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
 	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, GCPRegions(), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultGCPRegion()
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
+func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
+func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
+func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Maximum = 40
 	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
@@ -187,10 +201,13 @@ func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMin.Default = 2
 	}
 
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
-func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
+func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
 	if update && !additionalParams {
 		return empty()
 	}
@@ -221,7 +238,10 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 
 	properties.Region.Default = defaultRegion
 
-	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	if callFromUI {
+		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
+	}
+	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
 }
 
 func TrialSchema(additionalParams, update bool) *map[string]interface{} {
@@ -292,7 +312,7 @@ func unmarshalSchema(schema *RootSchema) *map[string]interface{} {
 
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
-func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool) map[string]domain.ServicePlan {
+func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, callFroumUI bool) map[string]domain.ServicePlan {
 	awsMachines := []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"}
 	awsMachinesDisplay := map[string]string{
 		// source: https://aws.amazon.com/ec2/instance-types/m5/
@@ -320,14 +340,14 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
 		"n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)",
 	}
-	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, false)
+	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, false, callFroumUI)
 
 	openStackMachines := []string{"g_c4_m16", "g_c8_m32"}
 	openStackMachinesDisplay := map[string]string{
 		"g_c4_m16": "g_c4_m16 (4vCPU, 16GB RAM)",
 		"g_c8_m32": "g_c8_m32 (8vCPU, 32GB RAM)",
 	}
-	openstackSchema := OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, false)
+	openstackSchema := OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, false, callFroumUI)
 
 	// source: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv3-series
 	azureMachines := []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"}
@@ -339,14 +359,14 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"Standard_D48_v3": "Standard_D48_v3 (48vCPU, 192GB RAM)",
 		"Standard_D64_v3": "Standard_D64_v3 (64vCPU, 256GB RAM)",
 	}
-	azureSchema := AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
+	azureSchema := AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
 
 	azureLiteMachines := []string{"Standard_D4_v3"}
 	azureLiteMachinesDisplay := map[string]string{
 		"Standard_D4_v3": azureMachinesDisplay["Standard_D4_v3"],
 	}
-	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
-	freemiumSchema := FreemiumSchema(provider, includeAdditionalParamsInSchema, false, euAccessRestricted)
+	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
+	freemiumSchema := FreemiumSchema(provider, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
 	trialSchema := TrialSchema(includeAdditionalParamsInSchema, false)
 	ownClusterSchema := OwnClusterSchema(false)
 
@@ -361,19 +381,19 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"m5.8xlarge":  awsMachinesDisplay["m5.8xlarge"],
 		"m5.12xlarge": awsMachinesDisplay["m5.12xlarge"],
 	}
-	awsCatalogSchema := AWSSchema(awsCatalogMachinesDisplay, awsCatalogMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
+	awsCatalogSchema := AWSSchema(awsCatalogMachinesDisplay, awsCatalogMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
 
 	outputPlans := map[string]domain.ServicePlan{
-		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
-		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, true)),
-		OpenStackPlanID:  defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, true)),
-		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
-		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
-		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
+		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, true, callFroumUI)),
+		OpenStackPlanID:  defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, true, callFroumUI)),
+		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
+		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
+		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
 		TrialPlanID:      defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
 		OwnClusterPlanID: defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
-		PreviewPlanID: defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, PreviewSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false, euAccessRestricted),
-			AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		PreviewPlanID: defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, PreviewSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI),
+			AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
 	}
 
 	return outputPlans

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -133,65 +133,51 @@ func requiredOwnClusterSchemaProperties() []string {
 	return []string{"name", "kubeconfig", "shootName", "shootDomain"}
 }
 
-func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
 	properties.Region.Default = getDefaultOpenStackRegion()
 	if !update {
 		properties.AutoScalerMax.Default = 8
 	}
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
+func PreviewSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Networking = NewNetworkingSchema()
 	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, GCPRegions(), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultGCPRegion()
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
+func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultAWSRegion(euAccessRestricted)
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
+func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Minimum = 3
 	properties.AutoScalerMin.Minimum = 3
 	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
+func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(euAccessRestricted), update)
 	properties.AutoScalerMax.Maximum = 40
 	properties.Region.Default = getDefaultAzureRegion(euAccessRestricted)
@@ -201,13 +187,10 @@ func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []strin
 		properties.AutoScalerMin.Default = 2
 	}
 
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
-func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool, callFromUI bool) *map[string]interface{} {
+func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	if update && !additionalParams {
 		return empty()
 	}
@@ -238,10 +221,7 @@ func FreemiumSchema(provider internal.CloudProvider, additionalParams, update bo
 
 	properties.Region.Default = defaultRegion
 
-	if callFromUI {
-		return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
-	}
-	return createSchemaWithProperties(properties, additionalParams, update, requiredTrialSchemaProperties())
+	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties())
 }
 
 func TrialSchema(additionalParams, update bool) *map[string]interface{} {
@@ -312,7 +292,7 @@ func unmarshalSchema(schema *RootSchema) *map[string]interface{} {
 
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
-func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, callFroumUI bool) map[string]domain.ServicePlan {
+func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool) map[string]domain.ServicePlan {
 	awsMachines := []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"}
 	awsMachinesDisplay := map[string]string{
 		// source: https://aws.amazon.com/ec2/instance-types/m5/
@@ -340,14 +320,14 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
 		"n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)",
 	}
-	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, false, callFroumUI)
+	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, false)
 
 	openStackMachines := []string{"g_c4_m16", "g_c8_m32"}
 	openStackMachinesDisplay := map[string]string{
 		"g_c4_m16": "g_c4_m16 (4vCPU, 16GB RAM)",
 		"g_c8_m32": "g_c8_m32 (8vCPU, 32GB RAM)",
 	}
-	openstackSchema := OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, false, callFroumUI)
+	openstackSchema := OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, false)
 
 	// source: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv3-series
 	azureMachines := []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"}
@@ -359,14 +339,14 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"Standard_D48_v3": "Standard_D48_v3 (48vCPU, 192GB RAM)",
 		"Standard_D64_v3": "Standard_D64_v3 (64vCPU, 256GB RAM)",
 	}
-	azureSchema := AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
+	azureSchema := AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
 
 	azureLiteMachines := []string{"Standard_D4_v3"}
 	azureLiteMachinesDisplay := map[string]string{
 		"Standard_D4_v3": azureMachinesDisplay["Standard_D4_v3"],
 	}
-	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
-	freemiumSchema := FreemiumSchema(provider, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
+	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
+	freemiumSchema := FreemiumSchema(provider, includeAdditionalParamsInSchema, false, euAccessRestricted)
 	trialSchema := TrialSchema(includeAdditionalParamsInSchema, false)
 	ownClusterSchema := OwnClusterSchema(false)
 
@@ -381,19 +361,19 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 		"m5.8xlarge":  awsMachinesDisplay["m5.8xlarge"],
 		"m5.12xlarge": awsMachinesDisplay["m5.12xlarge"],
 	}
-	awsCatalogSchema := AWSSchema(awsCatalogMachinesDisplay, awsCatalogMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI)
+	awsCatalogSchema := AWSSchema(awsCatalogMachinesDisplay, awsCatalogMachines, includeAdditionalParamsInSchema, false, euAccessRestricted)
 
 	outputPlans := map[string]domain.ServicePlan{
-		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
-		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, true, callFroumUI)),
-		OpenStackPlanID:  defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, true, callFroumUI)),
-		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
-		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
-		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
+		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, true)),
+		OpenStackPlanID:  defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, true)),
+		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, includeAdditionalParamsInSchema, true, euAccessRestricted)),
 		TrialPlanID:      defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
 		OwnClusterPlanID: defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
-		PreviewPlanID: defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, PreviewSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false, euAccessRestricted, callFroumUI),
-			AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted, callFroumUI)),
+		PreviewPlanID: defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, PreviewSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false, euAccessRestricted),
+			AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true, euAccessRestricted)),
 	}
 
 	return outputPlans

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -122,7 +122,7 @@ func OpenStackRegions() []string {
 }
 
 func requiredSchemaProperties() []string {
-	return []string{"name, region"}
+	return []string{"name", "region"}
 }
 
 func requiredTrialSchemaProperties() []string {
@@ -136,7 +136,7 @@ func requiredOwnClusterSchemaProperties() []string {
 func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
-	properties.Region.Default = OpenStackRegions()[0]
+	properties.Region.Default = getDefaultOpenStackRegion()
 	if !update {
 		properties.AutoScalerMax.Default = 8
 	}

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -28,7 +28,6 @@ type ProvisioningProperties struct {
 	ShootDomain *Type           `json:"shootDomain,omitempty"`
 	Region      *Type           `json:"region,omitempty"`
 	Networking  *NetworkingType `json:"networking,omitempty"`
-	Required    []string        `json:"required"`
 }
 
 type UpdateProperties struct {
@@ -172,7 +171,6 @@ func NewProvisioningProperties(machineTypesDisplay map[string]string, machineTyp
 			Enum: ToInterfaceSlice(regions),
 		},
 		Networking: NewNetworkingSchema(),
-		Required:   []string{"region"},
 	}
 
 	if update {
@@ -216,8 +214,16 @@ func NewOIDCSchema() *OIDCType {
 	}
 }
 
+func NewSchema(properties interface{}, update bool, requiered []string) *RootSchema {
+	return NewSchemaForOwnCluster(properties, update, requiered)
+}
+
 func NewSchemaWithOnlyNameRequired(properties interface{}, update bool) *RootSchema {
 	return NewSchemaForOwnCluster(properties, update, []string{"name"})
+}
+
+func NewSchemaWithOnlyNameAndRegionRequired(properties interface{}, update bool) *RootSchema {
+	return NewSchemaForOwnCluster(properties, update, []string{"name, region"})
 }
 
 func NewSchemaForOwnCluster(properties interface{}, update bool, required []string) *RootSchema {

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -214,19 +214,7 @@ func NewOIDCSchema() *OIDCType {
 	}
 }
 
-func NewSchema(properties interface{}, update bool, requiered []string) *RootSchema {
-	return NewSchemaForOwnCluster(properties, update, requiered)
-}
-
-func NewSchemaWithOnlyNameRequired(properties interface{}, update bool) *RootSchema {
-	return NewSchemaForOwnCluster(properties, update, []string{"name"})
-}
-
-func NewSchemaWithOnlyNameAndRegionRequired(properties interface{}, update bool) *RootSchema {
-	return NewSchemaForOwnCluster(properties, update, []string{"name, region"})
-}
-
-func NewSchemaForOwnCluster(properties interface{}, update bool, required []string) *RootSchema {
+func NewSchema(properties interface{}, update bool, required []string) *RootSchema {
 	schema := &RootSchema{
 		Schema: "http://json-schema.org/draft-04/schema#",
 		Type: Type{

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -28,6 +28,7 @@ type ProvisioningProperties struct {
 	ShootDomain *Type           `json:"shootDomain,omitempty"`
 	Region      *Type           `json:"region,omitempty"`
 	Networking  *NetworkingType `json:"networking,omitempty"`
+	Required    []string        `json:"required"`
 }
 
 type UpdateProperties struct {
@@ -171,6 +172,7 @@ func NewProvisioningProperties(machineTypesDisplay map[string]string, machineTyp
 			Enum: ToInterfaceSlice(regions),
 		},
 		Networking: NewNetworkingSchema(),
+		Required:   []string{"region"},
 	}
 
 	if update {

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -16,7 +16,7 @@ import (
 func TestSchemaGenerator(t *testing.T) {
 	tests := []struct {
 		name                string
-		generator           func(map[string]string, []string, bool, bool, bool) *map[string]interface{}
+		generator           func(map[string]string, []string, bool, bool) *map[string]interface{}
 		machineTypes        []string
 		machineTypesDisplay map[string]string
 		file                string
@@ -26,8 +26,8 @@ func TestSchemaGenerator(t *testing.T) {
 	}{
 		{
 			name: "AWS schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AWSSchema(machinesDisplay, machines, additionalParams, update, false, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AWSSchema(machinesDisplay, machines, additionalParams, update, false)
 			},
 			machineTypes:   []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-schema.json",
@@ -37,8 +37,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AWS schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AWSSchema(machinesDisplay, machines, additionalParams, update, true, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AWSSchema(machinesDisplay, machines, additionalParams, update, true)
 			},
 			machineTypes:   []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-schema-eu.json",
@@ -48,8 +48,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Azure schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AzureSchema(machinesDisplay, machines, additionalParams, update, false, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureSchema(machinesDisplay, machines, additionalParams, update, false)
 			},
 			machineTypes:   []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"},
 			file:           "azure-schema.json",
@@ -59,8 +59,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Azure schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AzureSchema(machinesDisplay, machines, additionalParams, update, true, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureSchema(machinesDisplay, machines, additionalParams, update, true)
 			},
 			machineTypes:   []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"},
 			file:           "azure-schema-eu.json",
@@ -70,8 +70,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AzureLite schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, false, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, false)
 			},
 			machineTypes:        []string{"Standard_D4_v3"},
 			machineTypesDisplay: map[string]string{"Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"},
@@ -82,8 +82,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AzureLite schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, true, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, true)
 			},
 			machineTypes:        []string{"Standard_D4_v3"},
 			machineTypesDisplay: map[string]string{"Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"},
@@ -94,8 +94,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Freemium schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return FreemiumSchema(internal.Azure, additionalParams, update, false, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return FreemiumSchema(internal.Azure, additionalParams, update, false)
 			},
 			machineTypes:   []string{},
 			file:           "free-azure-schema.json",
@@ -105,8 +105,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: " Freemium schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return FreemiumSchema(internal.AWS, additionalParams, update, false, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return FreemiumSchema(internal.AWS, additionalParams, update, false)
 			},
 			machineTypes:   []string{},
 			file:           "free-aws-schema.json",
@@ -116,8 +116,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Freemium schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return FreemiumSchema(internal.Azure, additionalParams, update, true, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return FreemiumSchema(internal.Azure, additionalParams, update, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-azure-schema-eu.json",
@@ -127,8 +127,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: " Freemium schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
-				return FreemiumSchema(internal.AWS, additionalParams, update, true, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return FreemiumSchema(internal.AWS, additionalParams, update, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-aws-schema-eu.json",
@@ -156,7 +156,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Trial schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return TrialSchema(additionalParams, update)
 			},
 			machineTypes:   []string{},
@@ -167,7 +167,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Own cluster schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return OwnClusterSchema(update)
 			},
 			machineTypes:   []string{},
@@ -179,16 +179,16 @@ func TestSchemaGenerator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, false, true)
+			got := tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, false)
 			validateSchema(t, Marshal(got), tt.file)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, true, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, true)
 			validateSchema(t, Marshal(got), tt.updateFile)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, false, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, false)
 			validateSchema(t, Marshal(got), tt.fileOIDC)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, true, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, true)
 			validateSchema(t, Marshal(got), tt.updateFileOIDC)
 		})
 	}

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -16,7 +16,7 @@ import (
 func TestSchemaGenerator(t *testing.T) {
 	tests := []struct {
 		name                string
-		generator           func(map[string]string, []string, bool, bool) *map[string]interface{}
+		generator           func(map[string]string, []string, bool, bool, bool) *map[string]interface{}
 		machineTypes        []string
 		machineTypesDisplay map[string]string
 		file                string
@@ -26,8 +26,8 @@ func TestSchemaGenerator(t *testing.T) {
 	}{
 		{
 			name: "AWS schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AWSSchema(machinesDisplay, machines, additionalParams, update, false)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AWSSchema(machinesDisplay, machines, additionalParams, update, false, true)
 			},
 			machineTypes:   []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-schema.json",
@@ -37,8 +37,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AWS schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AWSSchema(machinesDisplay, machines, additionalParams, update, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AWSSchema(machinesDisplay, machines, additionalParams, update, true, true)
 			},
 			machineTypes:   []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-schema-eu.json",
@@ -48,8 +48,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Azure schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AzureSchema(machinesDisplay, machines, additionalParams, update, false)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AzureSchema(machinesDisplay, machines, additionalParams, update, false, true)
 			},
 			machineTypes:   []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"},
 			file:           "azure-schema.json",
@@ -59,8 +59,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Azure schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AzureSchema(machinesDisplay, machines, additionalParams, update, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AzureSchema(machinesDisplay, machines, additionalParams, update, true, true)
 			},
 			machineTypes:   []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"},
 			file:           "azure-schema-eu.json",
@@ -70,8 +70,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AzureLite schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, false)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, false, true)
 			},
 			machineTypes:        []string{"Standard_D4_v3"},
 			machineTypesDisplay: map[string]string{"Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"},
@@ -82,8 +82,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "AzureLite schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, machines, additionalParams, update, true, true)
 			},
 			machineTypes:        []string{"Standard_D4_v3"},
 			machineTypesDisplay: map[string]string{"Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"},
@@ -94,8 +94,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Freemium schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return FreemiumSchema(internal.Azure, additionalParams, update, false)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return FreemiumSchema(internal.Azure, additionalParams, update, false, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-azure-schema.json",
@@ -105,8 +105,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: " Freemium schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return FreemiumSchema(internal.AWS, additionalParams, update, false)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return FreemiumSchema(internal.AWS, additionalParams, update, false, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-aws-schema.json",
@@ -116,8 +116,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Freemium schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return FreemiumSchema(internal.Azure, additionalParams, update, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return FreemiumSchema(internal.Azure, additionalParams, update, true, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-azure-schema-eu.json",
@@ -127,8 +127,8 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: " Freemium schema with EU access restriction is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return FreemiumSchema(internal.AWS, additionalParams, update, true)
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
+				return FreemiumSchema(internal.AWS, additionalParams, update, true, true)
 			},
 			machineTypes:   []string{},
 			file:           "free-aws-schema-eu.json",
@@ -156,7 +156,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Trial schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
 				return TrialSchema(additionalParams, update)
 			},
 			machineTypes:   []string{},
@@ -167,7 +167,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Own cluster schema is correct",
-			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool, callFromUI bool) *map[string]interface{} {
 				return OwnClusterSchema(update)
 			},
 			machineTypes:   []string{},
@@ -179,16 +179,16 @@ func TestSchemaGenerator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, false)
+			got := tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, false, true)
 			validateSchema(t, Marshal(got), tt.file)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, true, true)
 			validateSchema(t, Marshal(got), tt.updateFile)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, false)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, false, true)
 			validateSchema(t, Marshal(got), tt.fileOIDC)
 
-			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, true, true)
 			validateSchema(t, Marshal(got), tt.updateFileOIDC)
 		})
 	}

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -16,6 +16,7 @@ import (
 const (
 	ControlsOrderKey = "_controlsOrder"
 	PropertiesKey    = "properties"
+	CallFromUI       = true
 )
 
 type ServicesEndpoint struct {
@@ -54,7 +55,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion)) {
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), CallFromUI) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -54,7 +54,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion)) {
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), true) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -54,7 +54,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), true) {
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion)) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/testdata/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws-schema-additional-params-eu.json
@@ -112,6 +112,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1"
       ],
@@ -119,7 +120,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws-schema-additional-params-eu.json
@@ -120,7 +120,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws-schema-additional-params.json
@@ -130,7 +130,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws-schema-additional-params.json
@@ -112,6 +112,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1",
         "eu-west-2",
@@ -129,7 +130,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema-eu.json
+++ b/internal/broker/testdata/aws-schema-eu.json
@@ -73,7 +73,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema-eu.json
+++ b/internal/broker/testdata/aws-schema-eu.json
@@ -65,6 +65,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1"
       ],
@@ -72,7 +73,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema.json
+++ b/internal/broker/testdata/aws-schema.json
@@ -65,6 +65,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1",
         "eu-west-2",
@@ -82,7 +83,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/aws-schema.json
+++ b/internal/broker/testdata/aws-schema.json
@@ -83,7 +83,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure-lite-schema-additional-params-eu.json
@@ -114,7 +114,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure-lite-schema-additional-params-eu.json
@@ -106,6 +106,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -113,7 +114,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure-lite-schema-additional-params.json
@@ -121,7 +121,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure-lite-schema-additional-params.json
@@ -106,6 +106,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -120,7 +121,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure-lite-schema-eu.json
@@ -67,7 +67,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure-lite-schema-eu.json
@@ -59,6 +59,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -66,7 +67,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema.json
+++ b/internal/broker/testdata/azure-lite-schema.json
@@ -59,6 +59,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -73,7 +74,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-lite-schema.json
+++ b/internal/broker/testdata/azure-lite-schema.json
@@ -74,7 +74,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure-schema-additional-params-eu.json
@@ -116,7 +116,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure-schema-additional-params-eu.json
@@ -108,6 +108,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -115,7 +116,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure-schema-additional-params.json
@@ -123,7 +123,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure-schema-additional-params.json
@@ -108,6 +108,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -122,7 +123,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-eu.json
+++ b/internal/broker/testdata/azure-schema-eu.json
@@ -61,6 +61,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -68,7 +69,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema-eu.json
+++ b/internal/broker/testdata/azure-schema-eu.json
@@ -69,7 +69,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema.json
+++ b/internal/broker/testdata/azure-schema.json
@@ -76,7 +76,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/azure-schema.json
+++ b/internal/broker/testdata/azure-schema.json
@@ -61,6 +61,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -75,7 +76,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/free-aws-schema-additional-params-eu.json
@@ -89,7 +89,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/free-aws-schema-additional-params-eu.json
@@ -81,6 +81,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1"
       ],
@@ -88,7 +89,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-additional-params.json
+++ b/internal/broker/testdata/free-aws-schema-additional-params.json
@@ -81,6 +81,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1",
         "eu-west-2",
@@ -98,7 +99,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-additional-params.json
+++ b/internal/broker/testdata/free-aws-schema-additional-params.json
@@ -99,7 +99,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-eu.json
+++ b/internal/broker/testdata/free-aws-schema-eu.json
@@ -34,6 +34,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1"
       ],
@@ -41,7 +42,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema-eu.json
+++ b/internal/broker/testdata/free-aws-schema-eu.json
@@ -42,7 +42,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema.json
+++ b/internal/broker/testdata/free-aws-schema.json
@@ -52,7 +52,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-aws-schema.json
+++ b/internal/broker/testdata/free-aws-schema.json
@@ -34,6 +34,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-central-1",
       "enum": [
         "eu-central-1",
         "eu-west-2",
@@ -51,7 +52,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/free-azure-schema-additional-params-eu.json
@@ -89,7 +89,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/free-azure-schema-additional-params-eu.json
@@ -81,6 +81,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -88,7 +89,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-additional-params.json
+++ b/internal/broker/testdata/free-azure-schema-additional-params.json
@@ -96,7 +96,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-additional-params.json
+++ b/internal/broker/testdata/free-azure-schema-additional-params.json
@@ -81,6 +81,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -95,7 +96,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-eu.json
+++ b/internal/broker/testdata/free-azure-schema-eu.json
@@ -34,6 +34,7 @@
       "type": "object"
     },
     "region": {
+      "default": "switzerlandnorth",
       "enum": [
         "switzerlandnorth"
       ],
@@ -41,7 +42,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema-eu.json
+++ b/internal/broker/testdata/free-azure-schema-eu.json
@@ -42,7 +42,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema.json
+++ b/internal/broker/testdata/free-azure-schema.json
@@ -34,6 +34,7 @@
       "type": "object"
     },
     "region": {
+      "default": "eastus",
       "enum": [
         "eastus",
         "centralus",
@@ -48,7 +49,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/free-azure-schema.json
+++ b/internal/broker/testdata/free-azure-schema.json
@@ -49,7 +49,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp-schema-additional-params.json
@@ -117,7 +117,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp-schema-additional-params.json
@@ -107,6 +107,7 @@
       "type": "object"
     },
     "region": {
+      "default": "europe-west3",
       "enum": [
         "europe-west3",
         "asia-south1",
@@ -116,7 +117,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/gcp-schema.json
+++ b/internal/broker/testdata/gcp-schema.json
@@ -60,6 +60,7 @@
       "type": "object"
     },
     "region": {
+      "default": "europe-west3",
       "enum": [
         "europe-west3",
         "asia-south1",
@@ -69,7 +70,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/gcp-schema.json
+++ b/internal/broker/testdata/gcp-schema.json
@@ -70,7 +70,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/openstack-schema-additional-params.json
+++ b/internal/broker/testdata/openstack-schema-additional-params.json
@@ -114,7 +114,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/openstack-schema-additional-params.json
+++ b/internal/broker/testdata/openstack-schema-additional-params.json
@@ -104,7 +104,9 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-de-2",
       "enum": [
+        "eu-de-2",
         "eu-de-1",
         "ap-sa-1"
       ],
@@ -112,7 +114,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/openstack-schema.json
+++ b/internal/broker/testdata/openstack-schema.json
@@ -67,7 +67,8 @@
     }
   },
   "required": [
-    "name, region"
+    "name",
+    "region"
   ],
   "type": "object"
 }

--- a/internal/broker/testdata/openstack-schema.json
+++ b/internal/broker/testdata/openstack-schema.json
@@ -57,7 +57,9 @@
       "type": "object"
     },
     "region": {
+      "default": "eu-de-2",
       "enum": [
+        "eu-de-2",
         "eu-de-1",
         "ap-sa-1"
       ],
@@ -65,7 +67,7 @@
     }
   },
   "required": [
-    "name"
+    "name, region"
   ],
   "type": "object"
 }

--- a/internal/provider/aws_provider.go
+++ b/internal/provider/aws_provider.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	DefaultAWSRegion         = "eu-central-1"
-	DefaultAWSTrialRegion    = "eu-west-1"
-	DefaultEuAccessAWSRegion = "eu-central-1"
+	DefaultAWSRegion         = broker.DefaultAWSRegion
+	DefaultAWSTrialRegion    = broker.DefaultAWSTrialRegion
+	DefaultEuAccessAWSRegion = broker.DefaultEuAccessAWSRegion
 	DefaultAWSMultiZoneCount = 3
 )
 

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	DefaultAzureRegion         = "eastus"
-	DefaultEuAccessAzureRegion = "switzerlandnorth"
+	DefaultAzureRegion         = broker.DefaultAzureRegion
+	DefaultEuAccessAzureRegion = broker.DefaultEuAccessAzureRegion
 	DefaultAzureMultiZoneCount = 3
 )
 

--- a/internal/provider/gcp_provider.go
+++ b/internal/provider/gcp_provider.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultGCPRegion         = "europe-west3"
+	DefaultGCPRegion         = broker.DefaultGCPRegion
 	DefaultGCPMachineType    = "n2-standard-4"
 	DefaultGCPMultiZoneCount = 3
 )

--- a/internal/provider/openstack_provider.go
+++ b/internal/provider/openstack_provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/networking"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	DefaultOpenStackRegion = "eu-de-2"
+	DefaultOpenStackRegion = broker.DefaultOpenStackRegion
 	DefaultExposureClass   = "converged-cloud-internet"
 )
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Move default region constants to other package
- Make schema creation more generic
- Add the missing default region `eu-de-2`  for OpenStack
- Generate schema with required `region` when called from UI

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/control-plane/issues/3006