### PR TITLE
Region labels for kyma resource fix

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -1465,6 +1465,23 @@ func (s *BrokerSuiteTest) AssertKymaAnnotationExists(opId, annotationName string
 	assert.Contains(s.t, obj.GetAnnotations(), annotationName)
 }
 
+func (s *BrokerSuiteTest) AssertKymaLabelsExist(opId string, expectedLabels map[string]string) {
+	operation, err := s.db.Operations().GetOperationByID(opId)
+	assert.NoError(s.t, err)
+	obj := &unstructured.Unstructured{}
+	obj.SetName(operation.RuntimeID)
+	obj.SetNamespace("kyma-system")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operator.kyma-project.io",
+		Version: "v1beta2",
+		Kind:    "Kyma",
+	})
+
+	err = s.k8sKcp.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+
+	assert.Subset(s.t, obj.GetLabels(), expectedLabels)
+}
+
 func (s *BrokerSuiteTest) AssertSecretWithKubeconfigExists(opId string) {
 	operation, err := s.db.Operations().GetOperationByID(opId)
 	assert.NoError(s.t, err)

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -827,7 +827,7 @@ func (s *BrokerSuiteTest) AssertReconcilerStartedReconcilingWhenUpgrading(opID s
 }
 
 func (s *BrokerSuiteTest) DecodeErrorResponse(resp *http.Response) apiresponses.ErrorResponse {
-	m, err := ioutil.ReadAll(resp.Body)
+	m, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	require.NoError(s.t, err)
 
@@ -839,7 +839,7 @@ func (s *BrokerSuiteTest) DecodeErrorResponse(resp *http.Response) apiresponses.
 }
 
 func (s *BrokerSuiteTest) DecodeOperationID(resp *http.Response) string {
-	m, err := ioutil.ReadAll(resp.Body)
+	m, err := io.ReadAll(resp.Body)
 	s.Log(string(m))
 	require.NoError(s.t, err)
 	var provisioningResp struct {
@@ -852,7 +852,7 @@ func (s *BrokerSuiteTest) DecodeOperationID(resp *http.Response) string {
 }
 
 func (s *BrokerSuiteTest) DecodeOrchestrationID(resp *http.Response) string {
-	m, err := ioutil.ReadAll(resp.Body)
+	m, err := io.ReadAll(resp.Body)
 	s.Log(string(m))
 	require.NoError(s.t, err)
 	var upgradeResponse orchestration.UpgradeResponse
@@ -863,7 +863,7 @@ func (s *BrokerSuiteTest) DecodeOrchestrationID(resp *http.Response) string {
 }
 
 func (s *BrokerSuiteTest) DecodeLastUpgradeKymaOperationFromOrchestration(resp *http.Response) (*orchestration.OperationResponse, error) {
-	m, err := ioutil.ReadAll(resp.Body)
+	m, err := io.ReadAll(resp.Body)
 	s.Log(string(m))
 	require.NoError(s.t, err)
 	var operationsList orchestration.OperationResponseList
@@ -890,7 +890,7 @@ func (s *BrokerSuiteTest) DecodeLastUpgradeClusterOperationIDFromOrchestration(o
 	var operationsList orchestration.OperationResponseList
 	err := s.poller.Invoke(func() (bool, error) {
 		resp := s.CallAPI("GET", fmt.Sprintf("orchestrations/%s/operations", orchestrationID), "")
-		m, err := ioutil.ReadAll(resp.Body)
+		m, err := io.ReadAll(resp.Body)
 		s.Log(string(m))
 		if err != nil {
 			return false, fmt.Errorf("failed to read response body: %v", err)
@@ -1480,6 +1480,23 @@ func (s *BrokerSuiteTest) AssertKymaLabelsExist(opId string, expectedLabels map[
 	err = s.k8sKcp.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
 
 	assert.Subset(s.t, obj.GetLabels(), expectedLabels)
+}
+
+func (s *BrokerSuiteTest) AssertKymaLabelNotExists(opId string, notExpectedLabel string) {
+	operation, err := s.db.Operations().GetOperationByID(opId)
+	assert.NoError(s.t, err)
+	obj := &unstructured.Unstructured{}
+	obj.SetName(operation.RuntimeID)
+	obj.SetNamespace("kyma-system")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "operator.kyma-project.io",
+		Version: "v1beta2",
+		Kind:    "Kyma",
+	})
+
+	err = s.k8sKcp.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)
+
+	assert.NotContains(s.t, obj.GetLabels(), notExpectedLabel)
 }
 
 func (s *BrokerSuiteTest) AssertSecretWithKubeconfigExists(opId string) {

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -75,6 +75,9 @@ func TestProvisioning_HappyPathAWS(t *testing.T) {
 
 	suite.AssertKymaResourceExists(opID)
 	suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region": "eu-central-1",
+	})
 	suite.AssertSecretWithKubeconfigExists(opID)
 }
 
@@ -105,6 +108,9 @@ func TestProvisioning_Preview(t *testing.T) {
 	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region": "eu-central-1",
+	})
 	suite.AssertSecretWithKubeconfigExists(opID)
 }
 
@@ -245,6 +251,9 @@ func TestProvisioning_AzureWithEURestrictedAccessHappyFlow(t *testing.T) {
 
 	// then
 	suite.AssertAzureRegion("switzerlandnorth")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "switzerlandnorth",
+		"kyma-project.io/platform-region": "cf-ch20"})
 }
 
 func TestProvisioning_AzureWithEURestrictedAccessDefaultRegion(t *testing.T) {
@@ -276,6 +285,9 @@ func TestProvisioning_AzureWithEURestrictedAccessDefaultRegion(t *testing.T) {
 
 	// then
 	suite.AssertAzureRegion("switzerlandnorth")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "switzerlandnorth",
+		"kyma-project.io/platform-region": "cf-ch20"})
 }
 
 func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
@@ -308,6 +320,10 @@ func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/platform-region": "cf-eu11"})
+
 }
 
 func TestProvisioning_AWSWithEURestrictedAccessDefaultRegion(t *testing.T) {
@@ -339,6 +355,10 @@ func TestProvisioning_AWSWithEURestrictedAccessDefaultRegion(t *testing.T) {
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/platform-region": "cf-eu11"})
+
 }
 
 func TestProvisioning_TrialWithEmptyRegion(t *testing.T) {
@@ -371,6 +391,9 @@ func TestProvisioning_TrialWithEmptyRegion(t *testing.T) {
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-west-1")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region": "eu-west-1"})
+
 }
 
 func TestProvisioning_Conflict(t *testing.T) {
@@ -521,6 +544,9 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region": "eu-central-1",
+	})
 }
 
 func TestProvisioning_HandleExistingOperation(t *testing.T) {
@@ -629,6 +655,11 @@ func TestProvisioningWithReconciler_HappyPath(t *testing.T) {
 		Components:     suite.fixExpectedComponentListWithSMOperator(opID, clusterID),
 	})
 	suite.AssertClusterConfigWithKubeconfig(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
@@ -686,6 +717,11 @@ func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
 	})
 
 	suite.AssertClusterConfigWithKubeconfig(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestProvisioning_ClusterParameters(t *testing.T) {

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -4,7 +4,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -75,9 +74,8 @@ func TestProvisioning_HappyPathAWS(t *testing.T) {
 
 	suite.AssertKymaResourceExists(opID)
 	suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
-	suite.AssertKymaLabelsExist(opID, map[string]string{
-		"kyma-project.io/region": "eu-central-1",
-	})
+	suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-central-1"})
+	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 	suite.AssertSecretWithKubeconfigExists(opID)
 }
 
@@ -111,6 +109,7 @@ func TestProvisioning_Preview(t *testing.T) {
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region": "eu-central-1",
 	})
+	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 	suite.AssertSecretWithKubeconfigExists(opID)
 }
 
@@ -393,6 +392,7 @@ func TestProvisioning_TrialWithEmptyRegion(t *testing.T) {
 	suite.AssertAWSRegionAndZone("eu-west-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region": "eu-west-1"})
+	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 
 }
 
@@ -545,8 +545,10 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
-		"kyma-project.io/region": "eu-central-1",
+		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/platform-region": "cf-eu11",
 	})
+
 }
 
 func TestProvisioning_HandleExistingOperation(t *testing.T) {
@@ -592,8 +594,8 @@ func TestProvisioning_HandleExistingOperation(t *testing.T) {
 					}
 		}`)
 
-	firstBodyBytes, _ := ioutil.ReadAll(firstResp.Body)
-	secondBodyBytes, _ := ioutil.ReadAll(secondResp.Body)
+	firstBodyBytes, _ := io.ReadAll(firstResp.Body)
+	secondBodyBytes, _ := io.ReadAll(secondResp.Body)
 
 	// then
 	assert.Equal(t, string(firstBodyBytes), string(secondBodyBytes))

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -87,6 +87,11 @@ func TestUpdate(t *testing.T) {
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
 }
 
 func TestUpdateFailedInstance(t *testing.T) {
@@ -224,6 +229,12 @@ func TestExpiration(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	// we expect new suspension in progress operation (the last operation before is failed)
 	suite.WaitForLastOperation(iid, domain.InProgress)
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestExpirationOfNonTrial(t *testing.T) {
@@ -267,6 +278,12 @@ func TestExpirationOfNonTrial(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	instance := suite.GetInstance(iid)
 	assert.False(suite.t, instance.IsExpired())
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestTrialExpirationOnFailedOperations(t *testing.T) {
@@ -530,6 +547,13 @@ func TestUpdateDeprovisioningInstance(t *testing.T) {
 	errResponse := suite.DecodeErrorResponse(resp)
 
 	assert.Equal(t, "Unable to process an update of a deprovisioned instance", errResponse.Description)
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestUpdateWithNoOIDCParams(t *testing.T) {
@@ -588,6 +612,13 @@ func TestUpdateWithNoOIDCParams(t *testing.T) {
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestUpdateWithNoOidcOnUpdate(t *testing.T) {
@@ -706,6 +737,13 @@ func TestUpdateContext(t *testing.T) {
        }
    }`)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestUnsuspensionTrialKyma20(t *testing.T) {
@@ -778,6 +816,12 @@ func TestUnsuspensionTrialKyma20(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	suite.processProvisioningAndReconciliationByInstanceID(iid)
 
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region": "eu-west-1",
+	})
+	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
+
 }
 
 func TestUnsuspensionTrialWithDefaultProviderChangedForNonDefaultRegion(t *testing.T) {
@@ -848,6 +892,13 @@ func TestUnsuspensionTrialWithDefaultProviderChangedForNonDefaultRegion(t *testi
 
 	// check that the region and zone is set
 	suite.AssertAWSRegionAndZone("us-east-1")
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "us-east-1",
+		"kyma-project.io/platform-region": "cf-us10",
+	})
+
 }
 
 func TestUpdateWithOwnClusterPlan(t *testing.T) {
@@ -1009,6 +1060,13 @@ func TestUpdateOidcForSuspendedInstance(t *testing.T) {
 	assert.Equal(t, "id-oooxx", instance.Parameters.Parameters.OIDC.ClientID)
 	input := suite.LastProvisionInput(iid)
 	assert.Equal(t, "id-oooxx", input.ClusterConfig.GardenerConfig.OidcConfig.ClientID)
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
+
 }
 
 func TestUpdateOidcForPreview(t *testing.T) {
@@ -1118,6 +1176,12 @@ func TestUpdateNotExistingInstance(t *testing.T) {
        }
    }`)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	suite.AssertKymaResourceExists(opID)
+	suite.AssertKymaLabelsExist(opID, map[string]string{
+		"kyma-project.io/region":          "eu-west-1",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
 }
 
 func TestUpdateDefaultAdminNotChanged(t *testing.T) {

--- a/cmd/broker/upgrade_cluster_test.go
+++ b/cmd/broker/upgrade_cluster_test.go
@@ -148,4 +148,9 @@ func TestClusterUpgrade_UpgradeAfterUpdateWithNetworkPolicy(t *testing.T) {
 	upgradeOperationID = suite.DecodeOperationID(resp)
 	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
 
+	suite.AssertKymaResourceExists(upgradeOperationID)
+	suite.AssertKymaLabelsExist(upgradeOperationID, map[string]string{
+		"kyma-project.io/region":          "eastus",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
 }

--- a/cmd/broker/upgrade_kyma_test.go
+++ b/cmd/broker/upgrade_kyma_test.go
@@ -117,6 +117,11 @@ func TestClusterUpgradeUsesUpdatedAutoscalerParams(t *testing.T) {
 		Administrators: []string{"john.smith@email.com"},
 	})
 
+	suite.AssertKymaResourceExists(upgradeOperationID)
+	suite.AssertKymaLabelsExist(upgradeOperationID, map[string]string{
+		"kyma-project.io/region":          "eastus",
+		"kyma-project.io/platform-region": "cf-eu10",
+	})
 }
 
 func TestKymaUpgradeScheduledToFutureMaintenanceWindow(t *testing.T) {

--- a/internal/model.go
+++ b/internal/model.go
@@ -527,7 +527,7 @@ func NewDeprovisioningOperationWithID(operationID string, instance *Instance) (D
 	return DeprovisioningOperation{
 		Operation: Operation{
 			RuntimeOperation: orchestration.RuntimeOperation{
-				Runtime: orchestration.Runtime{GlobalAccountID: instance.GlobalAccountID, RuntimeID: instance.RuntimeID},
+				Runtime: orchestration.Runtime{GlobalAccountID: instance.GlobalAccountID, RuntimeID: instance.RuntimeID, Region: instance.ProviderRegion},
 			},
 			ID:                     operationID,
 			Version:                0,
@@ -559,8 +559,11 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 		FinishedStages:         make([]string, 0),
 		ProvisioningParameters: instance.Parameters,
 		UpdatingParameters:     updatingParams,
+		RuntimeOperation: orchestration.RuntimeOperation{
+			Runtime: orchestration.Runtime{
+				Region: instance.ProviderRegion},
+		},
 	}
-
 	if updatingParams.OIDC != nil {
 		op.ProvisioningParameters.Parameters.OIDC = updatingParams.OIDC
 	}
@@ -593,6 +596,10 @@ func NewSuspensionOperationWithID(operationID string, instance *Instance) Deprov
 			ProvisioningParameters: instance.Parameters,
 			FinishedStages:         make([]string, 0),
 			Temporary:              true,
+			RuntimeOperation: orchestration.RuntimeOperation{
+				Runtime: orchestration.Runtime{
+					Region: instance.ProviderRegion},
+			},
 		},
 	}
 }

--- a/internal/orchestration/manager/upgrade_cluster.go
+++ b/internal/orchestration/manager/upgrade_cluster.go
@@ -50,6 +50,7 @@ func NewUpgradeClusterManager(orchestrationStorage storage.Orchestrations, opera
 
 func (u *upgradeClusterFactory) NewOperation(o internal.Orchestration, r orchestration.Runtime, i internal.Instance, state domain.LastOperationState) (orchestration.RuntimeOperation, error) {
 	id := uuid.New().String()
+	r.Region = i.ProviderRegion
 	op := internal.UpgradeClusterOperation{
 		Operation: internal.Operation{
 			ID:                     id,

--- a/internal/orchestration/manager/upgrade_kyma.go
+++ b/internal/orchestration/manager/upgrade_kyma.go
@@ -56,6 +56,7 @@ func (u *upgradeKymaFactory) NewOperation(o internal.Orchestration, r orchestrat
 	if err != nil {
 		return orchestration.RuntimeOperation{}, err
 	}
+	r.Region = i.ProviderRegion
 	op := internal.UpgradeKymaOperation{
 		Operation: internal.Operation{
 			ID:                     id,

--- a/internal/process/provisioning/create_runtime_without_kyma_step.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_step.go
@@ -83,10 +83,11 @@ func (s *CreateRuntimeWithoutKymaStep) Run(operation internal.Operation, log log
 		operation.ProvisionerOperationID = *provisionerResponse.ID
 		if provisionerResponse.RuntimeID != nil {
 			operation.RuntimeID = *provisionerResponse.RuntimeID
+			operation.Region = requestInput.ClusterConfig.GardenerConfig.Region
 		}
 	}, log)
 	if repeat != 0 {
-		log.Errorf("cannot save operation ID from provisioner")
+		log.Errorf("cannot save neither runtime ID nor region from provisioner")
 		return operation, 5 * time.Second, nil
 	}
 

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -24,6 +24,9 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 	l["kyma-project.io/subaccount-id"] = operation.SubAccountID
 	l["kyma-project.io/shoot-name"] = operation.ShootName
 	l["kyma-project.io/region"] = operation.Region
+	if operation.ProvisioningParameters.PlatformRegion != "" {
+		l["kyma-project.io/platform-region"] = operation.ProvisioningParameters.PlatformRegion
+	}
 	l["operator.kyma-project.io/kyma-name"] = KymaName(operation)
 	l["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	if isKymaResourceInternal(operation) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- `kyma-project.io/region` label with provider region added 
- `kyma-project.io/platform-region` label with platform region added when set in the creation (PUT) request
- call to deprecated method `ioutil.ReadAll` replaced with `io.ReadAll`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
