### PR TITLE
Add Markdown link check to the repository

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,16 @@
+name: Markdown link check
+
+on: 
+    pull_request:
+    schedule:
+      - cron: '0 0 * * *' 
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.mlc.config.json'

--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -1,0 +1,9 @@
+{
+    "replacementPatterns": [
+      {
+        "_comment": "a replacement rule for all the in-repository references",
+        "pattern": "^/",
+        "replacement": "{{BASEURL}}/"
+      }
+    ]
+  }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of conduct
 
-Each contributor and maintainer of this project agrees to follow the [community Code of Conduct](https://github.com/kyma-project/community/blob/main/contributing/01-code-of-conduct.md) that relies on the CNCF Code of Conduct. Read it to learn about the agreed standards of behavior, shared values that govern our community, and details on how to report any suspected Code of Conduct violations.
+Each contributor and maintainer of this project agrees to follow the [community Code of Conduct](https://github.com/kyma-project/community/blob/main/docs/contributing/01-code-of-conduct.md) that relies on the CNCF Code of Conduct. Read it to learn about the agreed standards of behavior, shared values that govern our community, and details on how to report any suspected Code of Conduct violations.

--- a/docs/03-02-runtime-components.md
+++ b/docs/03-02-runtime-components.md
@@ -51,7 +51,7 @@ type OptionalComponentDisabler interface {
 
 In each method, the framework injects the  **components** parameter which is a list of components that are sent to the Runtime Provisioner. The implemented method is responsible for disabling a component and, as a result, returns a modified list.
 
-This interface allows you to easily register the disabler in the [`cmd/broker/main.go`](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/cmd/broker/main.go) file by adding a new entry in the **optionalComponentsDisablers** list:
+This interface allows you to easily register the disabler in the [`cmd/broker/main.go`](../cmd/broker/main.go) file by adding a new entry in the **optionalComponentsDisablers** list:
 
 ```go
 // Register disabler. Convention:

--- a/docs/03-03-runtime-operations.md
+++ b/docs/03-03-runtime-operations.md
@@ -32,7 +32,7 @@ The provisioning process contains the following steps:
 | post_actions   | AVS_Create_External_Eval_Step      | AvS                      | Sets up external monitoring of Kyma Runtime.                                                                                                | Team Gopher     |
 | post_actions   | AVS_Tags                           | AvS                      | Sets up proper tags in the internal monitoring system.                                                                                      | Team Gopher     |
 
-The timeout for processing the whole provisioning operation is set to `24h`. In Kyma 2.0 provisioning steps delegate resource creation to Reconciler. Since Reconciler does not constrain a number of retries in case of a failed reconciliation, KEB sets [provisioning timeout for Reconciler](../../resources/kcp/charts/kyma-environment-broker/values.yaml#L49) to `2h`.
+The timeout for processing the whole provisioning operation is set to `24h`. In Kyma 2.0 provisioning steps delegate resource creation to Reconciler. Since Reconciler does not constrain a number of retries in case of a failed reconciliation, KEB sets [provisioning timeout for Reconciler](../resources/kcp/charts/kyma-environment-broker/values.yaml) to `2h`.
 
 ## Deprovisioning
 
@@ -106,7 +106,7 @@ You can configure SAP BTP, Kyma runtime operations by providing additional steps
   Provisioning
   </summary>
 
-1. Create a new file in [this directory](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/provisioning).
+1. Create a new file in [this directory](../internal/process/provisioning).
 
 2. Implement the following interface in your provisioning or deprovisioning step:
 
@@ -238,7 +238,7 @@ You can configure SAP BTP, Kyma runtime operations by providing additional steps
     }
     ```
 
-3. Add the step to the [`/cmd/broker/main.go`](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/cmd/broker/main.go) file:
+3. Add the step to the [`/cmd/broker/main.go`](../cmd/broker/main.go) file:
 
     ```go
     provisioningSteps := []struct {
@@ -261,7 +261,7 @@ You can configure SAP BTP, Kyma runtime operations by providing additional steps
   Upgrade
   </summary>
 
-1. Create a new file in [this directory](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/kyma_upgrade).
+1. Create a new file in [this directory](../internal/process/upgrade_kyma).
 
 2. Implement the following interface in your upgrade step:
 

--- a/docs/03-03-runtime-operations.md
+++ b/docs/03-03-runtime-operations.md
@@ -376,7 +376,7 @@ You can configure SAP BTP, Kyma runtime operations by providing additional steps
     }
     ```
 
-3. Add the step to the [`/cmd/broker/main.go`](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/cmd/broker/main.go) file:
+3. Add the step to the [`/cmd/broker/main.go`](../cmd/broker/main.go) file:
 
     ```go
     upgradeSteps := []struct {

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -7,3 +7,9 @@ This [workflow](/.github/workflows/run-eslint.yaml) runs the ESLint for `*.js` f
 The workflow:
 - checks out code 
 - invokes `make lint -C testing/e2e/skr`
+
+## Markdown link check workflow
+
+This [workflow](/.github/workflows/markdown-link-check.yaml) checks for broken links in all Markdown files. It is triggered:
+- as a periodic check that runs daily at midnight on the main branch in the repository 
+- on every pull request that creates new or introduces changes to the existing Markdown files

--- a/internal/third_party/machinebox/graphql/README.md
+++ b/internal/third_party/machinebox/graphql/README.md
@@ -60,7 +60,7 @@ use multipart form data instead using the `UseMultipartForm` option when you cre
 client := graphql.NewClient("https://machinebox.io/graphql", graphql.UseMultipartForm())
 ```
 
-For more information, [read the godoc package documentation](http://godoc.org/github.com/machinebox/graphql) or the [blog post](https://blog.machinebox.io/a-graphql-client-library-for-go-5bffd0455878).
+For more information, [read the godoc package documentation](http://godoc.org/github.com/machinebox/graphql).
 
 ## Thanks
 

--- a/internal/third_party/machinebox/graphql/README.md
+++ b/internal/third_party/machinebox/graphql/README.md
@@ -60,7 +60,7 @@ use multipart form data instead using the `UseMultipartForm` option when you cre
 client := graphql.NewClient("https://machinebox.io/graphql", graphql.UseMultipartForm())
 ```
 
-For more information, [read the godoc package documentation](http://godoc.org/github.com/machinebox/graphql).
+For more information, read the [godoc package documentation](http://godoc.org/github.com/machinebox/graphql).
 
 ## Thanks
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add the Markdown link check tool to the repository
- Add its description to the GitHub Actions workflows doc
- fix the link to the community Code of Conduct file

**Related issue(s)**
#73  [#18189](https://github.com/kyma-project/kyma/issues/18189)