### PR TITLE
Fix cmd/broker unit test flakiness 

### DIFF
--- a/cmd/broker/last_operation_test.go
+++ b/cmd/broker/last_operation_test.go
@@ -35,7 +35,7 @@ func TestLastOperationWithoutOperationIDHappyPath(t *testing.T) {
 		}
 	}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	//when
 	resp = suite.CallAPI("GET", fmt.Sprintf("oauth/v2/service_instances/%s/last_operation", iid), "")
@@ -70,7 +70,7 @@ func TestLastOperationWithOperationIDHappyPath(t *testing.T) {
 		}
 	}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	//when
 	resp = suite.CallAPI("GET", fmt.Sprintf("oauth/v2/service_instances/%s/last_operation?operation=%s", iid, opID), "")
@@ -136,7 +136,7 @@ func TestLastOperationWithOperationIDAndNotExistingInstanceID(t *testing.T) {
 			}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	oid := uuid.New().String()
 

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -115,7 +115,7 @@ func TestProvisioning_HappyPathAWS(t *testing.T) {
 		}`)
 	opID := suite.DecodeOperationID(resp)
 
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	// then
 	suite.WaitForOperationState(opID, domain.Succeeded)
@@ -150,7 +150,7 @@ func TestProvisioning_HappyPathSapConvergedCloud(t *testing.T) {
 		}`)
 	opID := suite.DecodeOperationID(resp)
 
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	// then
 	suite.WaitForOperationState(opID, domain.Succeeded)
@@ -184,7 +184,7 @@ func TestProvisioning_HappyPathSapConvergedCloudWithDefaultRegion(t *testing.T) 
 		}`)
 	opID := suite.DecodeOperationID(resp)
 
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	// then
 	suite.WaitForOperationState(opID, domain.Succeeded)
@@ -260,7 +260,7 @@ func TestProvisioning_NetworkingParametersForAWS(t *testing.T) {
 		}`)
 	opID := suite.DecodeOperationID(resp)
 
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 
 	suite.WaitForOperationState(opID, domain.Succeeded)
 }
@@ -349,7 +349,8 @@ func TestProvisioning_AzureWithEURestrictedAccessHappyFlow(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAzureRegion("switzerlandnorth")
@@ -384,7 +385,8 @@ func TestProvisioning_AzureWithEURestrictedAccessDefaultRegion(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAzureRegion("switzerlandnorth")
@@ -419,7 +421,8 @@ func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
@@ -455,7 +458,8 @@ func TestProvisioning_AWSWithEURestrictedAccessDefaultRegion(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
@@ -491,7 +495,8 @@ func TestProvisioning_TrialWithEmptyRegion(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-west-1")
@@ -527,7 +532,8 @@ func TestProvisioning_Conflict(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// when
 	resp = suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", iid),
@@ -645,7 +651,8 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertAWSRegionAndZone("eu-central-1")
@@ -736,7 +743,8 @@ func TestProvisioningWithReconciler_HappyPath(t *testing.T) {
 		}`)
 
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 	provisioningOp, _ := suite.db.Operations().GetProvisioningOperationByID(opID)
 	clusterID := provisioningOp.InstanceDetails.ServiceManagerClusterID
 
@@ -798,7 +806,8 @@ func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
 		}`)
 
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// then
 	suite.AssertProvider("aws")
@@ -1251,7 +1260,7 @@ func TestProvisioning_WithoutNetworkFilter(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 	instance := suite.GetInstance(iid)
 
 	// then
@@ -1286,7 +1295,7 @@ func TestProvisioning_WithNetworkFilter(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 	instance := suite.GetInstance(iid)
 
 	// then
@@ -1369,7 +1378,7 @@ func TestProvisioning_Modules(t *testing.T) {
 				}`)
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)
@@ -1410,7 +1419,7 @@ func TestProvisioning_Modules(t *testing.T) {
 				}`)
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)
@@ -1455,7 +1464,7 @@ func TestProvisioning_Modules(t *testing.T) {
 				}`)
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)
@@ -1489,7 +1498,7 @@ func TestProvisioning_Modules(t *testing.T) {
 				}`)
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)
@@ -1524,7 +1533,7 @@ func TestProvisioning_Modules(t *testing.T) {
 
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)
@@ -1558,7 +1567,7 @@ func TestProvisioning_Modules(t *testing.T) {
 
 		opID := suite.DecodeOperationID(resp)
 
-		suite.processProvisioningAndReconcilingByOperationID(opID)
+		suite.processProvisioningByOperationID(opID)
 
 		suite.WaitForOperationState(opID, domain.Succeeded)
 		op, err := suite.db.Operations().GetOperationByID(opID)

--- a/cmd/broker/upgrade_cluster_test.go
+++ b/cmd/broker/upgrade_cluster_test.go
@@ -40,7 +40,7 @@ func TestClusterUpgrade_UpgradeAfterUpdateWithNetworkPolicy(t *testing.T) {
 	}
 }`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// provide license_type

--- a/cmd/broker/upgrade_kyma_test.go
+++ b/cmd/broker/upgrade_kyma_test.go
@@ -43,7 +43,7 @@ func TestClusterUpgradeUsesUpdatedAutoscalerParams(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// perform an update with custom autoscaler params
@@ -153,7 +153,7 @@ func TestKymaUpgradeScheduledToFutureMaintenanceWindow(t *testing.T) {
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
-	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.processProvisioningByOperationID(opID)
 	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	nextWeek := time.Now().AddDate(0, 0, 7)

--- a/internal/reconciler/fake.go
+++ b/internal/reconciler/fake.go
@@ -1,11 +1,11 @@
 package reconciler
 
 import (
-    "fmt"
-    "sync"
-    "time"
+	"fmt"
+	"sync"
+	"time"
 
-    reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
+	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
 )
 
 /*
@@ -22,200 +22,200 @@ FakeClient is simulating API and db transactions in Reconciler Inventory
 calling ApplyClusterConfig method on already existing cluster results in adding a new ClusterConfig
 */
 type FakeClient struct {
-    mu                sync.Mutex
-    inventoryClusters map[string]*registeredCluster
-    deleted           map[string]struct{}
+	mu                sync.Mutex
+	inventoryClusters map[string]*registeredCluster
+	deleted           map[string]struct{}
 
-    expectedStatus *reconcilerApi.Status // expected status
+	expectedStatus *reconcilerApi.Status // expected status
 }
 
 type registeredCluster struct {
-    clusterConfigs map[int64]reconcilerApi.Cluster
-    clusterStates  map[int64]*reconcilerApi.HTTPClusterResponse
-    statusChanges  []*reconcilerApi.StatusChange
+	clusterConfigs map[int64]reconcilerApi.Cluster
+	clusterStates  map[int64]*reconcilerApi.HTTPClusterResponse
+	statusChanges  []*reconcilerApi.StatusChange
 
-    numberOfGetStatusCalls int
+	numberOfGetStatusCalls int
 }
 
 func NewFakeClient() *FakeClient {
-    s := reconcilerApi.StatusReady
-    return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}, expectedStatus: &s}
+	s := reconcilerApi.StatusReady
+	return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}, expectedStatus: &s}
 }
 
 func (c *FakeClient) PrepareReconcilerClusterStatus(expectedStatus reconcilerApi.Status) {
-    c.expectedStatus = &expectedStatus
+	c.expectedStatus = &expectedStatus
 }
 
 // POST /v1/clusters
 func (c *FakeClient) ApplyClusterConfig(cluster reconcilerApi.Cluster) (*reconcilerApi.HTTPClusterResponse, error) {
-    return c.addToInventory(cluster)
+	return c.addToInventory(cluster)
 }
 
 // DELETE /v1/clusters/{clusterName}
 func (c *FakeClient) DeleteCluster(clusterName string) error {
-    c.mu.Lock()
-    defer c.mu.Unlock()
-    _, exists := c.inventoryClusters[clusterName]
-    if !exists {
-        return nil
-    }
-    c.deleted[clusterName] = struct{}{}
-    return nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, exists := c.inventoryClusters[clusterName]
+	if !exists {
+		return nil
+	}
+	c.deleted[clusterName] = struct{}{}
+	return nil
 }
 
 // GET /v1/clusters/{clusterName}/configs/{configVersion}/status
 func (c *FakeClient) GetCluster(clusterName string, configVersion int64) (*reconcilerApi.HTTPClusterResponse, error) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    existingCluster, exists := c.inventoryClusters[clusterName]
-    if !exists {
-        msg := stringKeys(c.inventoryClusters)
-        return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster not found, name=%s (%s)", clusterName, msg)
-    }
-    existingCluster.numberOfGetStatusCalls = existingCluster.numberOfGetStatusCalls - 1
-    if existingCluster.numberOfGetStatusCalls <= 0 {
-        existingCluster.numberOfGetStatusCalls = 0
-    }
-    state, exists := existingCluster.clusterStates[configVersion]
-    if !exists {
-        msg := intKeys(existingCluster.clusterStates)
-        return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster state not found, version=%d (%s)", configVersion, msg)
-    }
-    if existingCluster.numberOfGetStatusCalls == 0 && c.expectedStatus != nil {
-        state.Status = *c.expectedStatus
-    }
-    return state, nil
+	existingCluster, exists := c.inventoryClusters[clusterName]
+	if !exists {
+		msg := stringKeys(c.inventoryClusters)
+		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster not found, name=%s (%s)", clusterName, msg)
+	}
+	existingCluster.numberOfGetStatusCalls = existingCluster.numberOfGetStatusCalls - 1
+	if existingCluster.numberOfGetStatusCalls <= 0 {
+		existingCluster.numberOfGetStatusCalls = 0
+	}
+	state, exists := existingCluster.clusterStates[configVersion]
+	if !exists {
+		msg := intKeys(existingCluster.clusterStates)
+		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster state not found, version=%d (%s)", configVersion, msg)
+	}
+	if existingCluster.numberOfGetStatusCalls == 0 && c.expectedStatus != nil {
+		state.Status = *c.expectedStatus
+	}
+	return state, nil
 }
 
 func intKeys(states map[int64]*reconcilerApi.HTTPClusterResponse) string {
-    result := ""
-    for k, _ := range states {
-        result = result + fmt.Sprintf("[%d] ", k)
-    }
-    return result
+	result := ""
+	for k, _ := range states {
+		result = result + fmt.Sprintf("[%d] ", k)
+	}
+	return result
 }
 
 func stringKeys(clusters map[string]*registeredCluster) string {
-    result := ""
-    for k, _ := range clusters {
-        result = result + ", " + k
-    }
-    return result
+	result := ""
+	for k, _ := range clusters {
+		result = result + ", " + k
+	}
+	return result
 }
 
 // GET v1/clusters/{clusterName}/status
 func (c *FakeClient) GetLatestCluster(clusterName string) (*reconcilerApi.HTTPClusterResponse, error) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    existingCluster, exists := c.inventoryClusters[clusterName]
-    if !exists {
-        return &reconcilerApi.HTTPClusterResponse{}, nil
-    }
-    latestConfigVersion := int64(len(existingCluster.clusterStates))
+	existingCluster, exists := c.inventoryClusters[clusterName]
+	if !exists {
+		return &reconcilerApi.HTTPClusterResponse{}, nil
+	}
+	latestConfigVersion := int64(len(existingCluster.clusterStates))
 
-    return existingCluster.clusterStates[latestConfigVersion], nil
+	return existingCluster.clusterStates[latestConfigVersion], nil
 }
 
 // GET v1/clusters/{clusterName}/statusChanges/{offset}
 // offset is parsed to time.Duration
 func (c *FakeClient) GetStatusChange(clusterName, offset string) ([]*reconcilerApi.StatusChange, error) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    existingCluster, exists := c.inventoryClusters[clusterName]
-    if !exists {
-        return []*reconcilerApi.StatusChange{}, nil
-    }
-    return existingCluster.statusChanges, nil
+	existingCluster, exists := c.inventoryClusters[clusterName]
+	if !exists {
+		return []*reconcilerApi.StatusChange{}, nil
+	}
+	return existingCluster.statusChanges, nil
 }
 
 func (c *FakeClient) addToInventory(cluster reconcilerApi.Cluster) (*reconcilerApi.HTTPClusterResponse, error) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    _, exists := c.inventoryClusters[cluster.RuntimeID]
+	_, exists := c.inventoryClusters[cluster.RuntimeID]
 
-    // initial creation call - cluster does not exist in db
-    if !exists {
-        c.inventoryClusters[cluster.RuntimeID] = &registeredCluster{
-            clusterConfigs: map[int64]reconcilerApi.Cluster{
-                1: cluster,
-            },
-            clusterStates: map[int64]*reconcilerApi.HTTPClusterResponse{
-                1: {
-                    Cluster:              cluster.RuntimeID,
-                    ClusterVersion:       1,
-                    ConfigurationVersion: 1,
-                    Status:               "reconcile_pending",
-                },
-            },
-            statusChanges: []*reconcilerApi.StatusChange{{
-                Status:   reconcilerApi.StatusReconcilePending,
-                Duration: int64(10 * time.Second),
-            }},
-            numberOfGetStatusCalls: 4,
-        }
+	// initial creation call - cluster does not exist in db
+	if !exists {
+		c.inventoryClusters[cluster.RuntimeID] = &registeredCluster{
+			clusterConfigs: map[int64]reconcilerApi.Cluster{
+				1: cluster,
+			},
+			clusterStates: map[int64]*reconcilerApi.HTTPClusterResponse{
+				1: {
+					Cluster:              cluster.RuntimeID,
+					ClusterVersion:       1,
+					ConfigurationVersion: 1,
+					Status:               "reconcile_pending",
+				},
+			},
+			statusChanges: []*reconcilerApi.StatusChange{{
+				Status:   reconcilerApi.StatusReconcilePending,
+				Duration: int64(10 * time.Second),
+			}},
+			numberOfGetStatusCalls: 4,
+		}
 
-        return c.inventoryClusters[cluster.RuntimeID].clusterStates[1], nil
-    }
-    // cluster exists in db - add new configuration version
-    latestConfigVersion := int64(len(c.inventoryClusters[cluster.RuntimeID].clusterStates)) + 1
-    c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion] = &reconcilerApi.HTTPClusterResponse{
-        Cluster:              cluster.RuntimeID,
-        ClusterVersion:       1,
-        ConfigurationVersion: latestConfigVersion,
-        Status:               "reconcile_pending",
-    }
-    c.inventoryClusters[cluster.RuntimeID].statusChanges = append(c.inventoryClusters[cluster.RuntimeID].statusChanges, &reconcilerApi.StatusChange{
-        Status:   reconcilerApi.StatusReconcilePending,
-        Duration: int64(10 * time.Second),
-    })
-    c.inventoryClusters[cluster.RuntimeID].clusterConfigs[latestConfigVersion] = cluster
+		return c.inventoryClusters[cluster.RuntimeID].clusterStates[1], nil
+	}
+	// cluster exists in db - add new configuration version
+	latestConfigVersion := int64(len(c.inventoryClusters[cluster.RuntimeID].clusterStates)) + 1
+	c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion] = &reconcilerApi.HTTPClusterResponse{
+		Cluster:              cluster.RuntimeID,
+		ClusterVersion:       1,
+		ConfigurationVersion: latestConfigVersion,
+		Status:               "reconcile_pending",
+	}
+	c.inventoryClusters[cluster.RuntimeID].statusChanges = append(c.inventoryClusters[cluster.RuntimeID].statusChanges, &reconcilerApi.StatusChange{
+		Status:   reconcilerApi.StatusReconcilePending,
+		Duration: int64(10 * time.Second),
+	})
+	c.inventoryClusters[cluster.RuntimeID].clusterConfigs[latestConfigVersion] = cluster
 
-    return c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion], nil
+	return c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion], nil
 }
 
 func (c *FakeClient) ChangeClusterState(clusterName string, clusterVersion int64, desiredState reconcilerApi.Status) {
-    c.mu.Lock()
-    defer c.mu.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-    c.inventoryClusters[clusterName].clusterStates[clusterVersion].Status = desiredState
-    c.inventoryClusters[clusterName].statusChanges = append(c.inventoryClusters[clusterName].statusChanges, &reconcilerApi.StatusChange{
-        Status:   desiredState,
-        Duration: int64(10 * time.Second),
-    })
+	c.inventoryClusters[clusterName].clusterStates[clusterVersion].Status = desiredState
+	c.inventoryClusters[clusterName].statusChanges = append(c.inventoryClusters[clusterName].statusChanges, &reconcilerApi.StatusChange{
+		Status:   desiredState,
+		Duration: int64(10 * time.Second),
+	})
 }
 
 func (c *FakeClient) LastClusterConfig(runtimeID string) (*reconcilerApi.Cluster, error) {
-    cluster, found := c.inventoryClusters[runtimeID]
-    if !found {
-        return nil, fmt.Errorf("cluster not found in clusters inventory")
-    }
-    return getLastClusterConfig(cluster)
+	cluster, found := c.inventoryClusters[runtimeID]
+	if !found {
+		return nil, fmt.Errorf("cluster not found in clusters inventory")
+	}
+	return getLastClusterConfig(cluster)
 }
 
 func (c *FakeClient) IsBeingDeleted(id string) bool {
-    c.mu.Lock()
-    defer c.mu.Unlock()
-    _, exists := c.deleted[id]
-    if exists {
-        return true
-    }
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, exists := c.deleted[id]
+	if exists {
+		return true
+	}
 
-    return false
+	return false
 }
 
 func (c *FakeClient) ClusterExists(id string) bool {
-    _, found := c.inventoryClusters[id]
-    return found
+	_, found := c.inventoryClusters[id]
+	return found
 }
 
 func getLastClusterConfig(cluster *registeredCluster) (*reconcilerApi.Cluster, error) {
-    clusterConfig, found := cluster.clusterConfigs[int64(len(cluster.clusterConfigs))]
-    if !found {
-        return nil, fmt.Errorf("cluster config not found in cluster configs inventory")
-    }
-    return &clusterConfig, nil
+	clusterConfig, found := cluster.clusterConfigs[int64(len(cluster.clusterConfigs))]
+	if !found {
+		return nil, fmt.Errorf("cluster config not found in cluster configs inventory")
+	}
+	return &clusterConfig, nil
 }

--- a/internal/reconciler/fake.go
+++ b/internal/reconciler/fake.go
@@ -25,16 +25,25 @@ type FakeClient struct {
 	mu                sync.Mutex
 	inventoryClusters map[string]*registeredCluster
 	deleted           map[string]struct{}
+
+	expectedStatus *reconcilerApi.Status // expected status
 }
 
 type registeredCluster struct {
 	clusterConfigs map[int64]reconcilerApi.Cluster
 	clusterStates  map[int64]*reconcilerApi.HTTPClusterResponse
 	statusChanges  []*reconcilerApi.StatusChange
+
+	numberOfGetStatusCalls int
 }
 
 func NewFakeClient() *FakeClient {
-	return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}}
+	s := reconcilerApi.StatusReady
+	return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}, expectedStatus: &s}
+}
+
+func (c *FakeClient) PrepareReconcilerClusterStatus(expectedStatus reconcilerApi.Status) {
+	c.expectedStatus = &expectedStatus
 }
 
 // POST /v1/clusters
@@ -61,13 +70,38 @@ func (c *FakeClient) GetCluster(clusterName string, configVersion int64) (*recon
 
 	existingCluster, exists := c.inventoryClusters[clusterName]
 	if !exists {
-		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("not found")
+		msg := stringKeys(c.inventoryClusters)
+		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster not found, name=%s (%s)", clusterName, msg)
+	}
+	existingCluster.numberOfGetStatusCalls = existingCluster.numberOfGetStatusCalls - 1
+	if existingCluster.numberOfGetStatusCalls <= 0 {
+		existingCluster.numberOfGetStatusCalls = 0
 	}
 	state, exists := existingCluster.clusterStates[configVersion]
 	if !exists {
-		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("not found")
+		msg := intKeys(existingCluster.clusterStates)
+		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster state not found, version=%d (%s)", configVersion, msg)
+	}
+	if existingCluster.numberOfGetStatusCalls == 0 && c.expectedStatus != nil {
+		state.Status = *c.expectedStatus
 	}
 	return state, nil
+}
+
+func intKeys(states map[int64]*reconcilerApi.HTTPClusterResponse) string {
+	result := ""
+	for k, _ := range states {
+		result = result + fmt.Sprintf("[%d] ", k)
+	}
+	return result
+}
+
+func stringKeys(clusters map[string]*registeredCluster) string {
+	result := ""
+	for k, _ := range clusters {
+		result = result + ", " + k
+	}
+	return result
 }
 
 // GET v1/clusters/{clusterName}/status
@@ -121,6 +155,7 @@ func (c *FakeClient) addToInventory(cluster reconcilerApi.Cluster) (*reconcilerA
 				Status:   reconcilerApi.StatusReconcilePending,
 				Duration: int64(10 * time.Second),
 			}},
+			numberOfGetStatusCalls: 4,
 		}
 
 		return c.inventoryClusters[cluster.RuntimeID].clusterStates[1], nil
@@ -138,6 +173,13 @@ func (c *FakeClient) addToInventory(cluster reconcilerApi.Cluster) (*reconcilerA
 		Duration: int64(10 * time.Second),
 	})
 	c.inventoryClusters[cluster.RuntimeID].clusterConfigs[latestConfigVersion] = cluster
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+	}()
 
 	return c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion], nil
 }

--- a/internal/reconciler/fake.go
+++ b/internal/reconciler/fake.go
@@ -90,8 +90,8 @@ func (c *FakeClient) GetCluster(clusterName string, configVersion int64) (*recon
 
 func intKeys(states map[int64]*reconcilerApi.HTTPClusterResponse) string {
 	result := ""
-	for k, _ := range states {
-		result = result + fmt.Sprintf("[%d] ", k)
+	for k, state := range states {
+		result = result + fmt.Sprintf("[%d:%s] ", k, state.Status)
 	}
 	return result
 }

--- a/internal/reconciler/fake.go
+++ b/internal/reconciler/fake.go
@@ -1,11 +1,11 @@
 package reconciler
 
 import (
-	"fmt"
-	"sync"
-	"time"
+    "fmt"
+    "sync"
+    "time"
 
-	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
+    reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
 )
 
 /*
@@ -22,207 +22,200 @@ FakeClient is simulating API and db transactions in Reconciler Inventory
 calling ApplyClusterConfig method on already existing cluster results in adding a new ClusterConfig
 */
 type FakeClient struct {
-	mu                sync.Mutex
-	inventoryClusters map[string]*registeredCluster
-	deleted           map[string]struct{}
+    mu                sync.Mutex
+    inventoryClusters map[string]*registeredCluster
+    deleted           map[string]struct{}
 
-	expectedStatus *reconcilerApi.Status // expected status
+    expectedStatus *reconcilerApi.Status // expected status
 }
 
 type registeredCluster struct {
-	clusterConfigs map[int64]reconcilerApi.Cluster
-	clusterStates  map[int64]*reconcilerApi.HTTPClusterResponse
-	statusChanges  []*reconcilerApi.StatusChange
+    clusterConfigs map[int64]reconcilerApi.Cluster
+    clusterStates  map[int64]*reconcilerApi.HTTPClusterResponse
+    statusChanges  []*reconcilerApi.StatusChange
 
-	numberOfGetStatusCalls int
+    numberOfGetStatusCalls int
 }
 
 func NewFakeClient() *FakeClient {
-	s := reconcilerApi.StatusReady
-	return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}, expectedStatus: &s}
+    s := reconcilerApi.StatusReady
+    return &FakeClient{inventoryClusters: map[string]*registeredCluster{}, deleted: map[string]struct{}{}, expectedStatus: &s}
 }
 
 func (c *FakeClient) PrepareReconcilerClusterStatus(expectedStatus reconcilerApi.Status) {
-	c.expectedStatus = &expectedStatus
+    c.expectedStatus = &expectedStatus
 }
 
 // POST /v1/clusters
 func (c *FakeClient) ApplyClusterConfig(cluster reconcilerApi.Cluster) (*reconcilerApi.HTTPClusterResponse, error) {
-	return c.addToInventory(cluster)
+    return c.addToInventory(cluster)
 }
 
 // DELETE /v1/clusters/{clusterName}
 func (c *FakeClient) DeleteCluster(clusterName string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	_, exists := c.inventoryClusters[clusterName]
-	if !exists {
-		return nil
-	}
-	c.deleted[clusterName] = struct{}{}
-	return nil
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    _, exists := c.inventoryClusters[clusterName]
+    if !exists {
+        return nil
+    }
+    c.deleted[clusterName] = struct{}{}
+    return nil
 }
 
 // GET /v1/clusters/{clusterName}/configs/{configVersion}/status
 func (c *FakeClient) GetCluster(clusterName string, configVersion int64) (*reconcilerApi.HTTPClusterResponse, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+    c.mu.Lock()
+    defer c.mu.Unlock()
 
-	existingCluster, exists := c.inventoryClusters[clusterName]
-	if !exists {
-		msg := stringKeys(c.inventoryClusters)
-		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster not found, name=%s (%s)", clusterName, msg)
-	}
-	existingCluster.numberOfGetStatusCalls = existingCluster.numberOfGetStatusCalls - 1
-	if existingCluster.numberOfGetStatusCalls <= 0 {
-		existingCluster.numberOfGetStatusCalls = 0
-	}
-	state, exists := existingCluster.clusterStates[configVersion]
-	if !exists {
-		msg := intKeys(existingCluster.clusterStates)
-		return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster state not found, version=%d (%s)", configVersion, msg)
-	}
-	if existingCluster.numberOfGetStatusCalls == 0 && c.expectedStatus != nil {
-		state.Status = *c.expectedStatus
-	}
-	return state, nil
+    existingCluster, exists := c.inventoryClusters[clusterName]
+    if !exists {
+        msg := stringKeys(c.inventoryClusters)
+        return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster not found, name=%s (%s)", clusterName, msg)
+    }
+    existingCluster.numberOfGetStatusCalls = existingCluster.numberOfGetStatusCalls - 1
+    if existingCluster.numberOfGetStatusCalls <= 0 {
+        existingCluster.numberOfGetStatusCalls = 0
+    }
+    state, exists := existingCluster.clusterStates[configVersion]
+    if !exists {
+        msg := intKeys(existingCluster.clusterStates)
+        return &reconcilerApi.HTTPClusterResponse{}, fmt.Errorf("cluster state not found, version=%d (%s)", configVersion, msg)
+    }
+    if existingCluster.numberOfGetStatusCalls == 0 && c.expectedStatus != nil {
+        state.Status = *c.expectedStatus
+    }
+    return state, nil
 }
 
 func intKeys(states map[int64]*reconcilerApi.HTTPClusterResponse) string {
-	result := ""
-	for k, _ := range states {
-		result = result + fmt.Sprintf("[%d] ", k)
-	}
-	return result
+    result := ""
+    for k, _ := range states {
+        result = result + fmt.Sprintf("[%d] ", k)
+    }
+    return result
 }
 
 func stringKeys(clusters map[string]*registeredCluster) string {
-	result := ""
-	for k, _ := range clusters {
-		result = result + ", " + k
-	}
-	return result
+    result := ""
+    for k, _ := range clusters {
+        result = result + ", " + k
+    }
+    return result
 }
 
 // GET v1/clusters/{clusterName}/status
 func (c *FakeClient) GetLatestCluster(clusterName string) (*reconcilerApi.HTTPClusterResponse, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+    c.mu.Lock()
+    defer c.mu.Unlock()
 
-	existingCluster, exists := c.inventoryClusters[clusterName]
-	if !exists {
-		return &reconcilerApi.HTTPClusterResponse{}, nil
-	}
-	latestConfigVersion := int64(len(existingCluster.clusterStates))
+    existingCluster, exists := c.inventoryClusters[clusterName]
+    if !exists {
+        return &reconcilerApi.HTTPClusterResponse{}, nil
+    }
+    latestConfigVersion := int64(len(existingCluster.clusterStates))
 
-	return existingCluster.clusterStates[latestConfigVersion], nil
+    return existingCluster.clusterStates[latestConfigVersion], nil
 }
 
 // GET v1/clusters/{clusterName}/statusChanges/{offset}
 // offset is parsed to time.Duration
 func (c *FakeClient) GetStatusChange(clusterName, offset string) ([]*reconcilerApi.StatusChange, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+    c.mu.Lock()
+    defer c.mu.Unlock()
 
-	existingCluster, exists := c.inventoryClusters[clusterName]
-	if !exists {
-		return []*reconcilerApi.StatusChange{}, nil
-	}
-	return existingCluster.statusChanges, nil
+    existingCluster, exists := c.inventoryClusters[clusterName]
+    if !exists {
+        return []*reconcilerApi.StatusChange{}, nil
+    }
+    return existingCluster.statusChanges, nil
 }
 
 func (c *FakeClient) addToInventory(cluster reconcilerApi.Cluster) (*reconcilerApi.HTTPClusterResponse, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+    c.mu.Lock()
+    defer c.mu.Unlock()
 
-	_, exists := c.inventoryClusters[cluster.RuntimeID]
+    _, exists := c.inventoryClusters[cluster.RuntimeID]
 
-	// initial creation call - cluster does not exist in db
-	if !exists {
-		c.inventoryClusters[cluster.RuntimeID] = &registeredCluster{
-			clusterConfigs: map[int64]reconcilerApi.Cluster{
-				1: cluster,
-			},
-			clusterStates: map[int64]*reconcilerApi.HTTPClusterResponse{
-				1: {
-					Cluster:              cluster.RuntimeID,
-					ClusterVersion:       1,
-					ConfigurationVersion: 1,
-					Status:               "reconcile_pending",
-				},
-			},
-			statusChanges: []*reconcilerApi.StatusChange{{
-				Status:   reconcilerApi.StatusReconcilePending,
-				Duration: int64(10 * time.Second),
-			}},
-			numberOfGetStatusCalls: 4,
-		}
+    // initial creation call - cluster does not exist in db
+    if !exists {
+        c.inventoryClusters[cluster.RuntimeID] = &registeredCluster{
+            clusterConfigs: map[int64]reconcilerApi.Cluster{
+                1: cluster,
+            },
+            clusterStates: map[int64]*reconcilerApi.HTTPClusterResponse{
+                1: {
+                    Cluster:              cluster.RuntimeID,
+                    ClusterVersion:       1,
+                    ConfigurationVersion: 1,
+                    Status:               "reconcile_pending",
+                },
+            },
+            statusChanges: []*reconcilerApi.StatusChange{{
+                Status:   reconcilerApi.StatusReconcilePending,
+                Duration: int64(10 * time.Second),
+            }},
+            numberOfGetStatusCalls: 4,
+        }
 
-		return c.inventoryClusters[cluster.RuntimeID].clusterStates[1], nil
-	}
-	// cluster exists in db - add new configuration version
-	latestConfigVersion := int64(len(c.inventoryClusters[cluster.RuntimeID].clusterStates)) + 1
-	c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion] = &reconcilerApi.HTTPClusterResponse{
-		Cluster:              cluster.RuntimeID,
-		ClusterVersion:       1,
-		ConfigurationVersion: latestConfigVersion,
-		Status:               "reconcile_pending",
-	}
-	c.inventoryClusters[cluster.RuntimeID].statusChanges = append(c.inventoryClusters[cluster.RuntimeID].statusChanges, &reconcilerApi.StatusChange{
-		Status:   reconcilerApi.StatusReconcilePending,
-		Duration: int64(10 * time.Second),
-	})
-	c.inventoryClusters[cluster.RuntimeID].clusterConfigs[latestConfigVersion] = cluster
+        return c.inventoryClusters[cluster.RuntimeID].clusterStates[1], nil
+    }
+    // cluster exists in db - add new configuration version
+    latestConfigVersion := int64(len(c.inventoryClusters[cluster.RuntimeID].clusterStates)) + 1
+    c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion] = &reconcilerApi.HTTPClusterResponse{
+        Cluster:              cluster.RuntimeID,
+        ClusterVersion:       1,
+        ConfigurationVersion: latestConfigVersion,
+        Status:               "reconcile_pending",
+    }
+    c.inventoryClusters[cluster.RuntimeID].statusChanges = append(c.inventoryClusters[cluster.RuntimeID].statusChanges, &reconcilerApi.StatusChange{
+        Status:   reconcilerApi.StatusReconcilePending,
+        Duration: int64(10 * time.Second),
+    })
+    c.inventoryClusters[cluster.RuntimeID].clusterConfigs[latestConfigVersion] = cluster
 
-	go func() {
-		time.Sleep(5 * time.Millisecond)
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
-	}()
-
-	return c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion], nil
+    return c.inventoryClusters[cluster.RuntimeID].clusterStates[latestConfigVersion], nil
 }
 
 func (c *FakeClient) ChangeClusterState(clusterName string, clusterVersion int64, desiredState reconcilerApi.Status) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+    c.mu.Lock()
+    defer c.mu.Unlock()
 
-	c.inventoryClusters[clusterName].clusterStates[clusterVersion].Status = desiredState
-	c.inventoryClusters[clusterName].statusChanges = append(c.inventoryClusters[clusterName].statusChanges, &reconcilerApi.StatusChange{
-		Status:   desiredState,
-		Duration: int64(10 * time.Second),
-	})
+    c.inventoryClusters[clusterName].clusterStates[clusterVersion].Status = desiredState
+    c.inventoryClusters[clusterName].statusChanges = append(c.inventoryClusters[clusterName].statusChanges, &reconcilerApi.StatusChange{
+        Status:   desiredState,
+        Duration: int64(10 * time.Second),
+    })
 }
 
 func (c *FakeClient) LastClusterConfig(runtimeID string) (*reconcilerApi.Cluster, error) {
-	cluster, found := c.inventoryClusters[runtimeID]
-	if !found {
-		return nil, fmt.Errorf("cluster not found in clusters inventory")
-	}
-	return getLastClusterConfig(cluster)
+    cluster, found := c.inventoryClusters[runtimeID]
+    if !found {
+        return nil, fmt.Errorf("cluster not found in clusters inventory")
+    }
+    return getLastClusterConfig(cluster)
 }
 
 func (c *FakeClient) IsBeingDeleted(id string) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	_, exists := c.deleted[id]
-	if exists {
-		return true
-	}
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    _, exists := c.deleted[id]
+    if exists {
+        return true
+    }
 
-	return false
+    return false
 }
 
 func (c *FakeClient) ClusterExists(id string) bool {
-	_, found := c.inventoryClusters[id]
-	return found
+    _, found := c.inventoryClusters[id]
+    return found
 }
 
 func getLastClusterConfig(cluster *registeredCluster) (*reconcilerApi.Cluster, error) {
-	clusterConfig, found := cluster.clusterConfigs[int64(len(cluster.clusterConfigs))]
-	if !found {
-		return nil, fmt.Errorf("cluster config not found in cluster configs inventory")
-	}
-	return &clusterConfig, nil
+    clusterConfig, found := cluster.clusterConfigs[int64(len(cluster.clusterConfigs))]
+    if !found {
+        return nil, fmt.Errorf("cluster config not found in cluster configs inventory")
+    }
+    return &clusterConfig, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- sometimes update tests were failing because after the update (PATCH) the reconciler fake client was guided to a response for the previous operation (which has finished) and the fresh reconciler operation was never ended.

The change was to program the fake client with a response before any interaction. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
