### PR TITLE
Fix TestUpdateDeprovisioningInstance

### DIFF
--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -205,8 +205,6 @@ func TestUpdateDeprovisioningInstance(t *testing.T) {
 	errResponse := suite.DecodeErrorResponse(resp)
 
 	assert.Equal(t, "Unable to process an update of a deprovisioned instance", errResponse.Description)
-
-	suite.AssertKymaResourceNotExists(opID)
 }
 
 func TestUpdateWithNoOIDCParams(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- the test TestUpdateDeprovisioningInstance must check the returned status of an update when the instance is being deprovisioned. The test must not check if Kyma resource was deleted because there we are not sure if the deprovisioning succeeded.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
