### PR TITLE
Fix AvS problems with optimistic locking

### DIFF
--- a/internal/avs/delegator.go
+++ b/internal/avs/delegator.go
@@ -1,212 +1,212 @@
 package avs
 
 import (
-    "fmt"
-    "time"
+	"fmt"
+	"time"
 
-    "github.com/kyma-project/kyma-environment-broker/internal"
-    kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
-    "github.com/kyma-project/kyma-environment-broker/internal/process"
-    "github.com/kyma-project/kyma-environment-broker/internal/storage"
-    "github.com/sirupsen/logrus"
+	"github.com/kyma-project/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
 )
 
 type Delegator struct {
-    operationManager  *process.OperationManager
-    avsConfig         Config
-    client            *Client
-    operationsStorage storage.Operations
+	operationManager  *process.OperationManager
+	avsConfig         Config
+	client            *Client
+	operationsStorage storage.Operations
 }
 
 type avsApiErrorResp struct {
-    StatusCode int    `json:"statusCode"`
-    Status     string `json:"status"`
-    Message    string `json:"message"`
+	StatusCode int    `json:"statusCode"`
+	Status     string `json:"status"`
+	Message    string `json:"message"`
 }
 
 func NewDelegator(client *Client, avsConfig Config, os storage.Operations) *Delegator {
-    return &Delegator{
-        operationManager:  process.NewOperationManager(os),
-        avsConfig:         avsConfig,
-        client:            client,
-        operationsStorage: os,
-    }
+	return &Delegator{
+		operationManager:  process.NewOperationManager(os),
+		avsConfig:         avsConfig,
+		client:            client,
+		operationsStorage: os,
+	}
 }
 
 func (del *Delegator) CreateEvaluation(log logrus.FieldLogger, operation internal.Operation, evalAssistant EvalAssistant, url string) (internal.Operation, time.Duration, error) {
-    log.Infof("starting the step avs internal id [%d] and avs external id [%d]", operation.Avs.AvsEvaluationInternalId, operation.Avs.AVSEvaluationExternalId)
+	log.Infof("starting the step avs internal id [%d] and avs external id [%d]", operation.Avs.AvsEvaluationInternalId, operation.Avs.AVSEvaluationExternalId)
 
-    var updatedOperation internal.Operation
-    d := 0 * time.Second
+	var updatedOperation internal.Operation
+	d := 0 * time.Second
 
-    if evalAssistant.IsValid(operation.Avs) {
-        log.Infof("step has already been finished previously")
-        updatedOperation = operation
-    } else {
-        log.Infof("making avs calls to create the Evaluation")
-        evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, url)
-        if err != nil {
-            log.Errorf("step failed with error %v", err)
-            return operation, 5 * time.Second, nil
-        }
+	if evalAssistant.IsValid(operation.Avs) {
+		log.Infof("step has already been finished previously")
+		updatedOperation = operation
+	} else {
+		log.Infof("making avs calls to create the Evaluation")
+		evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, url)
+		if err != nil {
+			log.Errorf("step failed with error %v", err)
+			return operation, 5 * time.Second, nil
+		}
 
-        evalResp, err := del.client.CreateEvaluation(evaluationObject)
-        switch {
-        case err == nil:
-        case kebError.IsTemporaryError(err):
-            errMsg := "cannot create AVS evaluation (temporary)"
-            log.Errorf("%s: %s", errMsg, err)
-            retryConfig := evalAssistant.provideRetryConfig()
-            return del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
-        default:
-            errMsg := "cannot create AVS evaluation"
-            log.Errorf("%s: %s", errMsg, err)
-            return del.operationManager.OperationFailed(operation, errMsg, err, log)
-        }
-        updatedOperation, d, _ = del.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-            evalAssistant.SetEvalId(&operation.Avs, evalResp.Id)
-            evalAssistant.SetDeleted(&operation.Avs, false)
-        }, log)
-    }
+		evalResp, err := del.client.CreateEvaluation(evaluationObject)
+		switch {
+		case err == nil:
+		case kebError.IsTemporaryError(err):
+			errMsg := "cannot create AVS evaluation (temporary)"
+			log.Errorf("%s: %s", errMsg, err)
+			retryConfig := evalAssistant.provideRetryConfig()
+			return del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
+		default:
+			errMsg := "cannot create AVS evaluation"
+			log.Errorf("%s: %s", errMsg, err)
+			return del.operationManager.OperationFailed(operation, errMsg, err, log)
+		}
+		updatedOperation, d, _ = del.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
+			evalAssistant.SetEvalId(&operation.Avs, evalResp.Id)
+			evalAssistant.SetDeleted(&operation.Avs, false)
+		}, log)
+	}
 
-    return updatedOperation, d, nil
+	return updatedOperation, d, nil
 }
 
 func (del *Delegator) AddTags(log logrus.FieldLogger, operation internal.Operation, evalAssistant EvalAssistant, tags []*Tag) (internal.Operation, time.Duration, error) {
-    log.Infof("starting the AddTag to avs internal id [%d]", operation.Avs.AvsEvaluationInternalId)
-    var updatedOperation internal.Operation
-    d := 0 * time.Second
+	log.Infof("starting the AddTag to avs internal id [%d]", operation.Avs.AvsEvaluationInternalId)
+	var updatedOperation internal.Operation
+	d := 0 * time.Second
 
-    log.Infof("making avs calls to add tags to the Evaluation")
-    evalID := evalAssistant.GetEvaluationId(operation.Avs)
+	log.Infof("making avs calls to add tags to the Evaluation")
+	evalID := evalAssistant.GetEvaluationId(operation.Avs)
 
-    for _, tag := range tags {
-        _, err := del.client.AddTag(evalID, tag)
-        switch {
-        case err == nil:
-        case kebError.IsTemporaryError(err):
-            errMsg := "cannot add tags to AVS evaluation (temporary)"
-            log.Errorf("%s: %s", errMsg, err)
-            retryConfig := evalAssistant.provideRetryConfig()
-            op, duration, err := del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
-            return op, duration, err
-        default:
-            errMsg := "cannot add tags to AVS evaluation"
-            log.Errorf("%s: %s", errMsg, err)
-            op, duration, err := del.operationManager.OperationFailed(operation, errMsg, err, log)
-            return op, duration, err
-        }
-    }
-    return updatedOperation, d, nil
+	for _, tag := range tags {
+		_, err := del.client.AddTag(evalID, tag)
+		switch {
+		case err == nil:
+		case kebError.IsTemporaryError(err):
+			errMsg := "cannot add tags to AVS evaluation (temporary)"
+			log.Errorf("%s: %s", errMsg, err)
+			retryConfig := evalAssistant.provideRetryConfig()
+			op, duration, err := del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
+			return op, duration, err
+		default:
+			errMsg := "cannot add tags to AVS evaluation"
+			log.Errorf("%s: %s", errMsg, err)
+			op, duration, err := del.operationManager.OperationFailed(operation, errMsg, err, log)
+			return op, duration, err
+		}
+	}
+	return updatedOperation, d, nil
 }
 
 func (del *Delegator) ResetStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant) error {
-    status := evalAssistant.GetOriginalEvalStatus(*lifecycleData)
-    // For cases when operation is not loaded (properly) from DB, status fields will be rendered
-    // invalid. This will lead to a failing operation on reset in the following scenario:
-    //
-    // Upgrade operation when loaded (for the first time, on init) was InProgress and was later switched to complete.
-    // When launching post operation logic, SetStatus will be invoked with invalid value, failing the operation.
-    // One of possible hotfixes is to ensure that for invalid status there is a default value (such as Active).
-    if !ValidStatus(status) {
-        log.Errorf("invalid status for ResetStatus: %s", status)
-        status = StatusActive
-    }
+	status := evalAssistant.GetOriginalEvalStatus(*lifecycleData)
+	// For cases when operation is not loaded (properly) from DB, status fields will be rendered
+	// invalid. This will lead to a failing operation on reset in the following scenario:
+	//
+	// Upgrade operation when loaded (for the first time, on init) was InProgress and was later switched to complete.
+	// When launching post operation logic, SetStatus will be invoked with invalid value, failing the operation.
+	// One of possible hotfixes is to ensure that for invalid status there is a default value (such as Active).
+	if !ValidStatus(status) {
+		log.Errorf("invalid status for ResetStatus: %s", status)
+		status = StatusActive
+	}
 
-    return del.SetStatus(log, lifecycleData, evalAssistant, status)
+	return del.SetStatus(log, lifecycleData, evalAssistant, status)
 }
 
 // RefreshStatus ensures that operation AVS lifecycle data is fetched from Avs API
 func (del *Delegator) RefreshStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant) string {
-    evalID := evalAssistant.GetEvaluationId(*lifecycleData)
-    currentStatus := evalAssistant.GetEvalStatus(*lifecycleData)
+	evalID := evalAssistant.GetEvaluationId(*lifecycleData)
+	currentStatus := evalAssistant.GetEvalStatus(*lifecycleData)
 
-    // obtain status from avs
-    log.Infof("making avs calls to get evaluation data")
-    eval, err := del.client.GetEvaluation(evalID)
-    if err != nil || eval == nil {
-        log.Errorf("cannot obtain evaluation data on RefreshStatus: %s", err)
-    } else {
-        currentStatus = eval.Status
-    }
+	// obtain status from avs
+	log.Infof("making avs calls to get evaluation data")
+	eval, err := del.client.GetEvaluation(evalID)
+	if err != nil || eval == nil {
+		log.Errorf("cannot obtain evaluation data on RefreshStatus: %s", err)
+	} else {
+		currentStatus = eval.Status
+	}
 
-    evalAssistant.SetEvalStatus(lifecycleData, currentStatus)
+	evalAssistant.SetEvalStatus(lifecycleData, currentStatus)
 
-    return currentStatus
+	return currentStatus
 }
 
 func (del *Delegator) SetStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant, status string) error {
-    // skip for non-existent or deleted evaluation
-    if !evalAssistant.IsValid(*lifecycleData) {
-        return nil
-    }
+	// skip for non-existent or deleted evaluation
+	if !evalAssistant.IsValid(*lifecycleData) {
+		return nil
+	}
 
-    // fail for invalid status request
-    if !ValidStatus(status) {
-        errMsg := fmt.Sprintf("avs SetStatus tried invalid status: %s", status)
-        log.Error(errMsg)
-        return fmt.Errorf(errMsg)
-    }
+	// fail for invalid status request
+	if !ValidStatus(status) {
+		errMsg := fmt.Sprintf("avs SetStatus tried invalid status: %s", status)
+		log.Error(errMsg)
+		return fmt.Errorf(errMsg)
+	}
 
-    evalID := evalAssistant.GetEvaluationId(*lifecycleData)
-    currentStatus := del.RefreshStatus(log, lifecycleData, evalAssistant)
+	evalID := evalAssistant.GetEvaluationId(*lifecycleData)
+	currentStatus := del.RefreshStatus(log, lifecycleData, evalAssistant)
 
-    log.Infof("SetStatus %s to avs id [%d]", status, evalID)
+	log.Infof("SetStatus %s to avs id [%d]", status, evalID)
 
-    // do api call iff current and requested status are different
-    if currentStatus != status {
-        log.Infof("making avs calls to set status %s to the evaluation", status)
-        _, err := del.client.SetStatus(evalID, status)
+	// do api call iff current and requested status are different
+	if currentStatus != status {
+		log.Infof("making avs calls to set status %s to the evaluation", status)
+		_, err := del.client.SetStatus(evalID, status)
 
-        switch {
-        case err == nil:
-        case kebError.IsTemporaryError(err):
-            errMsg := "cannot set status to AVS evaluation (temporary)"
-            log.Errorf("%s: %s", errMsg, err)
-            return err
-        default:
-            errMsg := "cannot set status to AVS evaluation"
-            log.Errorf("%s: %s", errMsg, err)
-            return err
-        }
-    }
-    // update operation with newly configured status
-    evalAssistant.SetEvalStatus(lifecycleData, status)
+		switch {
+		case err == nil:
+		case kebError.IsTemporaryError(err):
+			errMsg := "cannot set status to AVS evaluation (temporary)"
+			log.Errorf("%s: %s", errMsg, err)
+			return err
+		default:
+			errMsg := "cannot set status to AVS evaluation"
+			log.Errorf("%s: %s", errMsg, err)
+			return err
+		}
+	}
+	// update operation with newly configured status
+	evalAssistant.SetEvalStatus(lifecycleData, status)
 
-    return nil
+	return nil
 }
 
 func (del *Delegator) DeleteAvsEvaluation(deProvisioningOperation internal.Operation, logger logrus.FieldLogger, assistant EvalAssistant) (internal.Operation, error) {
-    if assistant.IsAlreadyDeletedOrEmpty(deProvisioningOperation.Avs) {
-        logger.Infof("Evaluations have been deleted previously")
-        return deProvisioningOperation, nil
-    }
+	if assistant.IsAlreadyDeletedOrEmpty(deProvisioningOperation.Avs) {
+		logger.Infof("Evaluations have been deleted previously")
+		return deProvisioningOperation, nil
+	}
 
-    if err := del.tryDeleting(assistant, deProvisioningOperation, logger); err != nil {
-        return deProvisioningOperation, err
-    }
+	if err := del.tryDeleting(assistant, deProvisioningOperation, logger); err != nil {
+		return deProvisioningOperation, err
+	}
 
-    updatedDeProvisioningOp, _, err := del.operationManager.UpdateOperation(deProvisioningOperation, func(op *internal.Operation) {
-        assistant.SetDeleted(&op.Avs, true)
-    }, logger)
-    if err != nil {
-        return deProvisioningOperation, err
-    }
-    return updatedDeProvisioningOp, nil
+	updatedDeProvisioningOp, _, err := del.operationManager.UpdateOperation(deProvisioningOperation, func(op *internal.Operation) {
+		assistant.SetDeleted(&op.Avs, true)
+	}, logger)
+	if err != nil {
+		return deProvisioningOperation, err
+	}
+	return updatedDeProvisioningOp, nil
 }
 
 func (del *Delegator) tryDeleting(assistant EvalAssistant, deProvisioningOperation internal.Operation, logger logrus.FieldLogger) error {
-    evaluationID := assistant.GetEvaluationId(deProvisioningOperation.Avs)
-    parentID := assistant.ProvideParentId(deProvisioningOperation.ProvisioningParameters)
-    err := del.client.RemoveReferenceFromParentEval(parentID, evaluationID)
-    if err != nil {
-        logger.Errorf("error while deleting reference for evaluation %v", err)
-        return err
-    }
+	evaluationID := assistant.GetEvaluationId(deProvisioningOperation.Avs)
+	parentID := assistant.ProvideParentId(deProvisioningOperation.ProvisioningParameters)
+	err := del.client.RemoveReferenceFromParentEval(parentID, evaluationID)
+	if err != nil {
+		logger.Errorf("error while deleting reference for evaluation %v", err)
+		return err
+	}
 
-    err = del.client.DeleteEvaluation(evaluationID)
-    if err != nil {
-        logger.Errorf("error while deleting evaluation %v", err)
-    }
-    return err
+	err = del.client.DeleteEvaluation(evaluationID)
+	if err != nil {
+		logger.Errorf("error while deleting evaluation %v", err)
+	}
+	return err
 }

--- a/internal/avs/delegator.go
+++ b/internal/avs/delegator.go
@@ -1,212 +1,212 @@
 package avs
 
 import (
-	"fmt"
-	"time"
+    "fmt"
+    "time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal"
-	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
-	"github.com/kyma-project/kyma-environment-broker/internal/process"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
+    "github.com/kyma-project/kyma-environment-broker/internal"
+    kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+    "github.com/kyma-project/kyma-environment-broker/internal/process"
+    "github.com/kyma-project/kyma-environment-broker/internal/storage"
+    "github.com/sirupsen/logrus"
 )
 
 type Delegator struct {
-	provisionManager  *process.OperationManager
-	avsConfig         Config
-	client            *Client
-	operationsStorage storage.Operations
+    operationManager  *process.OperationManager
+    avsConfig         Config
+    client            *Client
+    operationsStorage storage.Operations
 }
 
 type avsApiErrorResp struct {
-	StatusCode int    `json:"statusCode"`
-	Status     string `json:"status"`
-	Message    string `json:"message"`
+    StatusCode int    `json:"statusCode"`
+    Status     string `json:"status"`
+    Message    string `json:"message"`
 }
 
 func NewDelegator(client *Client, avsConfig Config, os storage.Operations) *Delegator {
-	return &Delegator{
-		provisionManager:  process.NewOperationManager(os),
-		avsConfig:         avsConfig,
-		client:            client,
-		operationsStorage: os,
-	}
+    return &Delegator{
+        operationManager:  process.NewOperationManager(os),
+        avsConfig:         avsConfig,
+        client:            client,
+        operationsStorage: os,
+    }
 }
 
 func (del *Delegator) CreateEvaluation(log logrus.FieldLogger, operation internal.Operation, evalAssistant EvalAssistant, url string) (internal.Operation, time.Duration, error) {
-	log.Infof("starting the step avs internal id [%d] and avs external id [%d]", operation.Avs.AvsEvaluationInternalId, operation.Avs.AVSEvaluationExternalId)
+    log.Infof("starting the step avs internal id [%d] and avs external id [%d]", operation.Avs.AvsEvaluationInternalId, operation.Avs.AVSEvaluationExternalId)
 
-	var updatedOperation internal.Operation
-	d := 0 * time.Second
+    var updatedOperation internal.Operation
+    d := 0 * time.Second
 
-	if evalAssistant.IsValid(operation.Avs) {
-		log.Infof("step has already been finished previously")
-		updatedOperation = operation
-	} else {
-		log.Infof("making avs calls to create the Evaluation")
-		evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, url)
-		if err != nil {
-			log.Errorf("step failed with error %v", err)
-			return operation, 5 * time.Second, nil
-		}
+    if evalAssistant.IsValid(operation.Avs) {
+        log.Infof("step has already been finished previously")
+        updatedOperation = operation
+    } else {
+        log.Infof("making avs calls to create the Evaluation")
+        evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, url)
+        if err != nil {
+            log.Errorf("step failed with error %v", err)
+            return operation, 5 * time.Second, nil
+        }
 
-		evalResp, err := del.client.CreateEvaluation(evaluationObject)
-		switch {
-		case err == nil:
-		case kebError.IsTemporaryError(err):
-			errMsg := "cannot create AVS evaluation (temporary)"
-			log.Errorf("%s: %s", errMsg, err)
-			retryConfig := evalAssistant.provideRetryConfig()
-			return del.provisionManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
-		default:
-			errMsg := "cannot create AVS evaluation"
-			log.Errorf("%s: %s", errMsg, err)
-			return del.provisionManager.OperationFailed(operation, errMsg, err, log)
-		}
-		updatedOperation, d, _ = del.provisionManager.UpdateOperation(operation, func(operation *internal.Operation) {
-			evalAssistant.SetEvalId(&operation.Avs, evalResp.Id)
-			evalAssistant.SetDeleted(&operation.Avs, false)
-		}, log)
-	}
+        evalResp, err := del.client.CreateEvaluation(evaluationObject)
+        switch {
+        case err == nil:
+        case kebError.IsTemporaryError(err):
+            errMsg := "cannot create AVS evaluation (temporary)"
+            log.Errorf("%s: %s", errMsg, err)
+            retryConfig := evalAssistant.provideRetryConfig()
+            return del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
+        default:
+            errMsg := "cannot create AVS evaluation"
+            log.Errorf("%s: %s", errMsg, err)
+            return del.operationManager.OperationFailed(operation, errMsg, err, log)
+        }
+        updatedOperation, d, _ = del.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
+            evalAssistant.SetEvalId(&operation.Avs, evalResp.Id)
+            evalAssistant.SetDeleted(&operation.Avs, false)
+        }, log)
+    }
 
-	return updatedOperation, d, nil
+    return updatedOperation, d, nil
 }
 
 func (del *Delegator) AddTags(log logrus.FieldLogger, operation internal.Operation, evalAssistant EvalAssistant, tags []*Tag) (internal.Operation, time.Duration, error) {
-	log.Infof("starting the AddTag to avs internal id [%d]", operation.Avs.AvsEvaluationInternalId)
-	var updatedOperation internal.Operation
-	d := 0 * time.Second
+    log.Infof("starting the AddTag to avs internal id [%d]", operation.Avs.AvsEvaluationInternalId)
+    var updatedOperation internal.Operation
+    d := 0 * time.Second
 
-	log.Infof("making avs calls to add tags to the Evaluation")
-	evalID := evalAssistant.GetEvaluationId(operation.Avs)
+    log.Infof("making avs calls to add tags to the Evaluation")
+    evalID := evalAssistant.GetEvaluationId(operation.Avs)
 
-	for _, tag := range tags {
-		_, err := del.client.AddTag(evalID, tag)
-		switch {
-		case err == nil:
-		case kebError.IsTemporaryError(err):
-			errMsg := "cannot add tags to AVS evaluation (temporary)"
-			log.Errorf("%s: %s", errMsg, err)
-			retryConfig := evalAssistant.provideRetryConfig()
-			op, duration, err := del.provisionManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
-			return op, duration, err
-		default:
-			errMsg := "cannot add tags to AVS evaluation"
-			log.Errorf("%s: %s", errMsg, err)
-			op, duration, err := del.provisionManager.OperationFailed(operation, errMsg, err, log)
-			return op, duration, err
-		}
-	}
-	return updatedOperation, d, nil
+    for _, tag := range tags {
+        _, err := del.client.AddTag(evalID, tag)
+        switch {
+        case err == nil:
+        case kebError.IsTemporaryError(err):
+            errMsg := "cannot add tags to AVS evaluation (temporary)"
+            log.Errorf("%s: %s", errMsg, err)
+            retryConfig := evalAssistant.provideRetryConfig()
+            op, duration, err := del.operationManager.RetryOperation(operation, errMsg, err, retryConfig.retryInterval, retryConfig.maxTime, log)
+            return op, duration, err
+        default:
+            errMsg := "cannot add tags to AVS evaluation"
+            log.Errorf("%s: %s", errMsg, err)
+            op, duration, err := del.operationManager.OperationFailed(operation, errMsg, err, log)
+            return op, duration, err
+        }
+    }
+    return updatedOperation, d, nil
 }
 
 func (del *Delegator) ResetStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant) error {
-	status := evalAssistant.GetOriginalEvalStatus(*lifecycleData)
-	// For cases when operation is not loaded (properly) from DB, status fields will be rendered
-	// invalid. This will lead to a failing operation on reset in the following scenario:
-	//
-	// Upgrade operation when loaded (for the first time, on init) was InProgress and was later switched to complete.
-	// When launching post operation logic, SetStatus will be invoked with invalid value, failing the operation.
-	// One of possible hotfixes is to ensure that for invalid status there is a default value (such as Active).
-	if !ValidStatus(status) {
-		log.Errorf("invalid status for ResetStatus: %s", status)
-		status = StatusActive
-	}
+    status := evalAssistant.GetOriginalEvalStatus(*lifecycleData)
+    // For cases when operation is not loaded (properly) from DB, status fields will be rendered
+    // invalid. This will lead to a failing operation on reset in the following scenario:
+    //
+    // Upgrade operation when loaded (for the first time, on init) was InProgress and was later switched to complete.
+    // When launching post operation logic, SetStatus will be invoked with invalid value, failing the operation.
+    // One of possible hotfixes is to ensure that for invalid status there is a default value (such as Active).
+    if !ValidStatus(status) {
+        log.Errorf("invalid status for ResetStatus: %s", status)
+        status = StatusActive
+    }
 
-	return del.SetStatus(log, lifecycleData, evalAssistant, status)
+    return del.SetStatus(log, lifecycleData, evalAssistant, status)
 }
 
 // RefreshStatus ensures that operation AVS lifecycle data is fetched from Avs API
 func (del *Delegator) RefreshStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant) string {
-	evalID := evalAssistant.GetEvaluationId(*lifecycleData)
-	currentStatus := evalAssistant.GetEvalStatus(*lifecycleData)
+    evalID := evalAssistant.GetEvaluationId(*lifecycleData)
+    currentStatus := evalAssistant.GetEvalStatus(*lifecycleData)
 
-	// obtain status from avs
-	log.Infof("making avs calls to get evaluation data")
-	eval, err := del.client.GetEvaluation(evalID)
-	if err != nil || eval == nil {
-		log.Errorf("cannot obtain evaluation data on RefreshStatus: %s", err)
-	} else {
-		currentStatus = eval.Status
-	}
+    // obtain status from avs
+    log.Infof("making avs calls to get evaluation data")
+    eval, err := del.client.GetEvaluation(evalID)
+    if err != nil || eval == nil {
+        log.Errorf("cannot obtain evaluation data on RefreshStatus: %s", err)
+    } else {
+        currentStatus = eval.Status
+    }
 
-	evalAssistant.SetEvalStatus(lifecycleData, currentStatus)
+    evalAssistant.SetEvalStatus(lifecycleData, currentStatus)
 
-	return currentStatus
+    return currentStatus
 }
 
 func (del *Delegator) SetStatus(log logrus.FieldLogger, lifecycleData *internal.AvsLifecycleData, evalAssistant EvalAssistant, status string) error {
-	// skip for non-existent or deleted evaluation
-	if !evalAssistant.IsValid(*lifecycleData) {
-		return nil
-	}
+    // skip for non-existent or deleted evaluation
+    if !evalAssistant.IsValid(*lifecycleData) {
+        return nil
+    }
 
-	// fail for invalid status request
-	if !ValidStatus(status) {
-		errMsg := fmt.Sprintf("avs SetStatus tried invalid status: %s", status)
-		log.Error(errMsg)
-		return fmt.Errorf(errMsg)
-	}
+    // fail for invalid status request
+    if !ValidStatus(status) {
+        errMsg := fmt.Sprintf("avs SetStatus tried invalid status: %s", status)
+        log.Error(errMsg)
+        return fmt.Errorf(errMsg)
+    }
 
-	evalID := evalAssistant.GetEvaluationId(*lifecycleData)
-	currentStatus := del.RefreshStatus(log, lifecycleData, evalAssistant)
+    evalID := evalAssistant.GetEvaluationId(*lifecycleData)
+    currentStatus := del.RefreshStatus(log, lifecycleData, evalAssistant)
 
-	log.Infof("SetStatus %s to avs id [%d]", status, evalID)
+    log.Infof("SetStatus %s to avs id [%d]", status, evalID)
 
-	// do api call iff current and requested status are different
-	if currentStatus != status {
-		log.Infof("making avs calls to set status %s to the evaluation", status)
-		_, err := del.client.SetStatus(evalID, status)
+    // do api call iff current and requested status are different
+    if currentStatus != status {
+        log.Infof("making avs calls to set status %s to the evaluation", status)
+        _, err := del.client.SetStatus(evalID, status)
 
-		switch {
-		case err == nil:
-		case kebError.IsTemporaryError(err):
-			errMsg := "cannot set status to AVS evaluation (temporary)"
-			log.Errorf("%s: %s", errMsg, err)
-			return err
-		default:
-			errMsg := "cannot set status to AVS evaluation"
-			log.Errorf("%s: %s", errMsg, err)
-			return err
-		}
-	}
-	// update operation with newly configured status
-	evalAssistant.SetEvalStatus(lifecycleData, status)
+        switch {
+        case err == nil:
+        case kebError.IsTemporaryError(err):
+            errMsg := "cannot set status to AVS evaluation (temporary)"
+            log.Errorf("%s: %s", errMsg, err)
+            return err
+        default:
+            errMsg := "cannot set status to AVS evaluation"
+            log.Errorf("%s: %s", errMsg, err)
+            return err
+        }
+    }
+    // update operation with newly configured status
+    evalAssistant.SetEvalStatus(lifecycleData, status)
 
-	return nil
+    return nil
 }
 
 func (del *Delegator) DeleteAvsEvaluation(deProvisioningOperation internal.Operation, logger logrus.FieldLogger, assistant EvalAssistant) (internal.Operation, error) {
-	if assistant.IsAlreadyDeletedOrEmpty(deProvisioningOperation.Avs) {
-		logger.Infof("Evaluations have been deleted previously")
-		return deProvisioningOperation, nil
-	}
+    if assistant.IsAlreadyDeletedOrEmpty(deProvisioningOperation.Avs) {
+        logger.Infof("Evaluations have been deleted previously")
+        return deProvisioningOperation, nil
+    }
 
-	if err := del.tryDeleting(assistant, deProvisioningOperation, logger); err != nil {
-		return deProvisioningOperation, err
-	}
+    if err := del.tryDeleting(assistant, deProvisioningOperation, logger); err != nil {
+        return deProvisioningOperation, err
+    }
 
-	assistant.SetDeleted(&deProvisioningOperation.Avs, true)
-
-	updatedDeProvisioningOp, err := del.operationsStorage.UpdateOperation(deProvisioningOperation)
-	if err != nil {
-		return deProvisioningOperation, err
-	}
-	return *updatedDeProvisioningOp, nil
+    updatedDeProvisioningOp, _, err := del.operationManager.UpdateOperation(deProvisioningOperation, func(op *internal.Operation) {
+        assistant.SetDeleted(&op.Avs, true)
+    }, logger)
+    if err != nil {
+        return deProvisioningOperation, err
+    }
+    return updatedDeProvisioningOp, nil
 }
 
 func (del *Delegator) tryDeleting(assistant EvalAssistant, deProvisioningOperation internal.Operation, logger logrus.FieldLogger) error {
-	evaluationID := assistant.GetEvaluationId(deProvisioningOperation.Avs)
-	parentID := assistant.ProvideParentId(deProvisioningOperation.ProvisioningParameters)
-	err := del.client.RemoveReferenceFromParentEval(parentID, evaluationID)
-	if err != nil {
-		logger.Errorf("error while deleting reference for evaluation %v", err)
-		return err
-	}
+    evaluationID := assistant.GetEvaluationId(deProvisioningOperation.Avs)
+    parentID := assistant.ProvideParentId(deProvisioningOperation.ProvisioningParameters)
+    err := del.client.RemoveReferenceFromParentEval(parentID, evaluationID)
+    if err != nil {
+        logger.Errorf("error while deleting reference for evaluation %v", err)
+        return err
+    }
 
-	err = del.client.DeleteEvaluation(evaluationID)
-	if err != nil {
-		logger.Errorf("error while deleting evaluation %v", err)
-	}
-	return err
+    err = del.client.DeleteEvaluation(evaluationID)
+    if err != nil {
+        logger.Errorf("error while deleting evaluation %v", err)
+    }
+    return err
 }

--- a/internal/process/deprovisioning/avs_evaluations.go
+++ b/internal/process/deprovisioning/avs_evaluations.go
@@ -1,60 +1,60 @@
 package deprovisioning
 
 import (
-    "time"
+	"time"
 
-    "github.com/kyma-project/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
-    "github.com/kyma-project/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/kyma-environment-broker/internal/process"
 
-    "github.com/kyma-project/kyma-environment-broker/internal"
-    "github.com/kyma-project/kyma-environment-broker/internal/avs"
-    "github.com/kyma-project/kyma-environment-broker/internal/storage"
-    "github.com/sirupsen/logrus"
+	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/avs"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
 )
 
 type AvsEvaluationRemovalStep struct {
-    delegator             *avs.Delegator
-    externalEvalAssistant avs.EvalAssistant
-    internalEvalAssistant avs.EvalAssistant
-    deProvisioningManager *process.OperationManager
-    operationManager      *process.OperationManager
+	delegator             *avs.Delegator
+	externalEvalAssistant avs.EvalAssistant
+	internalEvalAssistant avs.EvalAssistant
+	deProvisioningManager *process.OperationManager
+	operationManager      *process.OperationManager
 }
 
 func NewAvsEvaluationsRemovalStep(delegator *avs.Delegator, operationsStorage storage.Operations, externalEvalAssistant, internalEvalAssistant avs.EvalAssistant) *AvsEvaluationRemovalStep {
-    return &AvsEvaluationRemovalStep{
-        delegator:             delegator,
-        externalEvalAssistant: externalEvalAssistant,
-        internalEvalAssistant: internalEvalAssistant,
-        deProvisioningManager: process.NewOperationManager(operationsStorage),
-    }
+	return &AvsEvaluationRemovalStep{
+		delegator:             delegator,
+		externalEvalAssistant: externalEvalAssistant,
+		internalEvalAssistant: internalEvalAssistant,
+		deProvisioningManager: process.NewOperationManager(operationsStorage),
+	}
 }
 
 func (ars *AvsEvaluationRemovalStep) Name() string {
-    return "De-provision_AVS_Evaluations"
+	return "De-provision_AVS_Evaluations"
 }
 
 func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-    logger.Infof("Avs lifecycle %+v", operation.Avs)
+	logger.Infof("Avs lifecycle %+v", operation.Avs)
 
-    // the delegator saves (update in the storage) is executed inside the DeleteAvsEvaluation
+	// the delegator saves (update in the storage) is executed inside the DeleteAvsEvaluation
 
-    operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
-    if err != nil {
-        logger.Warnf("unable to delete internal evaluation: %s", err.Error())
-        return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
-    }
+	operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
+	if err != nil {
+		logger.Warnf("unable to delete internal evaluation: %s", err.Error())
+		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
+	}
 
-    if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
-        logger.Info("skipping AVS external evaluation deletion for trial/freemium plan")
-        return operation, 0, nil
-    }
-    operation, err = ars.delegator.DeleteAvsEvaluation(operation, logger, ars.externalEvalAssistant)
-    if err != nil {
-        logger.Warnf("unable to delete external evaluation: %s", err.Error())
-        return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
-    }
+	if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
+		logger.Info("skipping AVS external evaluation deletion for trial/freemium plan")
+		return operation, 0, nil
+	}
+	operation, err = ars.delegator.DeleteAvsEvaluation(operation, logger, ars.externalEvalAssistant)
+	if err != nil {
+		logger.Warnf("unable to delete external evaluation: %s", err.Error())
+		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
+	}
 
-    return operation, 0, nil
+	return operation, 0, nil
 
 }

--- a/internal/process/deprovisioning/avs_evaluations.go
+++ b/internal/process/deprovisioning/avs_evaluations.go
@@ -18,7 +18,6 @@ type AvsEvaluationRemovalStep struct {
 	externalEvalAssistant avs.EvalAssistant
 	internalEvalAssistant avs.EvalAssistant
 	deProvisioningManager *process.OperationManager
-	operationManager      *process.OperationManager
 }
 
 func NewAvsEvaluationsRemovalStep(delegator *avs.Delegator, operationsStorage storage.Operations, externalEvalAssistant, internalEvalAssistant avs.EvalAssistant) *AvsEvaluationRemovalStep {

--- a/internal/process/deprovisioning/avs_evaluations.go
+++ b/internal/process/deprovisioning/avs_evaluations.go
@@ -37,7 +37,7 @@ func (ars *AvsEvaluationRemovalStep) Name() string {
 func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	logger.Infof("Avs lifecycle %+v", operation.Avs)
 
-	// the delegator saves (update in the storage) is executed inside the DeleteAvsEvaluation
+	// the delegator saves the operation (update in the storage) - it is executed inside the DeleteAvsEvaluation
 
 	operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
 	if err != nil {

--- a/internal/process/deprovisioning/avs_evaluations.go
+++ b/internal/process/deprovisioning/avs_evaluations.go
@@ -1,64 +1,60 @@
 package deprovisioning
 
 import (
-	"time"
+    "time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
+    "github.com/kyma-project/kyma-environment-broker/internal/broker"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/process"
+    "github.com/kyma-project/kyma-environment-broker/internal/process"
 
-	"github.com/kyma-project/kyma-environment-broker/internal"
-	"github.com/kyma-project/kyma-environment-broker/internal/avs"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
+    "github.com/kyma-project/kyma-environment-broker/internal"
+    "github.com/kyma-project/kyma-environment-broker/internal/avs"
+    "github.com/kyma-project/kyma-environment-broker/internal/storage"
+    "github.com/sirupsen/logrus"
 )
 
 type AvsEvaluationRemovalStep struct {
-	delegator             *avs.Delegator
-	operationsStorage     storage.Operations
-	externalEvalAssistant avs.EvalAssistant
-	internalEvalAssistant avs.EvalAssistant
-	deProvisioningManager *process.OperationManager
+    delegator             *avs.Delegator
+    externalEvalAssistant avs.EvalAssistant
+    internalEvalAssistant avs.EvalAssistant
+    deProvisioningManager *process.OperationManager
+    operationManager      *process.OperationManager
 }
 
 func NewAvsEvaluationsRemovalStep(delegator *avs.Delegator, operationsStorage storage.Operations, externalEvalAssistant, internalEvalAssistant avs.EvalAssistant) *AvsEvaluationRemovalStep {
-	return &AvsEvaluationRemovalStep{
-		delegator:             delegator,
-		operationsStorage:     operationsStorage,
-		externalEvalAssistant: externalEvalAssistant,
-		internalEvalAssistant: internalEvalAssistant,
-		deProvisioningManager: process.NewOperationManager(operationsStorage),
-	}
+    return &AvsEvaluationRemovalStep{
+        delegator:             delegator,
+        externalEvalAssistant: externalEvalAssistant,
+        internalEvalAssistant: internalEvalAssistant,
+        deProvisioningManager: process.NewOperationManager(operationsStorage),
+    }
 }
 
 func (ars *AvsEvaluationRemovalStep) Name() string {
-	return "De-provision_AVS_Evaluations"
+    return "De-provision_AVS_Evaluations"
 }
 
 func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	logger.Infof("Avs lifecycle %+v", operation.Avs)
+    logger.Infof("Avs lifecycle %+v", operation.Avs)
 
-	operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
-	if err != nil {
-		logger.Warnf("unable to delete internal evaluation: %s", err.Error())
-		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
-	}
+    // the delegator saves (update in the storage) is executed inside the DeleteAvsEvaluation
 
-	if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
-		logger.Info("skipping AVS external evaluation deletion for trial/freemium plan")
-		return operation, 0, nil
-	}
-	operation, err = ars.delegator.DeleteAvsEvaluation(operation, logger, ars.externalEvalAssistant)
-	if err != nil {
-		logger.Warnf("unable to delete external evaluation: %s", err.Error())
-		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
-	}
+    operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
+    if err != nil {
+        logger.Warnf("unable to delete internal evaluation: %s", err.Error())
+        return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
+    }
 
-	newOperation, err := ars.operationsStorage.UpdateOperation(operation)
-	if err != nil {
-		logger.Errorf("Unable to update an operation")
-		return operation, 5 * time.Second, nil
-	}
-	return *newOperation, 0, nil
+    if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
+        logger.Info("skipping AVS external evaluation deletion for trial/freemium plan")
+        return operation, 0, nil
+    }
+    operation, err = ars.delegator.DeleteAvsEvaluation(operation, logger, ars.externalEvalAssistant)
+    if err != nil {
+        logger.Warnf("unable to delete external evaluation: %s", err.Error())
+        return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
+    }
+
+    return operation, 0, nil
 
 }

--- a/internal/process/staged_manager.go
+++ b/internal/process/staged_manager.go
@@ -1,260 +1,260 @@
 package process
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "sync"
-    "time"
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
 
-    "github.com/pkg/errors"
+	"github.com/pkg/errors"
 
-    "github.com/kyma-project/kyma-environment-broker/internal"
-    kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
-    "github.com/kyma-project/kyma-environment-broker/internal/event"
-    "github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/kyma-project/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/kyma-environment-broker/internal/event"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 
-    "github.com/pivotal-cf/brokerapi/v8/domain"
-    "github.com/sirupsen/logrus"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/sirupsen/logrus"
 )
 
 type StagedManager struct {
-    log              logrus.FieldLogger
-    operationStorage storage.Operations
-    publisher        event.Publisher
+	log              logrus.FieldLogger
+	operationStorage storage.Operations
+	publisher        event.Publisher
 
-    stages           []*stage
-    operationTimeout time.Duration
+	stages           []*stage
+	operationTimeout time.Duration
 
-    mu sync.RWMutex
+	mu sync.RWMutex
 
-    speedFactor int64
+	speedFactor int64
 }
 
 type Step interface {
-    Name() string
-    Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error)
+	Name() string
+	Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error)
 }
 
 type StepCondition func(operation internal.Operation) bool
 
 type StepWithCondition struct {
-    Step
-    condition StepCondition
+	Step
+	condition StepCondition
 }
 
 type stage struct {
-    name  string
-    steps []StepWithCondition
+	name  string
+	steps []StepWithCondition
 }
 
 func (s *stage) AddStep(step Step, cnd StepCondition) {
-    s.steps = append(s.steps, StepWithCondition{
-        Step:      step,
-        condition: cnd,
-    })
+	s.steps = append(s.steps, StepWithCondition{
+		Step:      step,
+		condition: cnd,
+	})
 }
 
 func NewStagedManager(storage storage.Operations, pub event.Publisher, operationTimeout time.Duration, logger logrus.FieldLogger) *StagedManager {
-    return &StagedManager{
-        log:              logger,
-        operationStorage: storage,
-        publisher:        pub,
-        operationTimeout: operationTimeout,
-        speedFactor:      1,
-    }
+	return &StagedManager{
+		log:              logger,
+		operationStorage: storage,
+		publisher:        pub,
+		operationTimeout: operationTimeout,
+		speedFactor:      1,
+	}
 }
 
 // SpeedUp changes speedFactor parameter to reduce the sleep time if a step needs a retry.
 // This method should only be used for testing purposes
 func (m *StagedManager) SpeedUp(speedFactor int64) {
-    m.speedFactor = speedFactor
+	m.speedFactor = speedFactor
 }
 
 func (m *StagedManager) DefineStages(names []string) {
-    m.stages = make([]*stage, len(names))
-    for i, n := range names {
-        m.stages[i] = &stage{name: n, steps: []StepWithCondition{}}
-    }
+	m.stages = make([]*stage, len(names))
+	for i, n := range names {
+		m.stages[i] = &stage{name: n, steps: []StepWithCondition{}}
+	}
 }
 
 func (m *StagedManager) AddStep(stageName string, step Step, cnd StepCondition) error {
-    for _, s := range m.stages {
-        if s.name == stageName {
-            s.AddStep(step, cnd)
-            return nil
-        }
-    }
-    return fmt.Errorf("stage %s not defined", stageName)
+	for _, s := range m.stages {
+		if s.name == stageName {
+			s.AddStep(step, cnd)
+			return nil
+		}
+	}
+	return fmt.Errorf("stage %s not defined", stageName)
 }
 
 func (m *StagedManager) GetAllStages() []string {
-    var all []string
-    for _, s := range m.stages {
-        all = append(all, s.name)
-    }
-    return all
+	var all []string
+	for _, s := range m.stages {
+		all = append(all, s.name)
+	}
+	return all
 }
 
 func (m *StagedManager) Execute(operationID string) (time.Duration, error) {
 
-    operation, err := m.operationStorage.GetOperationByID(operationID)
-    if err != nil {
-        m.log.Errorf("Cannot fetch operation from storage: %s", err)
-        return 3 * time.Second, nil
-    }
+	operation, err := m.operationStorage.GetOperationByID(operationID)
+	if err != nil {
+		m.log.Errorf("Cannot fetch operation from storage: %s", err)
+		return 3 * time.Second, nil
+	}
 
-    logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID, "planID": operation.ProvisioningParameters.PlanID})
-    logOperation.Infof("Start process operation steps for GlobalAccount=%s, ", operation.ProvisioningParameters.ErsContext.GlobalAccountID)
-    if time.Since(operation.CreatedAt) > m.operationTimeout {
-        timeoutErr := kebError.TimeoutError("operation has reached the time limit")
-        operation.LastError = timeoutErr
-        defer m.callPubSubOutsideSteps(operation, timeoutErr)
+	logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID, "planID": operation.ProvisioningParameters.PlanID})
+	logOperation.Infof("Start process operation steps for GlobalAccount=%s, ", operation.ProvisioningParameters.ErsContext.GlobalAccountID)
+	if time.Since(operation.CreatedAt) > m.operationTimeout {
+		timeoutErr := kebError.TimeoutError("operation has reached the time limit")
+		operation.LastError = timeoutErr
+		defer m.callPubSubOutsideSteps(operation, timeoutErr)
 
-        logOperation.Infof("operation has reached the time limit: operation was created at: %s", operation.CreatedAt)
-        operation.State = domain.Failed
-        _, err = m.operationStorage.UpdateOperation(*operation)
-        if err != nil {
-            logOperation.Infof("Unable to save operation with finished the provisioning process")
-            timeoutErr = timeoutErr.SetMessage(fmt.Sprintf("%s and %s", timeoutErr.Error(), err.Error()))
-            operation.LastError = timeoutErr
-            return time.Second, timeoutErr
-        }
+		logOperation.Infof("operation has reached the time limit: operation was created at: %s", operation.CreatedAt)
+		operation.State = domain.Failed
+		_, err = m.operationStorage.UpdateOperation(*operation)
+		if err != nil {
+			logOperation.Infof("Unable to save operation with finished the provisioning process")
+			timeoutErr = timeoutErr.SetMessage(fmt.Sprintf("%s and %s", timeoutErr.Error(), err.Error()))
+			operation.LastError = timeoutErr
+			return time.Second, timeoutErr
+		}
 
-        return 0, timeoutErr
-    }
+		return 0, timeoutErr
+	}
 
-    var when time.Duration
-    processedOperation := *operation
+	var when time.Duration
+	processedOperation := *operation
 
-    for _, stage := range m.stages {
-        if processedOperation.IsStageFinished(stage.name) {
-            continue
-        }
+	for _, stage := range m.stages {
+		if processedOperation.IsStageFinished(stage.name) {
+			continue
+		}
 
-        for _, step := range stage.steps {
-            logStep := logOperation.WithField("step", step.Name()).
-                WithField("stage", stage.name)
-            if step.condition != nil && !step.condition(processedOperation) {
-                logStep.Debugf("Skipping")
-                continue
-            }
-            operation.EventInfof("processing step: %v", step.Name())
+		for _, step := range stage.steps {
+			logStep := logOperation.WithField("step", step.Name()).
+				WithField("stage", stage.name)
+			if step.condition != nil && !step.condition(processedOperation) {
+				logStep.Debugf("Skipping")
+				continue
+			}
+			operation.EventInfof("processing step: %v", step.Name())
 
-            processedOperation, when, err = m.runStep(step, processedOperation, logStep)
-            if err != nil {
-                logStep.Errorf("Process operation failed: %s", err)
-                operation.EventErrorf(err, "step %v processing returned error", step.Name())
-                return 0, err
-            }
-            if processedOperation.State == domain.Failed || processedOperation.State == domain.Succeeded {
-                logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, processedOperation.State)
-                operation.EventInfof("operation processing %v", processedOperation.State)
-                return 0, nil
-            }
+			processedOperation, when, err = m.runStep(step, processedOperation, logStep)
+			if err != nil {
+				logStep.Errorf("Process operation failed: %s", err)
+				operation.EventErrorf(err, "step %v processing returned error", step.Name())
+				return 0, err
+			}
+			if processedOperation.State == domain.Failed || processedOperation.State == domain.Succeeded {
+				logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, processedOperation.State)
+				operation.EventInfof("operation processing %v", processedOperation.State)
+				return 0, nil
+			}
 
-            // the step needs a retry
-            if when > 0 {
-                logStep.Warnf("retrying step by restarting the operation in %d s", int64(when.Seconds()))
-                return when, nil
-            }
-        }
+			// the step needs a retry
+			if when > 0 {
+				logStep.Warnf("retrying step by restarting the operation in %d s", int64(when.Seconds()))
+				return when, nil
+			}
+		}
 
-        processedOperation, err = m.saveFinishedStage(processedOperation, stage, logOperation)
-        if err != nil {
-            return time.Second, nil
-        }
-    }
+		processedOperation, err = m.saveFinishedStage(processedOperation, stage, logOperation)
+		if err != nil {
+			return time.Second, nil
+		}
+	}
 
-    logOperation.Infof("Operation succeeded")
+	logOperation.Infof("Operation succeeded")
 
-    processedOperation.State = domain.Succeeded
-    processedOperation.Description = "Processing finished"
-    m.publisher.Publish(context.TODO(), OperationSucceeded{
-        Operation: processedOperation,
-    })
+	processedOperation.State = domain.Succeeded
+	processedOperation.Description = "Processing finished"
+	m.publisher.Publish(context.TODO(), OperationSucceeded{
+		Operation: processedOperation,
+	})
 
-    _, err = m.operationStorage.UpdateOperation(processedOperation)
-    if err != nil {
-        logOperation.Infof("Unable to save operation with finished the provisioning process")
-        return time.Second, err
-    }
+	_, err = m.operationStorage.UpdateOperation(processedOperation)
+	if err != nil {
+		logOperation.Infof("Unable to save operation with finished the provisioning process")
+		return time.Second, err
+	}
 
-    return 0, nil
+	return 0, nil
 }
 
 func (m *StagedManager) saveFinishedStage(operation internal.Operation, s *stage, log logrus.FieldLogger) (internal.Operation, error) {
-    operation.FinishStage(s.name)
-    op, err := m.operationStorage.UpdateOperation(operation)
-    if err != nil {
-        log.Infof("Unable to save operation with finished stage %s: %s", s.name, err.Error())
-        return operation, err
-    }
-    log.Infof("Finished stage %s", s.name)
-    return *op, nil
+	operation.FinishStage(s.name)
+	op, err := m.operationStorage.UpdateOperation(operation)
+	if err != nil {
+		log.Infof("Unable to save operation with finished stage %s: %s", s.name, err.Error())
+		return operation, err
+	}
+	log.Infof("Finished stage %s", s.name)
+	return *op, nil
 }
 
 func (m *StagedManager) runStep(step Step, operation internal.Operation, logger logrus.FieldLogger) (processedOperation internal.Operation, backoff time.Duration, err error) {
-    var start time.Time
-    defer func() {
-        if pErr := recover(); pErr != nil {
-            log.Println("panic in RunStep in staged manager: ", pErr)
-            err = errors.New(fmt.Sprintf("%v", pErr))
-            om := NewOperationManager(m.operationStorage)
-            processedOperation, _, _ = om.OperationFailed(operation, "recovered from panic", err, m.log)
-        }
-    }()
+	var start time.Time
+	defer func() {
+		if pErr := recover(); pErr != nil {
+			log.Println("panic in RunStep in staged manager: ", pErr)
+			err = errors.New(fmt.Sprintf("%v", pErr))
+			om := NewOperationManager(m.operationStorage)
+			processedOperation, _, _ = om.OperationFailed(operation, "recovered from panic", err, m.log)
+		}
+	}()
 
-    processedOperation = operation
-    begin := time.Now()
-    for {
-        start = time.Now()
-        logger.Infof("Start step")
-        processedOperation, backoff, err = step.Run(processedOperation, logger)
-        if err != nil {
-            processedOperation.LastError = kebError.ReasonForError(err)
-            logOperation := m.log.WithFields(logrus.Fields{"operation": processedOperation.ID, "error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
-            logOperation.Errorf("Last error from step %s: %s", step.Name(), processedOperation.LastError.Error())
-            // only save to storage, skip for alerting if error
-            _, err = m.operationStorage.UpdateOperation(processedOperation)
-            if err != nil {
-                logOperation.Errorf("Unable to save operation with resolved last error from step: %s", step.Name())
-            }
-        }
+	processedOperation = operation
+	begin := time.Now()
+	for {
+		start = time.Now()
+		logger.Infof("Start step")
+		processedOperation, backoff, err = step.Run(processedOperation, logger)
+		if err != nil {
+			processedOperation.LastError = kebError.ReasonForError(err)
+			logOperation := m.log.WithFields(logrus.Fields{"operation": processedOperation.ID, "error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
+			logOperation.Errorf("Last error from step %s: %s", step.Name(), processedOperation.LastError.Error())
+			// only save to storage, skip for alerting if error
+			_, err = m.operationStorage.UpdateOperation(processedOperation)
+			if err != nil {
+				logOperation.Errorf("Unable to save operation with resolved last error from step: %s", step.Name())
+			}
+		}
 
-        m.publisher.Publish(context.TODO(), OperationStepProcessed{
-            StepProcessed: StepProcessed{
-                StepName: step.Name(),
-                Duration: time.Since(start),
-                When:     backoff,
-                Error:    err,
-            },
-            Operation:    processedOperation,
-            OldOperation: operation,
-        })
+		m.publisher.Publish(context.TODO(), OperationStepProcessed{
+			StepProcessed: StepProcessed{
+				StepName: step.Name(),
+				Duration: time.Since(start),
+				When:     backoff,
+				Error:    err,
+			},
+			Operation:    processedOperation,
+			OldOperation: operation,
+		})
 
-        // break the loop if:
-        // - the step does not need a retry
-        // - step returns an error
-        // - the loop takes too much time (to not block the worker too long)
-        if backoff == 0 || err != nil || time.Since(begin) > 10*time.Minute {
-            return processedOperation, backoff, err
-        }
-        operation.EventInfof("step %v sleeping for %v", step.Name(), backoff)
-        time.Sleep(backoff / time.Duration(m.speedFactor))
-    }
+		// break the loop if:
+		// - the step does not need a retry
+		// - step returns an error
+		// - the loop takes too much time (to not block the worker too long)
+		if backoff == 0 || err != nil || time.Since(begin) > 10*time.Minute {
+			return processedOperation, backoff, err
+		}
+		operation.EventInfof("step %v sleeping for %v", step.Name(), backoff)
+		time.Sleep(backoff / time.Duration(m.speedFactor))
+	}
 }
 
 func (m *StagedManager) callPubSubOutsideSteps(operation *internal.Operation, err error) {
-    logOperation := m.log.WithFields(logrus.Fields{"operation": operation.ID, "error_component": operation.LastError.Component(), "error_reason": operation.LastError.Reason()})
-    logOperation.Errorf("Last error: %s", operation.LastError.Error())
+	logOperation := m.log.WithFields(logrus.Fields{"operation": operation.ID, "error_component": operation.LastError.Component(), "error_reason": operation.LastError.Reason()})
+	logOperation.Errorf("Last error: %s", operation.LastError.Error())
 
-    m.publisher.Publish(context.TODO(), OperationStepProcessed{
-        StepProcessed: StepProcessed{
-            Duration: time.Since(operation.CreatedAt),
-            Error:    err,
-        },
-        OldOperation: *operation,
-        Operation:    *operation,
-    })
+	m.publisher.Publish(context.TODO(), OperationStepProcessed{
+		StepProcessed: StepProcessed{
+			Duration: time.Since(operation.CreatedAt),
+			Error:    err,
+		},
+		OldOperation: *operation,
+		Operation:    *operation,
+	})
 }

--- a/internal/process/staged_manager.go
+++ b/internal/process/staged_manager.go
@@ -1,259 +1,260 @@
 package process
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"sync"
-	"time"
+    "context"
+    "fmt"
+    "log"
+    "sync"
+    "time"
 
-	"github.com/pkg/errors"
+    "github.com/pkg/errors"
 
-	"github.com/kyma-project/kyma-environment-broker/internal"
-	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
-	"github.com/kyma-project/kyma-environment-broker/internal/event"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+    "github.com/kyma-project/kyma-environment-broker/internal"
+    kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+    "github.com/kyma-project/kyma-environment-broker/internal/event"
+    "github.com/kyma-project/kyma-environment-broker/internal/storage"
 
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
+    "github.com/pivotal-cf/brokerapi/v8/domain"
+    "github.com/sirupsen/logrus"
 )
 
 type StagedManager struct {
-	log              logrus.FieldLogger
-	operationStorage storage.Operations
-	publisher        event.Publisher
+    log              logrus.FieldLogger
+    operationStorage storage.Operations
+    publisher        event.Publisher
 
-	stages           []*stage
-	operationTimeout time.Duration
+    stages           []*stage
+    operationTimeout time.Duration
 
-	mu sync.RWMutex
+    mu sync.RWMutex
 
-	speedFactor int64
+    speedFactor int64
 }
 
 type Step interface {
-	Name() string
-	Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error)
+    Name() string
+    Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error)
 }
 
 type StepCondition func(operation internal.Operation) bool
 
 type StepWithCondition struct {
-	Step
-	condition StepCondition
+    Step
+    condition StepCondition
 }
 
 type stage struct {
-	name  string
-	steps []StepWithCondition
+    name  string
+    steps []StepWithCondition
 }
 
 func (s *stage) AddStep(step Step, cnd StepCondition) {
-	s.steps = append(s.steps, StepWithCondition{
-		Step:      step,
-		condition: cnd,
-	})
+    s.steps = append(s.steps, StepWithCondition{
+        Step:      step,
+        condition: cnd,
+    })
 }
 
 func NewStagedManager(storage storage.Operations, pub event.Publisher, operationTimeout time.Duration, logger logrus.FieldLogger) *StagedManager {
-	return &StagedManager{
-		log:              logger,
-		operationStorage: storage,
-		publisher:        pub,
-		operationTimeout: operationTimeout,
-		speedFactor:      1,
-	}
+    return &StagedManager{
+        log:              logger,
+        operationStorage: storage,
+        publisher:        pub,
+        operationTimeout: operationTimeout,
+        speedFactor:      1,
+    }
 }
 
 // SpeedUp changes speedFactor parameter to reduce the sleep time if a step needs a retry.
 // This method should only be used for testing purposes
 func (m *StagedManager) SpeedUp(speedFactor int64) {
-	m.speedFactor = speedFactor
+    m.speedFactor = speedFactor
 }
 
 func (m *StagedManager) DefineStages(names []string) {
-	m.stages = make([]*stage, len(names))
-	for i, n := range names {
-		m.stages[i] = &stage{name: n, steps: []StepWithCondition{}}
-	}
+    m.stages = make([]*stage, len(names))
+    for i, n := range names {
+        m.stages[i] = &stage{name: n, steps: []StepWithCondition{}}
+    }
 }
 
 func (m *StagedManager) AddStep(stageName string, step Step, cnd StepCondition) error {
-	for _, s := range m.stages {
-		if s.name == stageName {
-			s.AddStep(step, cnd)
-			return nil
-		}
-	}
-	return fmt.Errorf("stage %s not defined", stageName)
+    for _, s := range m.stages {
+        if s.name == stageName {
+            s.AddStep(step, cnd)
+            return nil
+        }
+    }
+    return fmt.Errorf("stage %s not defined", stageName)
 }
 
 func (m *StagedManager) GetAllStages() []string {
-	var all []string
-	for _, s := range m.stages {
-		all = append(all, s.name)
-	}
-	return all
+    var all []string
+    for _, s := range m.stages {
+        all = append(all, s.name)
+    }
+    return all
 }
 
 func (m *StagedManager) Execute(operationID string) (time.Duration, error) {
 
-	operation, err := m.operationStorage.GetOperationByID(operationID)
-	if err != nil {
-		m.log.Errorf("Cannot fetch operation from storage: %s", err)
-		return 3 * time.Second, nil
-	}
+    operation, err := m.operationStorage.GetOperationByID(operationID)
+    if err != nil {
+        m.log.Errorf("Cannot fetch operation from storage: %s", err)
+        return 3 * time.Second, nil
+    }
 
-	logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID, "planID": operation.ProvisioningParameters.PlanID})
-	logOperation.Infof("Start process operation steps for GlobalAccount=%s, ", operation.ProvisioningParameters.ErsContext.GlobalAccountID)
-	if time.Since(operation.CreatedAt) > m.operationTimeout {
-		timeoutErr := kebError.TimeoutError("operation has reached the time limit")
-		operation.LastError = timeoutErr
-		defer m.callPubSubOutsideSteps(operation, timeoutErr)
+    logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID, "planID": operation.ProvisioningParameters.PlanID})
+    logOperation.Infof("Start process operation steps for GlobalAccount=%s, ", operation.ProvisioningParameters.ErsContext.GlobalAccountID)
+    if time.Since(operation.CreatedAt) > m.operationTimeout {
+        timeoutErr := kebError.TimeoutError("operation has reached the time limit")
+        operation.LastError = timeoutErr
+        defer m.callPubSubOutsideSteps(operation, timeoutErr)
 
-		logOperation.Infof("operation has reached the time limit: operation was created at: %s", operation.CreatedAt)
-		operation.State = domain.Failed
-		_, err = m.operationStorage.UpdateOperation(*operation)
-		if err != nil {
-			logOperation.Infof("Unable to save operation with finished the provisioning process")
-			timeoutErr = timeoutErr.SetMessage(fmt.Sprintf("%s and %s", timeoutErr.Error(), err.Error()))
-			operation.LastError = timeoutErr
-			return time.Second, timeoutErr
-		}
+        logOperation.Infof("operation has reached the time limit: operation was created at: %s", operation.CreatedAt)
+        operation.State = domain.Failed
+        _, err = m.operationStorage.UpdateOperation(*operation)
+        if err != nil {
+            logOperation.Infof("Unable to save operation with finished the provisioning process")
+            timeoutErr = timeoutErr.SetMessage(fmt.Sprintf("%s and %s", timeoutErr.Error(), err.Error()))
+            operation.LastError = timeoutErr
+            return time.Second, timeoutErr
+        }
 
-		return 0, timeoutErr
-	}
+        return 0, timeoutErr
+    }
 
-	var when time.Duration
-	processedOperation := *operation
+    var when time.Duration
+    processedOperation := *operation
 
-	for _, stage := range m.stages {
-		if processedOperation.IsStageFinished(stage.name) {
-			continue
-		}
+    for _, stage := range m.stages {
+        if processedOperation.IsStageFinished(stage.name) {
+            continue
+        }
 
-		for _, step := range stage.steps {
-			logStep := logOperation.WithField("step", step.Name()).
-				WithField("stage", stage.name)
-			if step.condition != nil && !step.condition(processedOperation) {
-				logStep.Debugf("Skipping")
-				continue
-			}
-			operation.EventInfof("processing step: %v", step.Name())
+        for _, step := range stage.steps {
+            logStep := logOperation.WithField("step", step.Name()).
+                WithField("stage", stage.name)
+            if step.condition != nil && !step.condition(processedOperation) {
+                logStep.Debugf("Skipping")
+                continue
+            }
+            operation.EventInfof("processing step: %v", step.Name())
 
-			processedOperation, when, err = m.runStep(step, processedOperation, logStep)
-			if err != nil {
-				logStep.Errorf("Process operation failed: %s", err)
-				operation.EventErrorf(err, "step %v processing returned error", step.Name())
-				return 0, err
-			}
-			if processedOperation.State == domain.Failed || processedOperation.State == domain.Succeeded {
-				logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, processedOperation.State)
-				operation.EventInfof("operation processing %v", processedOperation.State)
-				return 0, nil
-			}
+            processedOperation, when, err = m.runStep(step, processedOperation, logStep)
+            if err != nil {
+                logStep.Errorf("Process operation failed: %s", err)
+                operation.EventErrorf(err, "step %v processing returned error", step.Name())
+                return 0, err
+            }
+            if processedOperation.State == domain.Failed || processedOperation.State == domain.Succeeded {
+                logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, processedOperation.State)
+                operation.EventInfof("operation processing %v", processedOperation.State)
+                return 0, nil
+            }
 
-			// the step needs a retry
-			if when > 0 {
-				logStep.Warnf("retrying step by restarting the operation in %d s", int64(when.Seconds()))
-				return when, nil
-			}
-		}
+            // the step needs a retry
+            if when > 0 {
+                logStep.Warnf("retrying step by restarting the operation in %d s", int64(when.Seconds()))
+                return when, nil
+            }
+        }
 
-		processedOperation, err = m.saveFinishedStage(processedOperation, stage, logOperation)
-		if err != nil {
-			return time.Second, nil
-		}
-	}
+        processedOperation, err = m.saveFinishedStage(processedOperation, stage, logOperation)
+        if err != nil {
+            return time.Second, nil
+        }
+    }
 
-	logOperation.Infof("Operation succeeded")
+    logOperation.Infof("Operation succeeded")
 
-	processedOperation.State = domain.Succeeded
-	processedOperation.Description = "Processing finished"
-	m.publisher.Publish(context.TODO(), OperationSucceeded{
-		Operation: processedOperation,
-	})
+    processedOperation.State = domain.Succeeded
+    processedOperation.Description = "Processing finished"
+    m.publisher.Publish(context.TODO(), OperationSucceeded{
+        Operation: processedOperation,
+    })
 
-	_, err = m.operationStorage.UpdateOperation(processedOperation)
-	if err != nil {
-		logOperation.Infof("Unable to save operation with finished the provisioning process")
-		return time.Second, err
-	}
+    _, err = m.operationStorage.UpdateOperation(processedOperation)
+    if err != nil {
+        logOperation.Infof("Unable to save operation with finished the provisioning process")
+        return time.Second, err
+    }
 
-	return 0, nil
+    return 0, nil
 }
 
 func (m *StagedManager) saveFinishedStage(operation internal.Operation, s *stage, log logrus.FieldLogger) (internal.Operation, error) {
-	operation.FinishStage(s.name)
-	op, err := m.operationStorage.UpdateOperation(operation)
-	if err != nil {
-		log.Infof("Unable to save operation with finished stage %s: %s", s.name, err.Error())
-		return operation, err
-	}
-	log.Infof("Finished stage %s", s.name)
-	return *op, nil
+    operation.FinishStage(s.name)
+    op, err := m.operationStorage.UpdateOperation(operation)
+    if err != nil {
+        log.Infof("Unable to save operation with finished stage %s: %s", s.name, err.Error())
+        return operation, err
+    }
+    log.Infof("Finished stage %s", s.name)
+    return *op, nil
 }
 
 func (m *StagedManager) runStep(step Step, operation internal.Operation, logger logrus.FieldLogger) (processedOperation internal.Operation, backoff time.Duration, err error) {
-	var start time.Time
-	defer func() {
-		if pErr := recover(); pErr != nil {
-			log.Println("panic in RunStep in staged manager: ", pErr)
-			err = errors.New(fmt.Sprintf("%v", pErr))
-			om := NewOperationManager(m.operationStorage)
-			processedOperation, _, _ = om.OperationFailed(operation, "recovered from panic", err, m.log)
-		}
-	}()
+    var start time.Time
+    defer func() {
+        if pErr := recover(); pErr != nil {
+            log.Println("panic in RunStep in staged manager: ", pErr)
+            err = errors.New(fmt.Sprintf("%v", pErr))
+            om := NewOperationManager(m.operationStorage)
+            processedOperation, _, _ = om.OperationFailed(operation, "recovered from panic", err, m.log)
+        }
+    }()
 
-	begin := time.Now()
-	for {
-		start = time.Now()
-		logger.Infof("Start step")
-		processedOperation, backoff, err = step.Run(operation, logger)
-		if err != nil {
-			processedOperation.LastError = kebError.ReasonForError(err)
-			logOperation := m.log.WithFields(logrus.Fields{"operation": processedOperation.ID, "error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
-			logOperation.Errorf("Last error from step %s: %s", step.Name(), processedOperation.LastError.Error())
-			// only save to storage, skip for alerting if error
-			_, err = m.operationStorage.UpdateOperation(processedOperation)
-			if err != nil {
-				logOperation.Errorf("Unable to save operation with resolved last error from step: %s", step.Name())
-			}
-		}
+    processedOperation = operation
+    begin := time.Now()
+    for {
+        start = time.Now()
+        logger.Infof("Start step")
+        processedOperation, backoff, err = step.Run(processedOperation, logger)
+        if err != nil {
+            processedOperation.LastError = kebError.ReasonForError(err)
+            logOperation := m.log.WithFields(logrus.Fields{"operation": processedOperation.ID, "error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
+            logOperation.Errorf("Last error from step %s: %s", step.Name(), processedOperation.LastError.Error())
+            // only save to storage, skip for alerting if error
+            _, err = m.operationStorage.UpdateOperation(processedOperation)
+            if err != nil {
+                logOperation.Errorf("Unable to save operation with resolved last error from step: %s", step.Name())
+            }
+        }
 
-		m.publisher.Publish(context.TODO(), OperationStepProcessed{
-			StepProcessed: StepProcessed{
-				StepName: step.Name(),
-				Duration: time.Since(start),
-				When:     backoff,
-				Error:    err,
-			},
-			Operation:    processedOperation,
-			OldOperation: operation,
-		})
+        m.publisher.Publish(context.TODO(), OperationStepProcessed{
+            StepProcessed: StepProcessed{
+                StepName: step.Name(),
+                Duration: time.Since(start),
+                When:     backoff,
+                Error:    err,
+            },
+            Operation:    processedOperation,
+            OldOperation: operation,
+        })
 
-		// break the loop if:
-		// - the step does not need a retry
-		// - step returns an error
-		// - the loop takes too much time (to not block the worker too long)
-		if backoff == 0 || err != nil || time.Since(begin) > 10*time.Minute {
-			return processedOperation, backoff, err
-		}
-		operation.EventInfof("step %v sleeping for %v", step.Name(), backoff)
-		time.Sleep(backoff / time.Duration(m.speedFactor))
-	}
+        // break the loop if:
+        // - the step does not need a retry
+        // - step returns an error
+        // - the loop takes too much time (to not block the worker too long)
+        if backoff == 0 || err != nil || time.Since(begin) > 10*time.Minute {
+            return processedOperation, backoff, err
+        }
+        operation.EventInfof("step %v sleeping for %v", step.Name(), backoff)
+        time.Sleep(backoff / time.Duration(m.speedFactor))
+    }
 }
 
 func (m *StagedManager) callPubSubOutsideSteps(operation *internal.Operation, err error) {
-	logOperation := m.log.WithFields(logrus.Fields{"operation": operation.ID, "error_component": operation.LastError.Component(), "error_reason": operation.LastError.Reason()})
-	logOperation.Errorf("Last error: %s", operation.LastError.Error())
+    logOperation := m.log.WithFields(logrus.Fields{"operation": operation.ID, "error_component": operation.LastError.Component(), "error_reason": operation.LastError.Reason()})
+    logOperation.Errorf("Last error: %s", operation.LastError.Error())
 
-	m.publisher.Publish(context.TODO(), OperationStepProcessed{
-		StepProcessed: StepProcessed{
-			Duration: time.Since(operation.CreatedAt),
-			Error:    err,
-		},
-		OldOperation: *operation,
-		Operation:    *operation,
-	})
+    m.publisher.Publish(context.TODO(), OperationStepProcessed{
+        StepProcessed: StepProcessed{
+            Duration: time.Since(operation.CreatedAt),
+            Error:    err,
+        },
+        OldOperation: *operation,
+        Operation:    *operation,
+    })
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- AvS makes a retry in case of optimistic locking error (conflict)
- stagedmanager runs the step with the newest operation

The staged manager implementation was working fine except a case, when step saves the operation, but then returns a retry. Probably AvS is the only one such case.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
