### PR TITLE
Bump cloudsql-proxy image to v1.33.16-133356bc

### DIFF
--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -3,7 +3,7 @@ global:
   ingress:
     domainName: localhost
   images:
-    cloudsql_proxy_image: "europe-docker.pkg.dev/kyma-project/prod/tpi/cloudsql-docker/gce-proxy:v1.33.8-afb993b8"
+    cloudsql_proxy_image: "europe-docker.pkg.dev/kyma-project/prod/tpi/cloudsql-docker/gce-proxy:v1.33.16-133356bc"
     container_registry:
       path: europe-docker.pkg.dev/kyma-project/prod
     schema_migrator:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump cloudsql-proxy image to v1.33.16-133356bc to address security vulnerabilities

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
