### PR TITLE
Remove unused issuer from RequestAuthentication

### DIFF
--- a/resources/keb/templates/request-authentication.yaml
+++ b/resources/keb/templates/request-authentication.yaml
@@ -7,8 +7,6 @@ metadata:
     argocd.argoproj.io/sync-options: Prune=false
 spec:
   jwtRules:
-  - issuer: https://oauth2.{{ .Values.global.ingress.domainName }}/
-    jwksUri: https://oauth2.{{ .Values.global.ingress.domainName }}/.well-known/jwks.json
   - issuer: {{ tpl .Values.oidc.issuer $ }}
     jwksUri: {{ tpl .Values.oidc.keysURL $ }}
   selector:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

* Ory stack was removed from KCP, this endpoint does not exists anymore, and it generates errors in istio
