### PR TITLE
Fix Gardener cluster name and kyma name cleanup in the deprovisioning…

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -198,24 +198,24 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 		avsDel, internalEvalAssistant, externalEvalCreator, runtimeVerConfigurator, runtimeOverrides,
 		edpClient, accountProvider, reconcilerClient, k8sClientProvider, cli, logs)
 
-	provisioningQueue.SpeedUp(100)
-	provisionManager.SpeedUp(100)
+	provisioningQueue.SpeedUp(10000)
+	provisionManager.SpeedUp(10000)
 
 	updateManager := process.NewStagedManager(db.Operations(), eventBroker, time.Hour, cfg.Update, logs)
 	rvc := runtimeversion.NewRuntimeVersionConfigurator(cfg.KymaVersion, nil, db.RuntimeStates())
 	updateQueue := NewUpdateProcessingQueue(context.Background(), updateManager, 1, db, inputFactory, provisionerClient,
 		eventBroker, rvc, db.RuntimeStates(), componentProvider, reconcilerClient, *cfg, k8sClientProvider, cli, logs)
-	updateQueue.SpeedUp(100)
-	updateManager.SpeedUp(100)
+	updateQueue.SpeedUp(10000)
+	updateManager.SpeedUp(10000)
 
 	deprovisionManager := process.NewStagedManager(db.Operations(), eventBroker, time.Hour, cfg.Deprovisioning, logs.WithField("deprovisioning", "manager"))
 	deprovisioningQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, cfg, db, eventBroker,
 		provisionerClient, avsDel, internalEvalAssistant, externalEvalAssistant,
 		bundleBuilder, edpClient, accountProvider, reconcilerClient, k8sClientProvider, cli, configProvider, logs,
 	)
-	deprovisionManager.SpeedUp(100)
+	deprovisionManager.SpeedUp(10000)
 
-	deprovisioningQueue.SpeedUp(100)
+	deprovisioningQueue.SpeedUp(10000)
 
 	ts := &BrokerSuiteTest{
 		db:                  db,

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -198,24 +198,24 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 		avsDel, internalEvalAssistant, externalEvalCreator, runtimeVerConfigurator, runtimeOverrides,
 		edpClient, accountProvider, reconcilerClient, k8sClientProvider, cli, logs)
 
-	provisioningQueue.SpeedUp(10000)
-	provisionManager.SpeedUp(10000)
+	provisioningQueue.SpeedUp(100)
+	provisionManager.SpeedUp(100)
 
 	updateManager := process.NewStagedManager(db.Operations(), eventBroker, time.Hour, cfg.Update, logs)
 	rvc := runtimeversion.NewRuntimeVersionConfigurator(cfg.KymaVersion, nil, db.RuntimeStates())
 	updateQueue := NewUpdateProcessingQueue(context.Background(), updateManager, 1, db, inputFactory, provisionerClient,
 		eventBroker, rvc, db.RuntimeStates(), componentProvider, reconcilerClient, *cfg, k8sClientProvider, cli, logs)
-	updateQueue.SpeedUp(10000)
-	updateManager.SpeedUp(10000)
+	updateQueue.SpeedUp(100)
+	updateManager.SpeedUp(100)
 
 	deprovisionManager := process.NewStagedManager(db.Operations(), eventBroker, time.Hour, cfg.Deprovisioning, logs.WithField("deprovisioning", "manager"))
 	deprovisioningQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, cfg, db, eventBroker,
 		provisionerClient, avsDel, internalEvalAssistant, externalEvalAssistant,
 		bundleBuilder, edpClient, accountProvider, reconcilerClient, k8sClientProvider, cli, configProvider, logs,
 	)
-	deprovisionManager.SpeedUp(10000)
+	deprovisionManager.SpeedUp(100)
 
-	deprovisioningQueue.SpeedUp(10000)
+	deprovisioningQueue.SpeedUp(100)
 
 	ts := &BrokerSuiteTest{
 		db:                  db,

--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -49,7 +49,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 		},
 		{
 			disabled: cfg.LifecycleManagerIntegrationDisabled,
-			step:     deprovisioning.NewDeleteKymaResourceStep(db.Operations(), cli, configProvider, cfg.KymaVersion),
+			step:     deprovisioning.NewDeleteKymaResourceStep(db.Operations(), db.Instances(), cli, configProvider, cfg.KymaVersion),
 		},
 		{
 			disabled: cfg.LifecycleManagerIntegrationDisabled,
@@ -64,7 +64,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 			step:     deprovisioning.NewCheckClusterDeregistrationStep(db.Operations(), reconcilerClient, 90*time.Minute),
 		},
 		{
-			step: deprovisioning.NewDeleteGardenerClusterStep(db.Operations(), cli),
+			step: deprovisioning.NewDeleteGardenerClusterStep(db.Operations(), cli, db.Instances()),
 		},
 		{
 			step: deprovisioning.NewCheckGardenerClusterDeletedStep(db.Operations(), cli),

--- a/internal/process/deprovisioning/check_gardenercluster_deleted_step.go
+++ b/internal/process/deprovisioning/check_gardenercluster_deleted_step.go
@@ -74,7 +74,7 @@ func (step *CheckGardenerClusterDeletedStep) Run(operation internal.Operation, l
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check GardenerCluster resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
 	}
 
-	return step.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-		operation.GardenerClusterName = ""
+	return step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+		op.GardenerClusterName = ""
 	}, logger)
 }

--- a/internal/process/deprovisioning/check_gardenercluster_deleted_step.go
+++ b/internal/process/deprovisioning/check_gardenercluster_deleted_step.go
@@ -74,5 +74,7 @@ func (step *CheckGardenerClusterDeletedStep) Run(operation internal.Operation, l
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check GardenerCluster resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
 	}
 
-	return operation, 0, nil
+	return step.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
+		operation.GardenerClusterName = ""
+	}, logger)
 }

--- a/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
+++ b/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
@@ -68,7 +68,7 @@ func (step *CheckKymaResourceDeletedStep) Run(operation internal.Operation, logg
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
 	}
 
-	return step.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-		operation.KymaResourceName = ""
+	return step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+		op.KymaResourceName = ""
 	}, logger)
 }

--- a/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
+++ b/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
@@ -68,5 +68,7 @@ func (step *CheckKymaResourceDeletedStep) Run(operation internal.Operation, logg
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
 	}
 
-	return operation, 0, nil
+	return step.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
+		operation.KymaResourceName = ""
+	}, logger)
 }

--- a/internal/process/deprovisioning/delete_gardener_cluster.go
+++ b/internal/process/deprovisioning/delete_gardener_cluster.go
@@ -50,10 +50,18 @@ func (step *DeleteGardenerClusterStep) Run(operation internal.Operation, logger 
 		logger.Infof("Using instance.RuntimeID")
 		instance, err := step.instances.GetByID(operation.InstanceID)
 		if err != nil {
-			logger.Errorf("Unable to get instance")
-			return step.operationManager.RetryOperation(operation, err.Error(), err, 15*time.Second, 2*time.Minute, logger)
+			logger.Errorf("Unable to get instance: %s", err.Error())
+			return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to get instance", 15*time.Second, 2*time.Minute, logger)
 		}
 		resourceName = steps.GardenerClusterNameFromInstance(instance)
+
+		// save the gardener cluster resource name to use for checking step
+		operation, backoff, _ := step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+			op.GardenerClusterName = resourceName
+		}, logger)
+		if backoff > 0 {
+			return operation, backoff, nil
+		}
 	}
 
 	if resourceName == "" {

--- a/internal/process/deprovisioning/delete_gardener_cluster.go
+++ b/internal/process/deprovisioning/delete_gardener_cluster.go
@@ -56,7 +56,8 @@ func (step *DeleteGardenerClusterStep) Run(operation internal.Operation, logger 
 		resourceName = steps.GardenerClusterNameFromInstance(instance)
 
 		// save the gardener cluster resource name to use for checking step
-		operation, backoff, _ := step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+		backoff := time.Duration(0)
+		operation, backoff, _ = step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
 			op.GardenerClusterName = resourceName
 		}, logger)
 		if backoff > 0 {

--- a/internal/process/deprovisioning/delete_gardener_cluster.go
+++ b/internal/process/deprovisioning/delete_gardener_cluster.go
@@ -20,12 +20,14 @@ import (
 type DeleteGardenerClusterStep struct {
 	operationManager *process.OperationManager
 	kcpClient        client.Client
+	instances        storage.Instances
 }
 
-func NewDeleteGardenerClusterStep(operations storage.Operations, kcpClient client.Client) *DeleteGardenerClusterStep {
+func NewDeleteGardenerClusterStep(operations storage.Operations, kcpClient client.Client, instances storage.Instances) *DeleteGardenerClusterStep {
 	return &DeleteGardenerClusterStep{
 		operationManager: process.NewOperationManager(operations),
 		kcpClient:        kcpClient,
+		instances:        instances,
 	}
 }
 
@@ -45,7 +47,17 @@ func (step *DeleteGardenerClusterStep) Run(operation internal.Operation, logger 
 		resourceName = steps.GardenerClusterName(&operation)
 	}
 	if resourceName == "" {
-		logger.Infof("Runtime ID is empty, skipping")
+		logger.Infof("Using instance.RuntimeID")
+		instance, err := step.instances.GetByID(operation.InstanceID)
+		if err != nil {
+			logger.Errorf("Unable to get instance")
+			return step.operationManager.RetryOperation(operation, err.Error(), err, 15*time.Second, 2*time.Minute, logger)
+		}
+		resourceName = steps.GardenerClusterNameFromInstance(instance)
+	}
+
+	if resourceName == "" {
+		logger.Info("Gardener cluster not known, skipping")
 		return operation, 0, nil
 	}
 

--- a/internal/process/deprovisioning/delete_gardenercluster_step_test.go
+++ b/internal/process/deprovisioning/delete_gardenercluster_step_test.go
@@ -27,7 +27,7 @@ func TestDeleteGardenerClusterResource_HappyFlowNoObject(t *testing.T) {
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	step := NewDeleteGardenerClusterStep(memoryStorage.Operations(), kcpClient)
+	step := NewDeleteGardenerClusterStep(memoryStorage.Operations(), kcpClient, memoryStorage.Instances())
 	memoryStorage.Operations().InsertOperation(operation)
 
 	// When
@@ -57,7 +57,7 @@ func TestDeleteGardenerClusterResource_HappyFlow(t *testing.T) {
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	step := NewDeleteGardenerClusterStep(memoryStorage.Operations(), kcpClient)
+	step := NewDeleteGardenerClusterStep(memoryStorage.Operations(), kcpClient, memoryStorage.Instances())
 	memoryStorage.Operations().InsertOperation(operation)
 
 	// When

--- a/internal/process/deprovisioning/delete_kyma_resource_step.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step.go
@@ -82,7 +82,8 @@ func (step *DeleteKymaResourceStep) Run(operation internal.Operation, logger log
 		}
 		kymaResourceName = steps.KymaNameFromInstance(instance)
 		// save the kyma resource name if it was taken from the instance.runtimeID
-		operation, backoff, _ := step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+		backoff := time.Duration(0)
+		operation, backoff, _ = step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
 			op.KymaResourceNamespace = kymaResourceName
 		}, logger)
 		if backoff > 0 {

--- a/internal/process/deprovisioning/delete_kyma_resource_step.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step.go
@@ -73,7 +73,7 @@ func (step *DeleteKymaResourceStep) Run(operation internal.Operation, logger log
 	}
 	kymaResourceName := steps.KymaName(operation)
 	if kymaResourceName == "" {
-		logger.Infof("Kyma resource name is empty, using isntance.RuntimeID")
+		logger.Infof("Kyma resource name is empty, using instance.RuntimeID")
 
 		instance, err := step.instances.GetByID(operation.InstanceID)
 		if err != nil {

--- a/internal/process/deprovisioning/delete_kyma_resource_step_test.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step_test.go
@@ -1,6 +1,7 @@
 package deprovisioning
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -35,7 +36,7 @@ func TestDeleteKymaResource_HappyFlow(t *testing.T) {
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	step := NewDeleteKymaResourceStep(memoryStorage.Operations(), kcpClient, fakeConfigProvider{}, "2.0")
+	step := NewDeleteKymaResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), kcpClient, fakeConfigProvider{}, "2.0")
 	memoryStorage.Operations().InsertOperation(operation)
 
 	// When
@@ -51,14 +52,17 @@ func TestDeleteKymaResource_EmptyRuntimeIDAndKymaResourceName(t *testing.T) {
 	operation.KymaResourceNamespace = "kyma-system"
 	operation.RuntimeID = ""
 	operation.KymaResourceName = ""
+	instance := fixture.FixInstance(fixInstanceID)
 
 	kcpClient := fake.NewClientBuilder().Build()
 	memoryStorage := storage.NewMemoryStorage()
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	step := NewDeleteKymaResourceStep(memoryStorage.Operations(), kcpClient, fakeConfigProvider{}, "2.0")
+	step := NewDeleteKymaResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), kcpClient, fakeConfigProvider{}, "2.0")
 	memoryStorage.Operations().InsertOperation(operation)
+	err = memoryStorage.Instances().Insert(instance)
+	require.NoError(t, err)
 
 	// When
 	_, backoff, err := step.Run(operation, logger.NewLogSpy().Logger)

--- a/internal/process/deprovisioning/delete_kyma_resource_step_test.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step_test.go
@@ -1,7 +1,6 @@
 package deprovisioning
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -10,6 +9,7 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/logger"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/internal/process/deprovisioning/remove_instance_step.go
+++ b/internal/process/deprovisioning/remove_instance_step.go
@@ -57,8 +57,6 @@ func (s *RemoveInstanceStep) Run(operation internal.Operation, log logrus.FieldL
 		log.Info("Removing the RuntimeID field from the operation")
 		operation, backoff, _ = s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
 			operation.RuntimeID = ""
-			operation.GardenerClusterName = ""
-			operation.KymaResourceName = ""
 		}, log)
 	} else if operation.ExcutedButNotCompleted != nil {
 		log.Info("Marking the instance needs to retry some steps")

--- a/internal/process/steps/gardener_cluster.go
+++ b/internal/process/steps/gardener_cluster.go
@@ -161,6 +161,10 @@ func GardenerClusterName(operation *internal.Operation) string {
 	return strings.ToLower(operation.RuntimeID)
 }
 
+func GardenerClusterNameFromInstance(instance *internal.Instance) string {
+	return strings.ToLower(instance.RuntimeID)
+}
+
 type GardenerCluster struct {
 	obj *unstructured.Unstructured
 }

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -54,6 +54,10 @@ func KymaName(operation internal.Operation) string {
 	return strings.ToLower(operation.RuntimeID)
 }
 
+func KymaNameFromInstance(instance *internal.Instance) string {
+	return strings.ToLower(instance.RuntimeID)
+}
+
 func isKymaResourceInternal(operation internal.Operation) bool {
 	return !*operation.ProvisioningParameters.ErsContext.DisableEnterprisePolicyFilter()
 }


### PR DESCRIPTION
… process

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
The Bug is if the delete gardener cluster resource fails, the name of the resource will be cleaned so it will never 

Changes proposed in this pull request:
- GardenerClusterName and KymaResourceName are cleaned if it was really removed

Because of orphaned resources (GardenerCluster and Kyma) - the cleaning steps takes runtime ID from the instance and use it if the saved resource name is empty.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
