### PR TITLE
Make gardener kubeconfig optional in SKR test

### DIFF
--- a/testing/e2e/skr/gardener/client.js
+++ b/testing/e2e/skr/gardener/client.js
@@ -11,7 +11,7 @@ const {
 class GardenerConfig {
   static fromEnv() {
     return new GardenerConfig({
-      kubeconfigPath: getEnvOrThrow('GARDENER_KUBECONFIG'),
+      kubeconfigPath: process.env['GARDENER_KUBECONFIG'],
       // Exception is not necessary below - shootTemplate is not used in all tests
       shootTemplate: process.env['GARDENER_SHOOT_TEMPLATE'],
     });

--- a/testing/e2e/skr/gardener/client.js
+++ b/testing/e2e/skr/gardener/client.js
@@ -1,5 +1,5 @@
 const k8s = require('@kubernetes/client-node');
-const {fromBase64, getEnvOrThrow, debug, error} = require('../utils');
+const {fromBase64, debug, error} = require('../utils');
 
 const GARDENER_PROJECT = process.env.KCP_GARDENER_NAMESPACE || 'garden-kyma-dev';
 const COMPASS_ID_ANNOTATION_KEY = 'compass.provisioner.kyma-project.io/runtime-id';
@@ -36,11 +36,13 @@ class GardenerClient {
     config = config || {};
     const kc = new k8s.KubeConfig();
     if (config.kubeconfigPath) {
+      console.log('Using Gardener kubeconfig');
       kc.loadFromFile(config.kubeconfigPath);
     } else if (config.kubeconfig) {
+      console.log('Using Gardener kubeconfig');
       kc.loadFromString(config.kubeconfig);
     } else {
-      console.log('Unable to create GardenerClient - no kubeconfig provided');
+      console.log('Unable to create GardenerClient - no Gardener kubeconfig provided');
       return null;
     }
 

--- a/testing/e2e/skr/gardener/client.js
+++ b/testing/e2e/skr/gardener/client.js
@@ -40,7 +40,8 @@ class GardenerClient {
     } else if (config.kubeconfig) {
       kc.loadFromString(config.kubeconfig);
     } else {
-      throw new Error('Unable to create GardenerClient - no kubeconfig');
+      console.log('Unable to create GardenerClient - no kubeconfig provided');
+      return null;
     }
 
     this.coreV1API = kc.makeApiClient(k8s.CoreV1Api);

--- a/testing/e2e/skr/kcp/client.js
+++ b/testing/e2e/skr/kcp/client.js
@@ -99,6 +99,9 @@ class KCPWrapper {
     if (query.ops) {
       args = args.concat('--ops');
     }
+    if (query.clusterConfig) {
+      args = args.concat('--cluster-config');
+    }
     const result = await this.exec(args);
     return JSON.parse(result);
   }
@@ -187,6 +190,20 @@ class KCPWrapper {
     }
   };
 
+  async kubeconfig(shoot) {
+    let args = ['kubeconfig', '--shoot', `${shoot}`];
+    const result = await this.exec(args);
+    return result;
+  }
+
+  async getKubeconfig(shoot) {
+    await this.login();
+    const result = await this.kubeconfig(shoot);
+    let words = result.split(" ");
+    let kubeconfigPath = words[words.length - 1];
+    return kubeconfigPath;
+  }
+
   async getReconciliationsOperations(runtimeID) {
     await this.login();
     const reconciliationsOperations = await this.reconciliations({parameter: 'operations',
@@ -212,6 +229,13 @@ class KCPWrapper {
     const runtimeStatus = await this.runtimes({instanceID: instanceID, ops: true, state: 'all'});
 
     return JSON.stringify(runtimeStatus, null, '\t');
+  }
+
+  async getRuntimeClusterConfig(shoot) {
+    await this.login();
+    const clusterConfig = await this.runtimes({shoot: shoot, clusterConfig: true});
+
+    return JSON.stringify(clusterConfig, null, '\t');
   }
 
   async getOrchestrationsOperations(orchestrationID) {

--- a/testing/e2e/skr/kcp/client.js
+++ b/testing/e2e/skr/kcp/client.js
@@ -191,7 +191,7 @@ class KCPWrapper {
   };
 
   async kubeconfig(shoot) {
-    let args = ['kubeconfig', '--shoot', `${shoot}`];
+    const args = ['kubeconfig', '--shoot', `${shoot}`];
     const result = await this.exec(args);
     return result;
   }
@@ -199,8 +199,8 @@ class KCPWrapper {
   async getKubeconfig(shoot) {
     await this.login();
     const result = await this.kubeconfig(shoot);
-    let words = result.split(" ");
-    let kubeconfigPath = words[words.length - 1];
+    const words = result.split(' ');
+    const kubeconfigPath = words[words.length - 1];
     return kubeconfigPath;
   }
 

--- a/testing/e2e/skr/kyma-environment-broker/helpers.js
+++ b/testing/e2e/skr/kyma-environment-broker/helpers.js
@@ -32,7 +32,6 @@ async function provisionSKR(
   const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
   const objRuntimeStatus = JSON.parse(runtimeStatus);
   expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;
-  debug('Fetching shoot info using kcp cli...');
   let shoot
   if (process.env['GARDENER_KUBECONFIG']) {
     debug('Fetching shoot info from gardener...');

--- a/testing/e2e/skr/kyma-environment-broker/helpers.js
+++ b/testing/e2e/skr/kyma-environment-broker/helpers.js
@@ -32,7 +32,7 @@ async function provisionSKR(
   const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
   const objRuntimeStatus = JSON.parse(runtimeStatus);
   expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;
-  let shoot
+  let shoot;
   if (process.env['GARDENER_KUBECONFIG']) {
     debug('Fetching shoot info from gardener...');
     shoot = await gardener.getShoot(objRuntimeStatus.data[0].shootName);
@@ -52,7 +52,7 @@ async function getShoot(kcp, shootName) {
   debug(`Fetching shoot: ${shootName}`);
 
   const kubeconfigPath = await kcp.getKubeconfig(shootName);
-  
+
   const runtimeClusterConfig = await kcp.getRuntimeClusterConfig(shootName);
   const objRuntimeClusterConfig = JSON.parse(runtimeClusterConfig);
   expect(objRuntimeClusterConfig).to.have.nested.property('data[0].clusterConfig.oidcConfig').not.empty;
@@ -111,7 +111,7 @@ async function updateSKR(keb,
 
   await ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeout);
 
-  let shoot
+  let shoot;
 
   if (process.env['GARDENER_KUBECONFIG']) {
     shoot = await gardener.getShoot(shootName);

--- a/testing/e2e/skr/skr-test/helpers.js
+++ b/testing/e2e/skr/skr-test/helpers.js
@@ -7,7 +7,7 @@ const os = require('os');
 const {expect} = require('chai');
 
 const keb = new KEBClient(KEBConfig.fromEnv());
-const gardener = new GardenerClient(GardenerConfig.fromEnv());
+const gardener = null;
 const kcp = new KCPWrapper(KCPConfig.fromEnv());
 const testNS = 'skr-test';
 const DEBUG = process.env.DEBUG === 'true';
@@ -185,4 +185,5 @@ module.exports = {
   saveKubeconfig,
   log,
   initK8sConfig,
+  initializeK8sClient,
 };

--- a/testing/e2e/skr/skr-test/helpers.js
+++ b/testing/e2e/skr/skr-test/helpers.js
@@ -7,7 +7,7 @@ const os = require('os');
 const {expect} = require('chai');
 
 const keb = new KEBClient(KEBConfig.fromEnv());
-const gardener = null;
+const gardener = new GardenerClient(GardenerConfig.fromEnv());
 const kcp = new KCPWrapper(KCPConfig.fromEnv());
 const testNS = 'skr-test';
 const DEBUG = process.env.DEBUG === 'true';

--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -13,7 +13,7 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
     let updateMachineType = undefined;
     let defaultMachineType = undefined;
     const planID = getEnvOrThrow('KEB_PLAN_ID');
-    const gardener = null;
+    const gardener = new GardenerClient(GardenerConfig.fromEnv());
 
     before('Get provisioned Shoot Info', async function() {
       shoot = getShootInfoFunc();
@@ -100,7 +100,13 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
 }
 
 async function getMachineType(gardener, shoot) {
-  //await gardener.waitForShoot(shoot, 'Reconcile');
+  if (process.env['GARDENER_KUBECONFIG']) {
+    await gardener.waitForShoot(shoot, 'Reconcile');
+    const sh = await gardener.getShoot(shoot);
+    return sh.spec.provider.workers[0].machine.type;
+  }
+  
+  shoot = await getShoot(kcp, shootName);
   const sh = await getShoot(kcp, shoot);
   return sh.spec
 }

--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -105,10 +105,10 @@ async function getMachineType(gardener, shoot) {
     const sh = await gardener.getShoot(shoot);
     return sh.spec.provider.workers[0].machine.type;
   }
-  
+
   shoot = await getShoot(kcp, shootName);
   const sh = await getShoot(kcp, shoot);
-  return sh.spec
+  return sh.spec;
 }
 
 module.exports = {

--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -1,5 +1,5 @@
 const {expect} = require('chai');
-const {updateSKR, getCatalog} = require('../../kyma-environment-broker');
+const {updateSKR, getCatalog, getShoot} = require('../../kyma-environment-broker');
 const {keb, kcp} = require('../helpers');
 const {GardenerClient, GardenerConfig} = require('../../gardener');
 const {getEnvOrThrow} = require('../../utils');
@@ -13,7 +13,7 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
     let updateMachineType = undefined;
     let defaultMachineType = undefined;
     const planID = getEnvOrThrow('KEB_PLAN_ID');
-    const gardener = new GardenerClient(GardenerConfig.fromEnv());
+    const gardener = null;
 
     before('Get provisioned Shoot Info', async function() {
       shoot = getShootInfoFunc();
@@ -100,9 +100,9 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
 }
 
 async function getMachineType(gardener, shoot) {
-  await gardener.waitForShoot(shoot, 'Reconcile');
-  const sh = await gardener.getShoot(shoot);
-  return sh.spec.provider.workers[0].machine.type;
+  //await gardener.waitForShoot(shoot, 'Reconcile');
+  const sh = await getShoot(kcp, shoot);
+  return sh.spec
 }
 
 module.exports = {

--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -106,7 +106,6 @@ async function getMachineType(gardener, shoot) {
     return sh.spec.provider.workers[0].machine.type;
   }
 
-  shoot = await getShoot(kcp, shootName);
   const sh = await getShoot(kcp, shoot);
   return sh.spec;
 }

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -5,6 +5,7 @@ const {
   keb,
   initK8sConfig,
   getSKRRuntimeStatus,
+  initializeK8sClient,
 } = require('../helpers');
 
 const {provisionSKR}= require('../../kyma-environment-broker');
@@ -14,8 +15,8 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
   const shoot = await provisionSKRInstance(options, provisioningTimeout);
 
-  console.log('Initiating K8s config...');
-  await initK8sConfig(shoot);
+  console.log('Initiating K8s client...');
+  await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
   console.log('Initialization of K8s finished...');
 
   return {

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -15,9 +15,15 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
   const shoot = await provisionSKRInstance(options, provisioningTimeout);
 
-  console.log('Initiating K8s client...');
-  await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
-  console.log('Initialization of K8s finished...');
+  if (process.env['GARDENER_KUBECONFIG']) {
+    console.log('Initiating K8s config...');
+    await initK8sConfig(shoot);
+  } else {
+    console.log('Initiating K8s client...');
+    await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
+    console.log('Initialization of K8s finished...');
+  }
+
 
   return {
     options,

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -21,8 +21,9 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   } else {
     console.log('Initiating K8s client...');
     await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
-    console.log('Initialization of K8s finished...');
   }
+
+  console.log('Initialization of K8s finished...');
 
 
   return {

--- a/testing/e2e/skr/skr-test/test.js
+++ b/testing/e2e/skr/skr-test/test.js
@@ -34,7 +34,7 @@ describe('SKR test', function() {
   });
 
   // Run BTP Manager Secret tests
-  btpManagerSecretTest();
+  //btpManagerSecretTest();
 
   // Run OIDC tests
   oidcE2ETest(getShootOptionsFunc, getShootInfoFunc);
@@ -42,8 +42,8 @@ describe('SKR test', function() {
   // Run Machine Type tests
   machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
 
-  after('Cleanup the resources', async function() {
-    this.timeout(deprovisioningTimeout);
-    await deprovisionAndUnregisterSKR(options, deprovisioningTimeout, true);
-  });
+ // after('Cleanup the resources', async function() {
+ //   this.timeout(deprovisioningTimeout);
+ //   await deprovisionAndUnregisterSKR(options, deprovisioningTimeout, true);
+ // });
 });

--- a/testing/e2e/skr/skr-test/test.js
+++ b/testing/e2e/skr/skr-test/test.js
@@ -42,7 +42,7 @@ describe('SKR test', function() {
   // Run Machine Type tests
   machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
 
- after('Cleanup the resources', async function() {
+  after('Cleanup the resources', async function() {
     this.timeout(deprovisioningTimeout);
     await deprovisionAndUnregisterSKR(options, deprovisioningTimeout, true);
   });

--- a/testing/e2e/skr/skr-test/test.js
+++ b/testing/e2e/skr/skr-test/test.js
@@ -34,7 +34,7 @@ describe('SKR test', function() {
   });
 
   // Run BTP Manager Secret tests
-  //btpManagerSecretTest();
+  btpManagerSecretTest();
 
   // Run OIDC tests
   oidcE2ETest(getShootOptionsFunc, getShootInfoFunc);
@@ -42,8 +42,8 @@ describe('SKR test', function() {
   // Run Machine Type tests
   machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc);
 
- // after('Cleanup the resources', async function() {
- //   this.timeout(deprovisioningTimeout);
- //   await deprovisionAndUnregisterSKR(options, deprovisioningTimeout, true);
- // });
+ after('Cleanup the resources', async function() {
+    this.timeout(deprovisioningTimeout);
+    await deprovisionAndUnregisterSKR(options, deprovisioningTimeout, true);
+  });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

SKR test will first try to look for gardener kubeconfig, and if it is not found, it will use kcp cli to run the test.

Changes proposed in this pull request:

- Make Gardener kubeconfig optional
- Use kcp cli when Gardener kubeconfig is not provided

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #153 