### PR TITLE
Fix link to KEB docs in swagger

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
@@ -2393,7 +2393,7 @@ components:
           example: Kyma Environment
         documentationUrl:
           type: string
-          example: https://github.com/kyma-project/control-plane/tree/main/docs/kyma-environment-broker
+          example: https://github.com/kyma-project/kyma-environment-broker/tree/main/docs
         imageUrl:
           type: string
           example: data:image/svg+xml;base64,imgURL
@@ -2439,4 +2439,4 @@ components:
 
 externalDocs:
   description: The offical Kyma Environment Broker documentation
-  url: 'https://github.com/kyma-project/control-plane/tree/main/docs/kyma-environment-broker'
+  url: 'https://github.com/kyma-project/kyma-environment-broker/tree/main/docs'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The url points to old docs in control-plane. This PR fixes that.

Changes proposed in this pull request:


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
