### PR TITLE
Add gardener_config param to query

### DIFF
--- a/common/runtime/client.go
+++ b/common/runtime/client.go
@@ -109,6 +109,9 @@ func setQuery(url *url.URL, params ListParameters) {
 	if params.ClusterConfig {
 		query.Add(ClusterConfigParam, "true")
 	}
+	if params.GardenerConfig {
+		query.Add(GardenerConfigParam, "true")
+	}
 	if params.Expired {
 		query.Add(ExpiredParam, "true")
 	}

--- a/common/runtime/client_test.go
+++ b/common/runtime/client_test.go
@@ -41,6 +41,7 @@ func TestClient_ListRuntimes(t *testing.T) {
 			OperationDetail:  LastOperation,
 			KymaConfig:       true,
 			ClusterConfig:    true,
+			GardenerConfig:   true,
 			GlobalAccountIDs: []string{"sa1", "ga2"},
 			SubAccountIDs:    []string{"sa1", "sa2"},
 			InstanceIDs:      []string{"id1", "id2"},
@@ -61,6 +62,7 @@ func TestClient_ListRuntimes(t *testing.T) {
 			assert.ElementsMatch(t, []string{string(LastOperation)}, query[OperationDetailParam])
 			assert.ElementsMatch(t, []string{"true"}, query[KymaConfigParam])
 			assert.ElementsMatch(t, []string{"true"}, query[ClusterConfigParam])
+			assert.ElementsMatch(t, []string{"true"}, query[GardenerConfigParam])
 			assert.ElementsMatch(t, params.GlobalAccountIDs, query[GlobalAccountIDParam])
 			assert.ElementsMatch(t, params.SubAccountIDs, query[SubAccountIDParam])
 			assert.ElementsMatch(t, params.InstanceIDs, query[InstanceIDParam])


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The `gardener_config` param added in #378 was not set in the query when using the client to interact with the `/runtimes` endpoint. This caused kcp cli to be unable to use the param. This PR fixes that.

Changes proposed in this pull request:


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
