### PR TITLE
Add direct support for argo sync waves for the migrator job

### DIFF
--- a/resources/keb/templates/migrator-job.yaml
+++ b/resources/keb/templates/migrator-job.yaml
@@ -108,22 +108,22 @@ spec:
               mountPath: /secrets/cloudsql-sslrootcert
               readOnly: true
             {{- end }}
-          volumes:
-            - name: kyma-environment-broker
-              configMap:
-                name: kyma-environment-broker-migrations
-            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true) (eq .Values.global.database.cloudsqlproxy.workloadIdentity.enabled false)}}
-            - name: cloudsql-instance-credentials
-              secret:
-                secretName: cloudsql-instance-credentials
-            {{- end }}
-            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false) }}
-            - name: cloudsql-sslrootcert
-              secret:
-                secretName: kcp-postgresql
-                items:
-                  - key: postgresql-sslRootCert
-                    path: server-ca.pem
-                optional: true
-            {{- end}}
+      volumes:
+        - name: kyma-environment-broker
+          configMap:
+            name: kyma-environment-broker-migrations
+        {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true) (eq .Values.global.database.cloudsqlproxy.workloadIdentity.enabled false)}}
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+        {{- end }}
+        {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false) }}
+        - name: cloudsql-sslrootcert
+          secret:
+            secretName: kcp-postgresql
+            items:
+              - key: postgresql-sslRootCert
+                path: server-ca.pem
+            optional: true
+          {{- end}}
 {{ end }}

--- a/resources/keb/templates/migrator-job.yaml
+++ b/resources/keb/templates/migrator-job.yaml
@@ -2,120 +2,128 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: kcp-migration-broker
-    labels:
+  name: kcp-migration-broker
+  labels:
+    app: {{ .Values.namePrefix }}
+    release: {{ .Values.namePrefix }}
+  {{- if or .Values.migratorJobs.helmhook.enabled .Values.migratorJobs.argosync.enabled }}
+  annotations:
+    {{- if .Values.migratorJobs.helmhook.enabled }}
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": {{ .Values.migratorJobs.helmhook.weight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
+    {{- if .Values.migratorJobs.argosync.enabled }}
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/sync-wave: {{ .Values.migratorJobs.argosync.syncwave | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  template:
+    metadata:
+      labels:
         app: {{ .Values.namePrefix }}
         release: {{ .Values.namePrefix }}
-    annotations:
-        "helm.sh/hook": post-install,post-upgrade
-        "helm.sh/hook-weight": "1"
-        "helm.sh/hook-delete-policy": before-hook-creation
-spec:
-    template:
-        metadata:
-            labels:
-                app: {{ .Values.namePrefix }}
-                release: {{ .Values.namePrefix }}
-            {{if eq .Values.global.database.embedded.enabled false}}
-            annotations:
-                sidecar.istio.io/inject: "false"
-            {{end}}
-        spec:
-            serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
-            restartPolicy: Never
-            shareProcessNamespace: true
-            containers:
-                {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true)}}
-                - name: cloudsql-proxy
-                  image: {{ .Values.global.images.cloudsql_proxy_image }}
-                  {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
-                  command: ["/cloud_sql_proxy",
-                            "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432"]
-                  {{- else }}
-                  command: ["/cloud_sql_proxy",
-                            "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432",
-                            "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"]
-                  volumeMounts:
-                      - name: cloudsql-instance-credentials
-                        mountPath: /secrets/cloudsql-instance-credentials
-                        readOnly: true
-                  {{- end }}
-                {{- end}}
-                - name: migrator
-                  image: {{ .Values.global.images.container_registry.path }}/{{ .Values.global.images.schema_migrator.dir }}/schema-migrator:{{ .Values.global.images.schema_migrator.version }}
-                  imagePullPolicy: IfNotPresent
-                  command: 
-                    - /bin/program
-                  env:
-                      {{if eq .Values.global.database.embedded.enabled true}}
-                      - name: DATABASE_EMBEDDED
-                        value: "true"
-                      {{end}}
-                      {{if eq .Values.global.database.embedded.enabled false}}
-                      - name: DATABASE_EMBEDDED
-                        value: "false"
-                      {{end}}
-                      - name: DB_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: kcp-postgresql
-                                key: postgresql-broker-username
-                      - name: DB_PASSWORD
-                        valueFrom:
-                            secretKeyRef:
-                                name: kcp-postgresql
-                                key: postgresql-broker-password
-                      - name: DB_HOST
-                        valueFrom:
-                            secretKeyRef:
-                                name: kcp-postgresql
-                                key: postgresql-serviceName
-                      - name: DB_PORT
-                        valueFrom:
-                            secretKeyRef:
-                                name: kcp-postgresql
-                                key: postgresql-servicePort
-                      - name: DB_NAME
-                        valueFrom:
-                          secretKeyRef:
-                            name: kcp-postgresql
-                            key: postgresql-broker-db-name
-                      - name: DB_SSL
-                        valueFrom:
-                          secretKeyRef:
-                            name: kcp-postgresql
-                            key: postgresql-sslMode
-                      - name: DB_SSLROOTCERT
-                        value: /secrets/cloudsql-sslrootcert/server-ca.pem
-                      - name: MIGRATION_PATH
-                        value: "kyma-environment-broker"
-                      - name: DIRECTION
-                        value: "up"
-                  volumeMounts:
-                      - name: kyma-environment-broker
-                        mountPath: /migrate/new-migrations/kyma-environment-broker
-                      {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false)}}
-                      - name: cloudsql-sslrootcert
-                        mountPath: /secrets/cloudsql-sslrootcert
-                        readOnly: true
-                      {{- end}}
-            volumes:
-              - name: kyma-environment-broker
-                configMap:
-                  name: kyma-environment-broker-migrations
-            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true) (eq .Values.global.database.cloudsqlproxy.workloadIdentity.enabled false)}}
-              - name: cloudsql-instance-credentials
-                secret:
-                  secretName: cloudsql-instance-credentials
+      {{- if eq .Values.global.database.embedded.enabled false }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+      {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
+      restartPolicy: Never
+      shareProcessNamespace: true
+      containers:
+        {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true)}}
+        - name: cloudsql-proxy
+          image: {{ .Values.global.images.cloudsql_proxy_image }}
+          {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
+          command: ["/cloud_sql_proxy",
+          "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432"]
+          {{- else }}
+          command:
+            - "/cloud_sql_proxy"
+            - "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432"
+            - "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+          volumeMounts:
+            - name: cloudsql-instance-credentials
+              mountPath: /secrets/cloudsql-instance-credentials
+              readOnly: true
+          {{- end }}
+        {{- end}}
+        - name: migrator
+          image: {{ .Values.global.images.container_registry.path }}/{{ .Values.global.images.schema_migrator.dir }}/schema-migrator:{{ .Values.global.images.schema_migrator.version }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/program
+          env:
+            {{- if eq .Values.global.database.embedded.enabled true }}
+            - name: DATABASE_EMBEDDED
+              value: "true"
             {{- end}}
-            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false)}}
-              - name: cloudsql-sslrootcert
-                secret:
-                  secretName: kcp-postgresql
-                  items:
+            {{- if eq .Values.global.database.embedded.enabled false }}
+            - name: DATABASE_EMBEDDED
+              value: "false"
+            {{- end }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-broker-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-broker-password
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-serviceName
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-servicePort
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-broker-db-name
+            - name: DB_SSL
+              valueFrom:
+                secretKeyRef:
+                  name: kcp-postgresql
+                  key: postgresql-sslMode
+            - name: DB_SSLROOTCERT
+              value: /secrets/cloudsql-sslrootcert/server-ca.pem
+            - name: MIGRATION_PATH
+              value: "kyma-environment-broker"
+            - name: DIRECTION
+              value: "up"
+          volumeMounts:
+            - name: kyma-environment-broker
+              mountPath: /migrate/new-migrations/kyma-environment-broker
+            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false) }}
+            - name: cloudsql-sslrootcert
+              mountPath: /secrets/cloudsql-sslrootcert
+              readOnly: true
+            {{- end }}
+          volumes:
+            - name: kyma-environment-broker
+              configMap:
+                name: kyma-environment-broker-migrations
+            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled true) (eq .Values.global.database.cloudsqlproxy.workloadIdentity.enabled false)}}
+            - name: cloudsql-instance-credentials
+              secret:
+                secretName: cloudsql-instance-credentials
+            {{- end }}
+            {{- if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.cloudsqlproxy.enabled false) }}
+            - name: cloudsql-sslrootcert
+              secret:
+                secretName: kcp-postgresql
+                items:
                   - key: postgresql-sslRootCert
                     path: server-ca.pem
-                  optional: true
+                optional: true
             {{- end}}
 {{ end }}
-

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -402,3 +402,9 @@ runtimeReconciler:
 
 migratorJobs:
   enabled: true
+  helmhook:
+    enabled: true
+    weight: "1"
+  argosync:
+    enabled: false
+    syncwave: "0"


### PR DESCRIPTION
**Description**

This change adds direct support for the ArgoCD sync waves on the migrator job, instead of relying on the converted helm hooks.

Also, the indentation of the yaml manifest is fixed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
