### PR TITLE
Runtime Reconciler with kubeconfig provider

### DIFF
--- a/internal/kubeconfig/provider.go
+++ b/internal/kubeconfig/provider.go
@@ -22,7 +22,7 @@ func NewK8sClientFromSecretProvider(kcpK8sClient client.Client) *SecretProvider 
 	}
 }
 
-func (p *SecretProvider) KubecofigForRuntimeID(runtimeId string) ([]byte, error) {
+func (p *SecretProvider) KubeconfigForRuntimeID(runtimeId string) ([]byte, error) {
 	kubeConfigSecret := &v1.Secret{}
 	err := p.kcpK8sClient.Get(context.Background(), p.objectKey(runtimeId), kubeConfigSecret)
 	if err != nil {
@@ -46,7 +46,7 @@ func (p *SecretProvider) objectKey(runtimeId string) client.ObjectKey {
 }
 
 func (p *SecretProvider) K8sClientForRuntimeID(runtimeID string) (client.Client, error) {
-	kubeconfig, err := p.KubecofigForRuntimeID(runtimeID)
+	kubeconfig, err := p.KubeconfigForRuntimeID(runtimeID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubeconfig/provider.go
+++ b/internal/kubeconfig/provider.go
@@ -1,0 +1,62 @@
+package kubeconfig
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const kcpNamespace = "kcp-system"
+
+type SecretProvider struct {
+	kcpK8sClient client.Client
+}
+
+func NewK8sClientFromSecretProvider(kcpK8sClient client.Client) *SecretProvider {
+	return &SecretProvider{
+		kcpK8sClient: kcpK8sClient,
+	}
+}
+
+func (p *SecretProvider) KubecofigForRuntimeID(runtimeId string) ([]byte, error) {
+	kubeConfigSecret := &v1.Secret{}
+	err := p.kcpK8sClient.Get(context.Background(), p.objectKey(runtimeId), kubeConfigSecret)
+	if err != nil {
+		return nil, fmt.Errorf("while getting secret from kcp for runtimeId=%s : %w", runtimeId, err)
+	}
+	config, ok := kubeConfigSecret.Data["config"]
+	if !ok {
+		return nil, fmt.Errorf("while getting 'config' from secret from %s", p.objectKey(runtimeId))
+	}
+	if len(config) == 0 {
+		return nil, fmt.Errorf("empty kubeconfig")
+	}
+	return config, nil
+}
+
+func (p *SecretProvider) objectKey(runtimeId string) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: kcpNamespace,
+		Name:      fmt.Sprintf("kubeconfig-%s", runtimeId),
+	}
+}
+
+func (p *SecretProvider) K8sClientForRuntimeID(runtimeID string) (client.Client, error) {
+	kubeconfig, err := p.KubecofigForRuntimeID(runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sCli, err := client.New(restCfg, client.Options{
+		Scheme: scheme.Scheme,
+	})
+	return k8sCli, err
+}

--- a/internal/kubeconfig/provider_test.go
+++ b/internal/kubeconfig/provider_test.go
@@ -1,0 +1,101 @@
+package kubeconfig
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const envTestAssets = "KUBEBUILDER_ASSETS"
+
+func TestSecretProvider_KubernetesAndK8sClientForRuntimeID(t *testing.T) {
+	// Given
+
+	// prepare envtest to provide valid kubeconfig
+	if os.Getenv(envTestAssets) == "" {
+		out, err := exec.Command("/bin/sh", "../../setup-envtest.sh").Output()
+		require.NoError(t, err)
+		path := strings.Replace(string(out), "\n", "", -1)
+		os.Setenv(envTestAssets, path)
+	}
+
+	env := envtest.Environment{}
+	config, err := env.Start()
+	assert.NoError(t, err)
+	defer env.Stop()
+	kubeconfig := createKubeconfigFileForRestConfig(*config)
+
+	// prepare a k8s client to store a secret with kubeconfig
+	kcpClient := fake.NewClientBuilder().Build()
+	kcpClient.Create(context.Background(), &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeconfig-runtime00",
+			Namespace: "kcp-system",
+		},
+		Data: map[string][]byte{
+			"config": kubeconfig,
+		},
+	})
+	provider := SecretProvider{
+		kcpK8sClient: kcpClient,
+	}
+
+	// when
+	kubeconfig, errKubeconfig := provider.KubecofigForRuntimeID("runtime00")
+	k8sClient, errClient := provider.K8sClientForRuntimeID("runtime00")
+
+	// then
+	assert.NotEmpty(t, kubeconfig)
+	assert.NotNil(t, k8sClient)
+	assert.NoError(t, errKubeconfig)
+	assert.NoError(t, errClient)
+}
+
+func createKubeconfigFileForRestConfig(restConfig rest.Config) []byte {
+	const (
+		userName    = "user"
+		clusterName = "cluster"
+		contextName = "context"
+	)
+
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters[clusterName] = &clientcmdapi.Cluster{
+		Server:                   restConfig.Host,
+		CertificateAuthorityData: restConfig.CAData,
+	}
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts[contextName] = &clientcmdapi.Context{
+		Cluster:  clusterName,
+		AuthInfo: userName,
+	}
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos[userName] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: restConfig.CertData,
+		ClientKeyData:         restConfig.KeyData,
+	}
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: contextName,
+		AuthInfos:      authinfos,
+	}
+	kubeconfig, _ := clientcmd.Write(clientConfig)
+	return kubeconfig
+}

--- a/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -30,6 +30,9 @@ const (
 	btpOperatorBinding         = "ServiceBinding"
 )
 
+type KubeconfigProvider interface {
+	KubecofigForRuntimeID(runtimeId string) ([]byte, error)
+}
 type BTPOperatorCleanupStep struct {
 	operationManager  *process.DeprovisionOperationManager
 	provisionerClient provisioner.Client

--- a/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -31,7 +31,7 @@ const (
 )
 
 type KubeconfigProvider interface {
-	KubecofigForRuntimeID(runtimeId string) ([]byte, error)
+	KubeconfigForRuntimeID(runtimeId string) ([]byte, error)
 }
 type BTPOperatorCleanupStep struct {
 	operationManager  *process.DeprovisionOperationManager


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- create a kubeconfig provider which gets the kubeconfig from the Secret.
- use this provider in runtime reconciler

This is a first PR about hte kubeconfig provider, it will be used in other places in KEB (next PRs)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
