### PR TITLE
Set Logrus Time Format to Nano Seconds

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -242,7 +242,9 @@ func main() {
 	logger.Info("Starting Kyma Environment Broker")
 
 	logs := logrus.New()
-	logs.SetFormatter(&logrus.JSONFormatter{})
+	logs.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	})
 	if cfg.LogLevel != "" {
 		l, _ := logrus.ParseLevel(cfg.LogLevel)
 		logs.SetLevel(l)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Logs in Kyma Environment are create with a timestamp rounder to two decimal places. Because most logs are happening within same seconds, such implementation makes it difficult to sort log entries in accordance to their invocation time. The following pr introduces timestamps rounded to nanoseconds - see examples of ".." log before and after the change taken from Logs Explorer:

Before:
```
{
...
  "timestamp": "2024-03-28T09:38:48Z",
  "severity": "INFO",
  "labels": {
     ...
    "k8s-pod/app_kubernetes_io/name": "kyma-environment-broker",
     ...
  },
  "receiveTimestamp": "2024-03-28T09:38:53.831710505Z"
}
```

After: 
```
{
   ...
  "timestamp": "2024-03-28T10:20:50.040432168Z",
  "severity": "INFO",
  "labels": {
     ...
    "k8s-pod/app_kubernetes_io/name": "kyma-environment-broker-ww",
     ...
  },
  ...
  "receiveTimestamp": "2024-03-28T10:20:52.939032767Z"
}
```

Changes proposed in this pull request:

- Setting logrus format to `time.RFC3339Nano`,
- Logrus info log that informs about starting KEB.

