### PR TITLE
Fix runtime dto Status.State for deprovision type

### DIFF
--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -198,7 +198,7 @@ func (c *converter) adjustRuntimeState(dto *pkg.RuntimeDTO) {
 		case pkg.Suspension:
 			dto.Status.State = pkg.StateSuspended
 		case pkg.Deprovision:
-			if len(lastOp.ExcutedButNotCompleted) == 0 {
+			if len(lastOp.ExecutedButNotCompletedSteps) == 0 {
 				dto.Status.State = pkg.StateDeprovisioned
 			} else {
 				dto.Status.State = pkg.StateDeprovisionIncomplete

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -194,8 +194,11 @@ func (c *converter) adjustRuntimeState(dto *pkg.RuntimeDTO) {
 	switch lastOp.State {
 	case string(domain.Succeeded):
 		dto.Status.State = pkg.StateSucceeded
-		if lastOp.Type == pkg.Suspension {
+		switch lastOp.Type {
+		case pkg.Suspension:
 			dto.Status.State = pkg.StateSuspended
+		case pkg.Deprovision:
+			dto.Status.State = pkg.StateDeprovisioning
 		}
 	case string(domain.Failed):
 		dto.Status.State = pkg.StateFailed

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -198,7 +198,11 @@ func (c *converter) adjustRuntimeState(dto *pkg.RuntimeDTO) {
 		case pkg.Suspension:
 			dto.Status.State = pkg.StateSuspended
 		case pkg.Deprovision:
-			dto.Status.State = pkg.StateDeprovisioning
+			if len(lastOp.ExcutedButNotCompleted) == 0 {
+				dto.Status.State = pkg.StateDeprovisioned
+			} else {
+				dto.Status.State = pkg.StateDeprovisionIncomplete
+			}
 		}
 	case string(domain.Failed):
 		dto.Status.State = pkg.StateFailed


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adjust the Status.State for deprovision type in Runtime DTO as the deprovisioning operation state can be `domain.Succeeded` when it still contains non empty executedButNotCompletedSteps. so as long as the latest operation is in type `Deprovision` and state is `Succeeded`, turn its runitme Status.State to `StateDeprovisioning`.
 it's now causing [the mop-agent issue](https://github.tools.sap/kyma/backlog/issues/4564) (failed [in the check here](https://github.tools.sap/kyma/mop-agent/blob/6b86990ec7f5e1ccb625d071af9ddfeb5b445917/internal/runtime/manager.go#L205) and mop-agent still trying to send request to AVS for the deprovisioning runtime causing `400: bad request`).


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
