### PR TITLE
PostgreSQL container is not removed after test failure

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -120,6 +120,11 @@ type componentProviderDecorated struct {
 }
 
 func (s *BrokerSuiteTest) TearDown() {
+	if r := recover(); r != nil {
+		err := cleanupContainer()
+		assert.NoError(s.t, err)
+		panic(r)
+	}
 	s.httpServer.Close()
 	if s.storageCleanup != nil {
 		err := s.storageCleanup()
@@ -138,6 +143,13 @@ func NewBrokerSuiteTestWithOptionalRegion(t *testing.T, version ...string) *Brok
 }
 
 func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) *BrokerSuiteTest {
+	defer func() {
+		if r := recover(); r != nil {
+			err := cleanupContainer()
+			assert.NoError(t, err)
+			panic(r)
+		}
+	}()
 	ctx := context.Background()
 	sch := internal.NewSchemeForTests(t)
 	err := apiextensionsv1.AddToScheme(sch)

--- a/cmd/broker/deprovisioning_suite_test.go
+++ b/cmd/broker/deprovisioning_suite_test.go
@@ -50,7 +50,22 @@ type DeprovisioningSuite struct {
 	t *testing.T
 }
 
+func (s *DeprovisioningSuite) TearDown() {
+	if r := recover(); r != nil {
+		err := cleanupContainer()
+		assert.NoError(s.t, err)
+		panic(r)
+	}
+}
+
 func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
+	defer func() {
+		if r := recover(); r != nil {
+			err := cleanupContainer()
+			assert.NoError(t, err)
+			panic(r)
+		}
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 
 	logs := logrus.New()

--- a/cmd/broker/deprovisioning_test.go
+++ b/cmd/broker/deprovisioning_test.go
@@ -28,6 +28,7 @@ func TestKymaReDeprovisionFailed(t *testing.T) {
 	}
 
 	suite := NewDeprovisioningSuite(t)
+	defer suite.TearDown()
 	instanceId := suite.CreateProvisionedRuntime(runtimeOptions)
 	// when
 	deprovisioningOperationID := suite.CreateDeprovisioning(deprovisioningOpID, instanceId)

--- a/cmd/broker/orchestration_test.go
+++ b/cmd/broker/orchestration_test.go
@@ -11,6 +11,7 @@ func TestKymaUpgrade_OneRuntimeHappyPath(t *testing.T) {
 	// given
 
 	suite := NewOrchestrationSuite(t, nil)
+	defer suite.TearDown()
 	runtimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	otherRuntimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	orchestrationParams := fixOrchestrationParams(runtimeID)
@@ -32,6 +33,7 @@ func TestKymaUpgrade_VersionParameter(t *testing.T) {
 	// given
 	givenVersion := "2.0.0-rc5"
 	suite := NewOrchestrationSuite(t, []string{givenVersion})
+	defer suite.TearDown()
 	runtimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	otherRuntimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	orchestrationParams := fixOrchestrationParams(runtimeID)
@@ -53,6 +55,7 @@ func TestKymaUpgrade_VersionParameter(t *testing.T) {
 func TestClusterUpgrade_OneRuntimeHappyPath(t *testing.T) {
 	// given
 	suite := NewOrchestrationSuite(t, nil)
+	defer suite.TearDown()
 	runtimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	otherRuntimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	orchestrationParams := fixOrchestrationParams(runtimeID)

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -76,6 +76,7 @@ func TestCatalog(t *testing.T) {
 func TestProvisioning_HappyPath(t *testing.T) {
 	// given
 	suite := NewProvisioningSuite(t, false, "", false)
+	defer suite.TearDown()
 
 	// when
 	provisioningOperationID := suite.CreateProvisioning(RuntimeOptions{})
@@ -997,6 +998,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			// given
 			suite := NewProvisioningSuite(t, tc.multiZone, tc.controlPlaneFailureTolerance, tc.includeNewMachineTypes)
+			defer suite.TearDown()
 
 			// when
 			provisioningOperationID := suite.CreateProvisioning(RuntimeOptions{
@@ -1035,6 +1037,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 	t.Run("should apply default OIDC values when OIDC object is nil", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		defaultOIDC := fixture.FixOIDCConfigDTO()
 		expectedOIDC := gqlschema.OIDCConfigInput{
 			ClientID:       defaultOIDC.ClientID,
@@ -1065,6 +1068,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 	t.Run("should apply default OIDC values when all OIDC object's fields are empty", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		defaultOIDC := fixture.FixOIDCConfigDTO()
 		expectedOIDC := gqlschema.OIDCConfigInput{
 			ClientID:       defaultOIDC.ClientID,
@@ -1098,6 +1102,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 	t.Run("should apply provided OIDC configuration", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		providedOIDC := internal.OIDCConfigDTO{
 			ClientID:       "fake-client-id-1",
 			GroupsClaim:    "fakeGroups",
@@ -1136,6 +1141,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 	t.Run("should apply default OIDC values on empty OIDC params from input", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		providedOIDC := internal.OIDCConfigDTO{
 			ClientID:  "fake-client-id-1",
 			IssuerURL: "https://testurl.local",
@@ -1173,6 +1179,7 @@ func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 	t.Run("should use UserID as default value for admins list", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID: "fake-user-id",
 		}
@@ -1198,6 +1205,7 @@ func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 	t.Run("should apply new admins list", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID:        "fake-user-id",
 			RuntimeAdmins: []string{"admin1@test.com", "admin2@test.com"},
@@ -1224,6 +1232,7 @@ func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 	t.Run("should apply empty admin value (list is not empty)", func(t *testing.T) {
 		// given
 		suite := NewProvisioningSuite(t, false, "", false)
+		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID:        "fake-user-id",
 			RuntimeAdmins: []string{""},

--- a/cmd/broker/storage_test.go
+++ b/cmd/broker/storage_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 )
 
+var cleanupContainer func() error
+
 func brokerStorageE2ETestConfig() storage.Config {
 	return storage.Config{
 		Host:            "localhost",
@@ -47,7 +49,7 @@ func TestMain(m *testing.M) {
 			}
 		}(docker)
 
-		cleanupContainer, err := docker.CreateDBContainer(internal.ContainerCreateRequest{
+		cleanupContainer, err = docker.CreateDBContainer(internal.ContainerCreateRequest{
 			Port:          config.Port,
 			User:          config.User,
 			Password:      config.Password,

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -97,7 +97,22 @@ type OrchestrationSuite struct {
 	t *testing.T
 }
 
+func (s *OrchestrationSuite) TearDown() {
+	if r := recover(); r != nil {
+		err := cleanupContainer()
+		assert.NoError(s.t, err)
+		panic(r)
+	}
+}
+
 func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *OrchestrationSuite {
+	defer func() {
+		if r := recover(); r != nil {
+			err := cleanupContainer()
+			assert.NoError(t, err)
+			panic(r)
+		}
+	}()
 	logs := logrus.New()
 	logs.Formatter.(*logrus.TextFormatter).TimestampFormat = "15:04:05.000"
 
@@ -592,7 +607,22 @@ type ProvisioningSuite struct {
 	k8sKcpCli        client.Client
 }
 
+func (s *ProvisioningSuite) TearDown() {
+	if r := recover(); r != nil {
+		err := cleanupContainer()
+		assert.NoError(s.t, err)
+		panic(r)
+	}
+}
+
 func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailureTolerance string, includeNewMachineTypes bool) *ProvisioningSuite {
+	defer func() {
+		if r := recover(); r != nil {
+			err := cleanupContainer()
+			assert.NoError(t, err)
+			panic(r)
+		}
+	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	logs := logrus.New()
 	storageCleanup, db, err := GetStorageForE2ETests()

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -683,9 +683,9 @@ func TestUpdateWithOwnClusterPlan(t *testing.T) {
 func TestUpdateOidcForSuspendedInstance(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
 	// uncomment to see graphql queries
 	//suite.EnableDumpingProvisionerRequests()
-	defer suite.TearDown()
 	iid := uuid.New().String()
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
@@ -797,9 +797,9 @@ func TestUpdateOidcForSuspendedInstance(t *testing.T) {
 func TestUpdateOidcForPreview(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
 	// uncomment to see graphql queries
 	//suite.EnableDumpingProvisionerRequests()
-	defer suite.TearDown()
 	iid := uuid.New().String()
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
@@ -1918,9 +1918,9 @@ func TestUpdateAutoscalerPartialSequence(t *testing.T) {
 func TestUpdateWhenBothErsContextAndUpdateParametersProvided(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
 	// uncomment to see graphql queries
 	//suite.EnableDumpingProvisionerRequests()
-	defer suite.TearDown()
 	iid := uuid.New().String()
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
@@ -1989,8 +1989,8 @@ func TestUpdateWhenBothErsContextAndUpdateParametersProvided(t *testing.T) {
 func TestUpdateMachineType(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	id := "InstanceID-machineType"
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", id), `
@@ -2049,8 +2049,8 @@ func TestUpdateMachineType(t *testing.T) {
 func TestUpdateBTPOperatorCredsSuccess(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	id := "InstanceID-BTPOperator"
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", id), `
@@ -2249,8 +2249,8 @@ func TestUpdateNetworkFilterPersisted(t *testing.T) {
 func TestUpdateStoreNetworkFilterAndUpdate(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t, "2.0")
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	id := uuid.New().String()
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", id),
@@ -2320,8 +2320,8 @@ func TestUpdateStoreNetworkFilterAndUpdate(t *testing.T) {
 func TestMultipleUpdateNetworkFilterPersisted(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t, "2.0")
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	id := uuid.New().String()
 
 	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", id),

--- a/cmd/broker/upgrade_cluster_test.go
+++ b/cmd/broker/upgrade_cluster_test.go
@@ -13,8 +13,8 @@ import (
 func TestClusterUpgrade_UpgradeAfterUpdateWithNetworkPolicy(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	id := "InstanceID-UpgradeAfterUpdate"
 
 	// provision Kyma 2.0

--- a/cmd/broker/upgrade_kyma_test.go
+++ b/cmd/broker/upgrade_kyma_test.go
@@ -128,8 +128,8 @@ func TestClusterUpgradeUsesUpdatedAutoscalerParams(t *testing.T) {
 func TestKymaUpgradeScheduledToFutureMaintenanceWindow(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
+	mockBTPOperatorClusterID()
 	iid := uuid.New().String()
 
 	// Create an SKR with a default autoscaler params


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove `keb-e2e-tests` container in case of panic.

**Related issue(s)**
Resolves #560