### PR TITLE
Don't provide GardenerShootName AvS tag

### DIFF
--- a/internal/avs/config.go
+++ b/internal/avs/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	ParentId                                        int64
 	InstanceIdTagClassId                            int
 	ShootNameTagClassId                             int
-	GardenerShootNameTagClassId                     int
 	RegionTagClassId                                int
 	GlobalAccountIdTagClassId                       int
 	SubAccountIdTagClassId                          int

--- a/internal/avs/external_eval_assistant.go
+++ b/internal/avs/external_eval_assistant.go
@@ -75,10 +75,6 @@ func (eea *ExternalEvalAssistant) ProvideTags(operation internal.Operation) []*T
 			Content:    operation.ShootName,
 			TagClassId: eea.avsConfig.ShootNameTagClassId,
 		},
-		{
-			Content:    operation.ShootName,
-			TagClassId: eea.avsConfig.GardenerShootNameTagClassId,
-		},
 	}
 
 	region := ""

--- a/internal/avs/internal_eval_assistant.go
+++ b/internal/avs/internal_eval_assistant.go
@@ -87,10 +87,6 @@ func (iec *InternalEvalAssistant) ProvideTags(operation internal.Operation) []*T
 			Content:    operation.ShootName,
 			TagClassId: iec.avsConfig.ShootNameTagClassId,
 		},
-		{
-			Content:    operation.ShootName,
-			TagClassId: iec.avsConfig.GardenerShootNameTagClassId,
-		},
 	}
 
 	region := ""

--- a/internal/avs/model_test.go
+++ b/internal/avs/model_test.go
@@ -48,7 +48,7 @@ func TestAvsEvaluationConfigs(t *testing.T) {
 	assert.Equal("external-dummy", externalEvalAssistant.ProvideNewOrDefaultServiceName("dummy"))
 
 	params := internal.Operation{}
-	assert.Equal(8, len(internalEvalAssistant.ProvideTags(internal.Operation{})))
+	assert.Equal(7, len(internalEvalAssistant.ProvideTags(internal.Operation{})))
 
 	// verify confg as json
 	tags, testTag := externalEvalAssistant.ProvideTags(params), Tag{}

--- a/internal/process/provisioning/internal_eval_test.go
+++ b/internal/process/provisioning/internal_eval_test.go
@@ -190,10 +190,9 @@ func avsConfig(mockOauthServer *httptest.Server, mockAvsServer *httptest.Server)
 		ExternalTesterAccessId: 5678,
 		ExternalTesterService:  dummyStrAvsTest,
 
-		GroupId:                     5555,
-		ParentId:                    9101112,
-		GardenerShootNameTagClassId: 111112,
-		RegionTagClassId:            111113,
+		GroupId:          5555,
+		ParentId:         9101112,
+		RegionTagClassId: 111113,
 	}
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

The GardenerShootName AvS Tag is not publicly available in all the KCP environments' respective AvS groups which KEB connects to. Moreover the tag is superfluous as the shoot name is already provided via the `ShootNameTagClassId`

This PR removes support from configuring the shoot name in AvS tags via the `GardenerShootNameTagClassId`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
