### PR TITLE
Fix region for kyma CR

### DIFF
--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -23,7 +23,11 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 	l["kyma-project.io/global-account-id"] = operation.GlobalAccountID
 	l["kyma-project.io/subaccount-id"] = operation.SubAccountID
 	l["kyma-project.io/shoot-name"] = operation.ShootName
-	l["kyma-project.io/region"] = *operation.ProvisioningParameters.Parameters.Region
+	if operation.ProvisioningParameters.Parameters.Region != nil {
+		l["kyma-project.io/region"] = *operation.ProvisioningParameters.Parameters.Region
+	} else {
+		l["kyma-project.io/region"] = ""
+	}
 	l["operator.kyma-project.io/kyma-name"] = KymaName(operation)
 	l["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	if isKymaResourceInternal(operation) {

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -23,7 +23,7 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 	l["kyma-project.io/global-account-id"] = operation.GlobalAccountID
 	l["kyma-project.io/subaccount-id"] = operation.SubAccountID
 	l["kyma-project.io/shoot-name"] = operation.ShootName
-	l["kyma-project.io/region"] = operation.Region
+	l["kyma-project.io/region"] = *operation.ProvisioningParameters.Parameters.Region
 	l["operator.kyma-project.io/kyma-name"] = KymaName(operation)
 	l["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	if isKymaResourceInternal(operation) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix the issue that the region value is missing when it's assigned to Kyma CR as the region is from `operation.Region` and this `operation.Region` currently is from [operation.RuntimeOperation.Runtime.Region](https://github.com/kyma-project/kyma-environment-broker/blob/e8cdf9dc1e84c723cb727daa7d56693beccc6f02/common/orchestration/ext.go#L21). it's missing during provisioning.
The region is actually assigned to [requestInput.ClusterConfig.GardenerConfig.Region](https://github.com/kyma-project/kyma-environment-broker/blob/e8cdf9dc1e84c723cb727daa7d56693beccc6f02/internal/process/provisioning/create_runtime_without_kyma_step.go#L63C3-L63C51) already in the step `Create_Runtime_Without_Kyma` and this `requestInput.ClusterConfig.GardenerConfig.Region` is assigned from [r.provisioningParameters.Parameters](https://github.com/kyma-project/kyma-environment-broker/blob/e8cdf9dc1e84c723cb727daa7d56693beccc6f02/internal/process/input/input.go#L458).
The `r.provisioningParameters.Parameters` is set in [operation.InputCreator.SetProvisioningParameters](https://github.com/kyma-project/kyma-environment-broker/blob/e8cdf9dc1e84c723cb727daa7d56693beccc6f02/internal/process/provisioning/create_runtime_without_kyma_step.go#L143) from `operation.ProvisioningParameters`. So here use the region from `operation.ProvisioningParameters.Parameters.Region` directly.


**Related issue(s)**
related to [the issue](https://github.tools.sap/kyma/backlog/issues/4575)
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
