### PR TITLE
Add a flag to expose schema with region required

### DIFF
--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -997,9 +997,10 @@ func fixConfig() *Config {
 		EnableOnDemandVersion:   true,
 		UpdateProcessingEnabled: true,
 		Broker: broker.Config{
-			EnablePlans:               []string{"azure", "trial", "aws", "own_cluster", "preview"},
-			AllowNetworkingParameters: true,
-			RegionParameterIsRequired: true,
+			EnablePlans:                    []string{"azure", "trial", "aws", "own_cluster", "preview"},
+			AllowNetworkingParameters:      true,
+			RegionParameterIsRequired:      true,
+			ExposeSchemaWithRegionRequired: true,
 		},
 		Avs: avs.Config{},
 		IAS: ias.Config{

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -42,8 +42,9 @@ type Config struct {
 	SubaccountsIdsToShowTrialExpirationInfo string `envconfig:"default="`
 	TrialDocsURL                            string `envconfig:"default="`
 
-	AllowNetworkingParameters bool `envconfig:"default=false"`
-	RegionParameterIsRequired bool `envconfig:"default=false"`
+	AllowNetworkingParameters      bool `envconfig:"default=false"`
+	RegionParameterIsRequired      bool `envconfig:"default=false"`
+	ExposeSchemaWithRegionRequired bool `envconfig:"default=false"`
 }
 
 type ServicesConfig map[string]Service

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -54,7 +54,8 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.cfg.RegionParameterIsRequired) {
+	regionRequired := b.cfg.ExposeSchemaWithRegionRequired || b.cfg.RegionParameterIsRequired
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), regionRequired) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/services_test.go
+++ b/internal/broker/services_test.go
@@ -116,7 +116,7 @@ func TestServices_Services(t *testing.T) {
 		assertPlansContainPropertyInSchemas(t, services[0], "administrators")
 	})
 
-	t.Run("should containt the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is true and RegionParameterIsRequired is false", func(t *testing.T) {
+	t.Run("should contain the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is true and RegionParameterIsRequired is false", func(t *testing.T) {
 		// given
 		var (
 			name       = "testServiceName"

--- a/internal/broker/services_test.go
+++ b/internal/broker/services_test.go
@@ -196,7 +196,7 @@ func TestServices_Services(t *testing.T) {
 
 	})
 
-	t.Run("should containt the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is false and RegionParameterIsRequired is true", func(t *testing.T) {
+	t.Run("should contain the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is false and RegionParameterIsRequired is true", func(t *testing.T) {
 		// given
 		var (
 			name       = "testServiceName"

--- a/internal/broker/services_test.go
+++ b/internal/broker/services_test.go
@@ -236,7 +236,7 @@ func TestServices_Services(t *testing.T) {
 
 	})
 
-	t.Run("should containt the property 'required' with values [name] when ExposeSchemaWithRegionRequired is false and RegionParameterIsRequired is false", func(t *testing.T) {
+	t.Run("should contain the property 'required' with values [name] when ExposeSchemaWithRegionRequired is false and RegionParameterIsRequired is false", func(t *testing.T) {
 		// given
 		var (
 			name       = "testServiceName"

--- a/internal/broker/services_test.go
+++ b/internal/broker/services_test.go
@@ -156,7 +156,7 @@ func TestServices_Services(t *testing.T) {
 
 	})
 
-	t.Run("should containt the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is true and RegionParameterIsRequired is true", func(t *testing.T) {
+	t.Run("should contain the property 'required' with values [name region] when ExposeSchemaWithRegionRequired is true and RegionParameterIsRequired is true", func(t *testing.T) {
 		// given
 		var (
 			name       = "testServiceName"

--- a/internal/broker/services_test.go
+++ b/internal/broker/services_test.go
@@ -309,15 +309,6 @@ func assertPlanContainsPropertyValuesInCreateSchema(t *testing.T, plan domain.Se
 	}
 
 	for _, wantedPropVal = range wantedPropertyValues {
-		found := false
-		for _, planPropVal := range planPropertyValues.([]interface{}) {
-			if wantedPropVal == planPropVal {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("plan %s does not contain the value '%s' for the property '%s' in Create schema", plan.Name, wantedPropVal, property)
-		}
+		assert.Contains(t, planPropertyValues, wantedPropVal)
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The flag allows to expose a new schema for KEB that makes the region parameter mandatory, but KEB will still accept requests without the region parameter.

Changes proposed in this pull request:

- Add a flag to expose schema with the region required parameter
- Add unit tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also https://github.com/kyma-project/control-plane/issues/3006