### PR TITLE
Add gardener_config parameter to /runtimes endpoint

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -426,7 +426,7 @@ func main() {
 	orchestrationHandler.AttachRoutes(router)
 
 	// create list runtimes endpoint
-	runtimeHandler := runtime.NewHandler(db.Instances(), db.Operations(), db.RuntimeStates(), cfg.MaxPaginationPage, cfg.DefaultRequestRegion)
+	runtimeHandler := runtime.NewHandler(db.Instances(), db.Operations(), db.RuntimeStates(), cfg.MaxPaginationPage, cfg.DefaultRequestRegion, provisionerClient)
 	runtimeHandler.AttachRoutes(router)
 
 	// create expiration endpoint

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -57,18 +57,19 @@ type RuntimeDTO struct {
 }
 
 type RuntimeStatus struct {
-	CreatedAt        time.Time       `json:"createdAt"`
-	ModifiedAt       time.Time       `json:"modifiedAt"`
-	ExpiredAt        *time.Time      `json:"expiredAt,omitempty"`
-	DeletedAt        *time.Time      `json:"deletedAt,omitempty"`
-	State            State           `json:"state"`
-	Provisioning     *Operation      `json:"provisioning,omitempty"`
-	Deprovisioning   *Operation      `json:"deprovisioning,omitempty"`
-	UpgradingKyma    *OperationsData `json:"upgradingKyma,omitempty"`
-	UpgradingCluster *OperationsData `json:"upgradingCluster,omitempty"`
-	Update           *OperationsData `json:"update,omitempty"`
-	Suspension       *OperationsData `json:"suspension,omitempty"`
-	Unsuspension     *OperationsData `json:"unsuspension,omitempty"`
+	CreatedAt        time.Time                 `json:"createdAt"`
+	ModifiedAt       time.Time                 `json:"modifiedAt"`
+	ExpiredAt        *time.Time                `json:"expiredAt,omitempty"`
+	DeletedAt        *time.Time                `json:"deletedAt,omitempty"`
+	State            State                     `json:"state"`
+	Provisioning     *Operation                `json:"provisioning,omitempty"`
+	Deprovisioning   *Operation                `json:"deprovisioning,omitempty"`
+	UpgradingKyma    *OperationsData           `json:"upgradingKyma,omitempty"`
+	UpgradingCluster *OperationsData           `json:"upgradingCluster,omitempty"`
+	Update           *OperationsData           `json:"update,omitempty"`
+	Suspension       *OperationsData           `json:"suspension,omitempty"`
+	Unsuspension     *OperationsData           `json:"unsuspension,omitempty"`
+	GardenerConfig   *gqlschema.GardenerConfig `json:"gardenerConfig,omitempty"`
 }
 
 type OperationType string

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -122,6 +122,7 @@ const (
 	KymaConfigParam      = "kyma_config"
 	ClusterConfigParam   = "cluster_config"
 	ExpiredParam         = "expired"
+	GardenerConfigParam  = "gardener_config"
 )
 
 type OperationDetail string

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -143,6 +143,8 @@ type ListParameters struct {
 	KymaConfig bool
 	// ClusterConfig specifies whether Gardener cluster configuration details should be included in the response for each runtime
 	ClusterConfig bool
+	// GardenerConfig specifies whether current Gardener cluster configuration details from provisioner should be included in the response for each runtime
+	GardenerConfig bool
 	// GlobalAccountIDs parameter filters runtimes by specified global account IDs
 	GlobalAccountIDs []string
 	// SubAccountIDs parameter filters runtimes by specified subaccount IDs

--- a/internal/provisioner/fake_client.go
+++ b/internal/provisioner/fake_client.go
@@ -210,9 +210,10 @@ func (c *FakeClient) RuntimeStatus(accountID, runtimeID string) (schema.RuntimeS
 			return schema.RuntimeStatus{
 				RuntimeConfiguration: &schema.RuntimeConfig{
 					ClusterConfig: &schema.GardenerConfig{
-						Name:   ptr.String("fake-name"),
-						Region: ptr.String("fake-region"),
-						Seed:   ptr.String("fake-seed"),
+						Name:     ptr.String("fake-name"),
+						Region:   ptr.String("fake-region"),
+						Seed:     ptr.String("fake-seed"),
+						Provider: ptr.String("aws"),
 					},
 					Kubeconfig: ptr.String("kubeconfig-content"),
 				},

--- a/internal/runtime/handler_test.go
+++ b/internal/runtime/handler_test.go
@@ -715,7 +715,8 @@ func TestRuntimeHandler(t *testing.T) {
 		input, err := operation.InputCreator.CreateProvisionRuntimeInput()
 		require.NoError(t, err)
 
-		provisionerClient.ProvisionRuntimeWithIDs(operation.GlobalAccountID, operation.SubAccountID, operation.RuntimeID, operation.ID, input)
+		_, err = provisionerClient.ProvisionRuntimeWithIDs(operation.GlobalAccountID, operation.SubAccountID, operation.RuntimeID, operation.ID, input)
+		require.NoError(t, err)
 
 		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 

--- a/internal/runtime/handler_test.go
+++ b/internal/runtime/handler_test.go
@@ -13,6 +13,7 @@ import (
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/driver/memory"
@@ -26,6 +27,7 @@ import (
 func TestRuntimeHandler(t *testing.T) {
 	t.Run("test pagination should work", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -49,7 +51,7 @@ func TestRuntimeHandler(t *testing.T) {
 		err = instances.Insert(testInstance2)
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		req, err := http.NewRequest("GET", "/runtimes?page_size=1", nil)
 		require.NoError(t, err)
@@ -96,11 +98,12 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("test validation should work", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "region")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "region", provisionerClient)
 
 		req, err := http.NewRequest("GET", "/runtimes?page_size=a", nil)
 		require.NoError(t, err)
@@ -132,6 +135,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("test filtering should work", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -155,7 +159,7 @@ func TestRuntimeHandler(t *testing.T) {
 		err = operations.InsertOperation(testOp2)
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		req, err := http.NewRequest("GET", fmt.Sprintf("/runtimes?account=%s&subaccount=%s&instance_id=%s&runtime_id=%s&region=%s&shoot=%s", testID1, testID1, testID1, testID1, testID1, fmt.Sprintf("Shoot-%s", testID1)), nil)
 		require.NoError(t, err)
@@ -182,6 +186,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("test state filtering should work", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -228,7 +233,7 @@ func TestRuntimeHandler(t *testing.T) {
 		err = operations.InsertDeprovisioningOperation(deprovOp3)
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()
@@ -285,6 +290,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("should show suspension and unsuspension operations", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -334,7 +340,7 @@ func TestRuntimeHandler(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		req, err := http.NewRequest("GET", "/runtimes", nil)
 		require.NoError(t, err)
@@ -369,6 +375,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("should distinguish between provisioning & unsuspension operations", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -404,7 +411,7 @@ func TestRuntimeHandler(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		req, err := http.NewRequest("GET", "/runtimes", nil)
 		require.NoError(t, err)
@@ -436,6 +443,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("should distinguish between deprovisioning & suspension operations", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -473,7 +481,7 @@ func TestRuntimeHandler(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		req, err := http.NewRequest("GET", "/runtimes", nil)
 		require.NoError(t, err)
@@ -506,6 +514,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("test operation detail parameter and runtime state", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -525,7 +534,7 @@ func TestRuntimeHandler(t *testing.T) {
 		err = operations.InsertUpgradeKymaOperation(upgOp)
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()
@@ -577,6 +586,7 @@ func TestRuntimeHandler(t *testing.T) {
 
 	t.Run("test kyma_config and cluster_config optional attributes", func(t *testing.T) {
 		// given
+		provisionerClient := provisioner.NewFakeClient()
 		operations := memory.NewOperation()
 		instances := memory.NewInstance(operations)
 		states := memory.NewRuntimeStates()
@@ -656,7 +666,7 @@ func TestRuntimeHandler(t *testing.T) {
 		err = states.Insert(fixOpgClusterState)
 		require.NoError(t, err)
 
-		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "")
+		runtimeHandler := runtime.NewHandler(instances, operations, states, 2, "", provisionerClient)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()

--- a/resources/keb/files/swagger.yaml
+++ b/resources/keb/files/swagger.yaml
@@ -288,6 +288,12 @@ paths:
             items:
               type: string
         - in: query
+          name: gardener_config
+          required: false
+          description: Get Gardener cluster config
+          schema:
+            type: boolean
+        - in: query
           name: state
           required: false
           description: Filter by Runtime state. By default, if no state(s) are provided, suspended Runtimes are filtered out.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The `/runtimes` endpoint can't return the current gardener cluster config if it has been changed since provisioning. The new `gardener_config` parameter allows KEB to ask Provisioner what the current config is.

Changes proposed in this pull request:

- Add `gardener_config` parameter to `/runtimes` endpoint

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
