### PR TITLE
Disable skr test assertions

### DIFF
--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -88,14 +88,14 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
       shoot = skr.shoot;
     });
 
-    it('Should check machine type after update', async function() {
+   /* it('Should check machine type after update', async function() {
       if (updateMachineType === undefined) {
         console.log('skipping machine type update');
         return;
       }
       const machineType = await getMachineType(gardener, shoot.name);
       expect(machineType).to.equal(updateMachineType);
-    });
+    });*/
   });
 }
 

--- a/testing/e2e/skr/skr-test/machine-type/index.js
+++ b/testing/e2e/skr/skr-test/machine-type/index.js
@@ -1,4 +1,4 @@
-const {expect} = require('chai');
+// const {expect} = require('chai');
 const {updateSKR, getCatalog, getShoot} = require('../../kyma-environment-broker');
 const {keb, kcp} = require('../helpers');
 const {GardenerClient, GardenerConfig} = require('../../gardener');
@@ -88,7 +88,7 @@ function machineTypeE2ETest(getShootOptionsFunc, getShootInfoFunc) {
       shoot = skr.shoot;
     });
 
-   /* it('Should check machine type after update', async function() {
+    /* it('Should check machine type after update', async function() {
       if (updateMachineType === undefined) {
         console.log('skipping machine type update');
         return;

--- a/testing/e2e/skr/skr-test/oidc/index.js
+++ b/testing/e2e/skr/skr-test/oidc/index.js
@@ -65,9 +65,9 @@ function oidcE2ETest(getShootOptionsFunc, getShootInfoFunc) {
       }
     });
 
-    it('Assure updated OIDC config is applied on shoot cluster', async function() {
+    /*it('Assure updated OIDC config is applied on shoot cluster', async function() {
       ensureValidShootOIDCConfig(shoot, options.oidc1);
-    });
+    });*/
 
     it('Assure updated OIDC config is part of kubeconfig', async function() {
       await ensureValidOIDCConfigInCustomerFacingKubeconfig(keb, options.instanceID, options.oidc1);

--- a/testing/e2e/skr/skr-test/oidc/index.js
+++ b/testing/e2e/skr/skr-test/oidc/index.js
@@ -65,7 +65,7 @@ function oidcE2ETest(getShootOptionsFunc, getShootInfoFunc) {
       }
     });
 
-    /*it('Assure updated OIDC config is applied on shoot cluster', async function() {
+    /* it('Assure updated OIDC config is applied on shoot cluster', async function() {
       ensureValidShootOIDCConfig(shoot, options.oidc1);
     });*/
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Disable assertions that false fail tests. To enable again we need to be able to get the actual cluster config without using Gardener kubeconfig.

Changes proposed in this pull request:


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #153 