### PR TITLE
temporary metric handler changes

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/metricsv2"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 )
 
 func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGetter, instanceStatsGetter InstancesStatsGetter) {
@@ -31,6 +32,17 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.OperationStepProcessed{}, opDurationCollector.OnOperationStepProcessed)
 
 	// test of metrics for upcoming new implementation
-	sub.Subscribe(process.ProvisioningSucceeded{}, metricsv2.Handler)
-	sub.Subscribe(process.OperationStepProcessed{}, metricsv2.Handler)
+	metricsv2err := prometheus.Register(metricsv2.ProvisionedInstancesCounter)
+	if metricsv2err != nil {
+		logrus.Errorf("Error while registering ProvisionedInstancesCounter: %s", metricsv2err.Error())
+	} else {
+		sub.Subscribe(process.ProvisioningSucceeded{}, metricsv2.Handler)
+	}
+
+	metricsv2err = prometheus.Register(metricsv2.OperationsCounter)
+	if metricsv2err != nil {
+		logrus.Errorf("Error while registering OperationsCounter: %s", metricsv2err.Error())
+	} else {
+		sub.Subscribe(process.OperationStepProcessed{}, metricsv2.Handler)
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,7 +5,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/metricsv2"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGetter, instanceStatsGetter InstancesStatsGetter) {
@@ -32,17 +31,5 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.OperationStepProcessed{}, opDurationCollector.OnOperationStepProcessed)
 
 	// test of metrics for upcoming new implementation
-	metricsv2err := prometheus.Register(metricsv2.ProvisionedInstancesCounter)
-	if metricsv2err != nil {
-		logrus.Errorf("Error while registering ProvisionedInstancesCounter: %s", metricsv2err.Error())
-	} else {
-		sub.Subscribe(process.ProvisioningSucceeded{}, metricsv2.Handler)
-	}
-
-	metricsv2err = prometheus.Register(metricsv2.OperationsCounter)
-	if metricsv2err != nil {
-		logrus.Errorf("Error while registering OperationsCounter: %s", metricsv2err.Error())
-	} else {
-		sub.Subscribe(process.OperationStepProcessed{}, metricsv2.Handler)
-	}
+	metricsv2.Register(sub)
 }

--- a/internal/metricsv2/metricsv2.go
+++ b/internal/metricsv2/metricsv2.go
@@ -1,5 +1,7 @@
 package metricsv2
 
+// test package for exposing real metrics and analyze on plutono to further develop
+
 import (
 	"context"
 	"sync"

--- a/internal/metricsv2/metricsv2.go
+++ b/internal/metricsv2/metricsv2.go
@@ -2,6 +2,7 @@ package metricsv2
 
 import (
 	"context"
+	"sync"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,15 +22,19 @@ var (
 		Name:      "operations_total_counter",
 		Help:      "Results of operations (total count)",
 	}, []string{"type", "state"})
+	mutex = sync.Mutex{}
 )
 
 // dont fail anything since it is just test function which is used for gathering informations before development
 func Handler(ctx context.Context, ev interface{}) error {
+	logrus.Info("metricsv2 test handler called")
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Errorf("recovered in test metrics: %v", r)
 		}
 	}()
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	switch data := ev.(type) {
 	case process.ProvisioningSucceeded:

--- a/internal/metricsv2/metricsv2.go
+++ b/internal/metricsv2/metricsv2.go
@@ -6,19 +6,20 @@ import (
 	"context"
 	"sync"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/event"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
 var (
-	ProvisionedInstancesCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	provisionedInstancesCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "keb",
 		Subsystem: "test",
 		Name:      "provisioned_counter",
 		Help:      "counter of successfully provisioned instances",
 	})
-	OperationsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	operationsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "keb",
 		Subsystem: "test",
 		Name:      "operations_total_counter",
@@ -26,6 +27,22 @@ var (
 	}, []string{"type", "state"})
 	mutex = sync.Mutex{}
 )
+
+func Register(sub event.Subscriber) {
+	metricsv2err := prometheus.Register(provisionedInstancesCounter)
+	if metricsv2err != nil {
+		logrus.Errorf("Error while registering ProvisionedInstancesCounter: %s", metricsv2err.Error())
+	} else {
+		sub.Subscribe(process.ProvisioningSucceeded{}, Handler)
+	}
+
+	metricsv2err = prometheus.Register(operationsCounter)
+	if metricsv2err != nil {
+		logrus.Errorf("Error while registering OperationsCounter: %s", metricsv2err.Error())
+	} else {
+		sub.Subscribe(process.OperationStepProcessed{}, Handler)
+	}
+}
 
 // dont fail anything since it is just test function which is used for gathering informations before development
 func Handler(ctx context.Context, ev interface{}) error {
@@ -41,10 +58,10 @@ func Handler(ctx context.Context, ev interface{}) error {
 	switch data := ev.(type) {
 	case process.ProvisioningSucceeded:
 		// keb_test_provisioned_counter X
-		ProvisionedInstancesCounter.Inc()
+		provisionedInstancesCounter.Inc()
 	case process.OperationStepProcessed:
 		// keb_test_result_operations_total_counter{type="provision", state="in progress"} X
-		OperationsCounter.WithLabelValues(string(data.Operation.Type), string(data.Operation.State)).Inc()
+		operationsCounter.WithLabelValues(string(data.Operation.Type), string(data.Operation.State)).Inc()
 	default:
 		logrus.Error("ev type not supported")
 	}

--- a/internal/metricsv2/metricsv2.go
+++ b/internal/metricsv2/metricsv2.go
@@ -12,13 +12,13 @@ import (
 )
 
 var (
-	provisionedInstancesCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	ProvisionedInstancesCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "keb",
 		Subsystem: "test",
 		Name:      "provisioned_counter",
 		Help:      "counter of successfully provisioned instances",
 	})
-	operationsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	OperationsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "keb",
 		Subsystem: "test",
 		Name:      "operations_total_counter",
@@ -41,10 +41,10 @@ func Handler(ctx context.Context, ev interface{}) error {
 	switch data := ev.(type) {
 	case process.ProvisioningSucceeded:
 		// keb_test_provisioned_counter X
-		provisionedInstancesCounter.Inc()
+		ProvisionedInstancesCounter.Inc()
 	case process.OperationStepProcessed:
 		// keb_test_result_operations_total_counter{type="provision", state="in progress"} X
-		operationsCounter.WithLabelValues(string(data.Operation.Type), string(data.Operation.State)).Inc()
+		OperationsCounter.WithLabelValues(string(data.Operation.Type), string(data.Operation.State)).Inc()
 	default:
 		logrus.Error("ev type not supported")
 	}

--- a/internal/metricsv2/metricsv2.go
+++ b/internal/metricsv2/metricsv2.go
@@ -1,6 +1,7 @@
 package metricsv2
 
 // test package for exposing real metrics and analyze on plutono to further develop
+// dont fail anything since it is just test function which is used for gathering informations before development
 
 import (
 	"context"
@@ -25,7 +26,7 @@ var (
 		Name:      "operations_total_counter",
 		Help:      "Results of operations (total count)",
 	}, []string{"type", "state"})
-	mutex = sync.Mutex{}
+	handlerMutex = sync.Mutex{}
 )
 
 func Register(sub event.Subscriber) {
@@ -44,7 +45,6 @@ func Register(sub event.Subscriber) {
 	}
 }
 
-// dont fail anything since it is just test function which is used for gathering informations before development
 func Handler(ctx context.Context, ev interface{}) error {
 	logrus.Info("metricsv2 test handler called")
 	defer func() {
@@ -52,8 +52,8 @@ func Handler(ctx context.Context, ev interface{}) error {
 			logrus.Errorf("recovered in test metrics: %v", r)
 		}
 	}()
-	mutex.Lock()
-	defer mutex.Unlock()
+	handlerMutex.Lock()
+	defer handlerMutex.Unlock()
 
 	switch data := ev.(type) {
 	case process.ProvisioningSucceeded:


### PR DESCRIPTION
- add mutex to temporary metric handler to prevent from override metrics from different events
- register metrics in prom