### PR TITLE
Fix btpoperatorcleanup step 

### DIFF
--- a/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -93,6 +93,7 @@ func (s *BTPOperatorCleanupStep) Run(operation internal.Operation, log logrus.Fi
 			log.Info("Kubeconfig does not exists, skipping")
 			return operation, 0, nil
 		}
+		log.Warnf("Error: %+v", err)
 
 		return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), fmt.Sprintf("failed to get kube client: %s", err.Error()), time.Second, 30*time.Second, log)
 	}

--- a/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -93,7 +93,8 @@ func (s *BTPOperatorCleanupStep) Run(operation internal.Operation, log logrus.Fi
 			log.Info("Kubeconfig does not exists, skipping")
 			return operation, 0, nil
 		}
-		return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), "failed to get kube client", time.Second, 30*time.Second, log)
+
+		return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), fmt.Sprintf("failed to get kube client: %s", err.Error()), time.Second, 30*time.Second, log)
 	}
 	if operation.UserAgent == broker.AccountCleanupJob {
 		log.Info("executing soft delete cleanup for accountcleanup-job")

--- a/internal/process/deprovisioning/btp_operator_cleanup_test.go
+++ b/internal/process/deprovisioning/btp_operator_cleanup_test.go
@@ -260,6 +260,8 @@ func TestBTPOperatorCleanupStep_SoftDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
+		op.Temporary = true
+		op.ProvisioningParameters.PlanID = broker.TrialPlanID
 		op.UserAgent = broker.AccountCleanupJob
 		op.State = "in progress"
 		step := NewBTPOperatorCleanupStep(ms.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sCli))
@@ -301,6 +303,8 @@ func TestBTPOperatorCleanupStep_SoftDelete(t *testing.T) {
 		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
 		op.UserAgent = broker.AccountCleanupJob
 		op.State = "in progress"
+		op.Temporary = true
+		op.ProvisioningParameters.PlanID = broker.TrialPlanID
 		step := NewBTPOperatorCleanupStep(ms.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sCli))
 
 		// when

--- a/internal/process/provisioning/apply_kyma_step.go
+++ b/internal/process/provisioning/apply_kyma_step.go
@@ -97,6 +97,8 @@ func (a *ApplyKymaStep) addLabelsAndName(operation internal.Operation, obj *unst
 		obj.SetAnnotations(annotations)
 	}
 
+	// Kyma resource name must be created once again
+	operation.KymaResourceName = ""
 	obj.SetName(steps.KymaName(operation))
 	return !reflect.DeepEqual(obj.GetLabels(), oldLabels)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- do not take kube client in btp operator cleanup if not needed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
