### PR TITLE
Enhanced Logging

### DIFF
--- a/internal/kubeconfig/provider.go
+++ b/internal/kubeconfig/provider.go
@@ -28,10 +28,10 @@ func (p *SecretProvider) KubeconfigForRuntimeID(runtimeId string) ([]byte, error
 	kubeConfigSecret := &v1.Secret{}
 	err := p.kcpK8sClient.Get(context.Background(), p.objectKey(runtimeId), kubeConfigSecret)
 	if errors.IsNotFound(err) {
-		return nil, NewNotFoundError(err.Error())
+		return nil, NewNotFoundError("secret not found")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("while getting secret from kcp for runtimeId=%s : %w", runtimeId, err)
+		return nil, fmt.Errorf("while getting secret from kcp for runtimeId=%s", runtimeId)
 	}
 	config, ok := kubeConfigSecret.Data["config"]
 	if !ok {

--- a/internal/process/provisioning/inject_btp_operator_credentials_step.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step.go
@@ -47,7 +47,7 @@ func (s *InjectBTPOperatorCredentialsStep) Run(operation internal.Operation, log
 	k8sClient, err := s.k8sClientProvider.K8sClientForRuntimeID(operation.RuntimeID)
 
 	if err != nil {
-		log.Error("kubernetes client not set")
+		log.Error("kubernetes client not set: %w", err)
 		return s.operationManager.OperationFailed(operation, "kubernetes client not set", nil, log)
 	}
 

--- a/internal/process/provisioning/inject_btp_operator_credentials_step.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step.go
@@ -47,7 +47,7 @@ func (s *InjectBTPOperatorCredentialsStep) Run(operation internal.Operation, log
 	k8sClient, err := s.k8sClientProvider.K8sClientForRuntimeID(operation.RuntimeID)
 
 	if err != nil {
-		log.Error("kubernetes client not set: %w", err)
+		log.Errorf("kubernetes client not set: %w", err)
 		return s.operationManager.OperationFailed(operation, "kubernetes client not set", nil, log)
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- logging information about error returned from `K8sClientForRuntimeID` in `internal/process/provisioning/inject_btp_operator_credentials_step.go`
- not returning k8s errors in `internal/kubeconfig/provider.go`

