### PR TITLE
Block EDP deregistration if other instances exists with the same subaccount

### DIFF
--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -40,7 +40,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 			step: deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),
 		},
 		{
-			step:     deprovisioning.NewEDPDeregistrationStep(db.Operations(), edpClient, cfg.EDP),
+			step:     deprovisioning.NewEDPDeregistrationStep(db.Operations(), db.Instances(), edpClient, cfg.EDP),
 			disabled: cfg.EDP.Disabled,
 		},
 		{

--- a/internal/edp/client_fake.go
+++ b/internal/edp/client_fake.go
@@ -103,7 +103,7 @@ func (f *FakeClient) DeleteMetadataTenant(name, env, key string) error {
 
 func checkDataTenantPayload(data DataTenantPayload) error {
 	if data.Name == "" || data.Environment == "" || data.Secret == "" {
-		return fmt.Errorf("one of the fields in DataTenantPayload is missing")
+		return fmt.Errorf("one of the fields in DataTenantPayload is missing: %v", data)
 	}
 	return nil
 }

--- a/internal/process/deprovisioning/edp_deregistration_test.go
+++ b/internal/process/deprovisioning/edp_deregistration_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
+
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/edp"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
@@ -18,43 +21,27 @@ const (
 	edpEnvironment = "test"
 )
 
+var metadataTenantKeys = []string{
+	edp.MaasConsumerEnvironmentKey,
+	edp.MaasConsumerRegionKey,
+	edp.MaasConsumerSubAccountKey,
+	edp.MaasConsumerServicePlan,
+}
+
 func TestEDPDeregistration_Run(t *testing.T) {
 	// given
 	client := edp.NewFakeClient()
-	err := client.CreateDataTenant(edp.DataTenantPayload{
-		Name:        edpName,
-		Environment: edpEnvironment,
-		Secret:      base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", edpName, edpEnvironment))),
-	})
-	assert.NoError(t, err)
-
-	metadataTenantKeys := []string{
-		edp.MaasConsumerEnvironmentKey,
-		edp.MaasConsumerRegionKey,
-		edp.MaasConsumerSubAccountKey,
-		edp.MaasConsumerServicePlan,
-	}
-
-	for _, key := range metadataTenantKeys {
-		err = client.CreateMetadataTenant(edpName, edpEnvironment, edp.MetadataTenantPayload{
-			Key:   key,
-			Value: "-",
-		})
-		assert.NoError(t, err)
-	}
+	prepareEDP(edpName, client)
 
 	memoryStorage := storage.NewMemoryStorage()
-	step := NewEDPDeregistrationStep(memoryStorage.Operations(), client, edp.Config{
+	_, operation := prepareDeprovisioningInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+
+	step := NewEDPDeregistrationStep(memoryStorage.Operations(), memoryStorage.Instances(), client, edp.Config{
 		Environment: edpEnvironment,
 	})
 
 	// when
-	_, repeat, err := step.Run(
-		internal.Operation{
-			InstanceDetails: internal.InstanceDetails{
-				SubAccountID: edpName,
-			},
-		}, logrus.New())
+	_, repeat, err := step.Run(operation, logrus.New())
 
 	// then
 	assert.Equal(t, 0*time.Second, repeat)
@@ -69,4 +56,130 @@ func TestEDPDeregistration_Run(t *testing.T) {
 	dataTenant, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
 	assert.False(t, dataTenantExists)
 	assert.Equal(t, edp.DataTenantItem{}, dataTenant)
+}
+
+func TestEDPDeregistration_RunWithOtherInstances(t *testing.T) {
+	// given
+	client := edp.NewFakeClient()
+	prepareEDP(edpName, client)
+
+	memoryStorage := storage.NewMemoryStorage()
+	_, _ = prepareProvisionedInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+	_, operation := prepareDeprovisioningInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+
+	step := NewEDPDeregistrationStep(memoryStorage.Operations(), memoryStorage.Instances(), client, edp.Config{
+		Environment: edpEnvironment,
+	})
+
+	// when
+	_, repeat, err := step.Run(operation, logrus.New())
+
+	// then
+	assert.Equal(t, 0*time.Second, repeat)
+	assert.NoError(t, err)
+
+	for _, key := range metadataTenantKeys {
+		_, metadataTenantExists := client.GetMetadataItem(edpName, edpEnvironment, key)
+		assert.True(t, metadataTenantExists)
+	}
+
+	_, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
+	assert.True(t, dataTenantExists)
+}
+
+func TestEDPDeregistration_RunWithOtherInstancesButDifferentSubaccount(t *testing.T) {
+	// given
+	client := edp.NewFakeClient()
+	prepareEDP(edpName, client)
+
+	memoryStorage := storage.NewMemoryStorage()
+	_, _ = prepareProvisionedInstanceWithSubaccount("subaccount-other", memoryStorage.Instances(), memoryStorage.Operations())
+	_, operation := prepareDeprovisioningInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+
+	step := NewEDPDeregistrationStep(memoryStorage.Operations(), memoryStorage.Instances(), client, edp.Config{
+		Environment: edpEnvironment,
+	})
+
+	// when
+	_, repeat, err := step.Run(operation, logrus.New())
+
+	// then
+	assert.Equal(t, 0*time.Second, repeat)
+	assert.NoError(t, err)
+
+	for _, key := range metadataTenantKeys {
+		_, metadataTenantExists := client.GetMetadataItem(edpName, edpEnvironment, key)
+		assert.False(t, metadataTenantExists)
+	}
+
+	_, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
+	assert.False(t, dataTenantExists)
+}
+
+func TestEDPDeregistration_RunWithOtherInstancesInDeprovisioningState(t *testing.T) {
+	// given
+	client := edp.NewFakeClient()
+	prepareEDP(edpName, client)
+
+	memoryStorage := storage.NewMemoryStorage()
+	_, _ = prepareDeprovisioningInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+	_, operation := prepareDeprovisioningInstanceWithSubaccount(edpName, memoryStorage.Instances(), memoryStorage.Operations())
+
+	step := NewEDPDeregistrationStep(memoryStorage.Operations(), memoryStorage.Instances(), client, edp.Config{
+		Environment: edpEnvironment,
+	})
+
+	// when
+	_, repeat, err := step.Run(operation, logrus.New())
+
+	// then
+	assert.Equal(t, 0*time.Second, repeat)
+	assert.NoError(t, err)
+
+	for _, key := range metadataTenantKeys {
+		_, metadataTenantExists := client.GetMetadataItem(edpName, edpEnvironment, key)
+		assert.False(t, metadataTenantExists)
+	}
+
+	_, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
+	assert.False(t, dataTenantExists)
+}
+
+func prepareEDP(subaccountId string, client *edp.FakeClient) {
+	client.CreateDataTenant(edp.DataTenantPayload{
+		Name:        subaccountId,
+		Environment: edpEnvironment,
+		Secret:      base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", edpName, edpEnvironment))),
+	})
+
+	for _, key := range metadataTenantKeys {
+		client.CreateMetadataTenant(subaccountId, edpEnvironment, edp.MetadataTenantPayload{
+			Key:   key,
+			Value: "-",
+		})
+	}
+}
+
+func prepareProvisionedInstanceWithSubaccount(subaccountId string, instances storage.Instances, operations storage.Operations) (internal.Instance, internal.Operation) {
+	instanceID := uuid.New().String()
+	instance := fixture.FixInstance(instanceID)
+	instance.SubAccountID = subaccountId
+	operation := fixture.FixProvisioningOperation(uuid.New().String(), instanceID)
+	operation.SubAccountID = subaccountId
+	instances.Insert(instance)
+	operations.InsertOperation(operation)
+
+	return instance, operation
+}
+
+func prepareDeprovisioningInstanceWithSubaccount(subaccountId string, instances storage.Instances, operations storage.Operations) (internal.Instance, internal.Operation) {
+	instanceID := uuid.New().String()
+	instance := fixture.FixInstance(instanceID)
+	instance.SubAccountID = subaccountId
+	operation := fixture.FixDeprovisioningOperationAsOperation(uuid.New().String(), instanceID)
+	operation.SubAccountID = subaccountId
+	instances.Insert(instance)
+	operations.InsertOperation(operation)
+
+	return instance, operation
 }


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- the deprovisioning EDP step must not deregister SKR if there is another instance which is not in deprovisioning state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
