### PR TITLE
Added Missing `DATABASE_EMBEDDED` Env

### DIFF
--- a/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
+++ b/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
@@ -32,7 +32,7 @@ spec:
               imagePullPolicy: IfNotPresent
               env:
                 - name: DATABASE_EMBEDDED
-                  value: false
+                  value: "false"
                 - name: APP_MAX_AGE_HOURS
                   value: 24h
                 - name: APP_GARDENER_PROJECT

--- a/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
+++ b/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
@@ -31,6 +31,8 @@ spec:
               image: europe-docker.pkg.dev/kyma-project/prod/kyma-environments-cleanup-job:1.3.1
               imagePullPolicy: IfNotPresent
               env:
+                - name: DATABASE_EMBEDDED
+                  value: false
                 - name: APP_MAX_AGE_HOURS
                   value: 24h
                 - name: APP_GARDENER_PROJECT


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Kyma Environments Cleanup Job implemented halting cloudsql proxy based on environment variable called `DATABASE_EMBEDDED`. Without this env [`halt.go`](https://github.com/kyma-project/control-plane/blob/e2054a2272b70f5782ba3ffe419c40c4aa263af3/components/schema-migrator/cleaner/halt.go#L13) does not stop proxy container, which makes it impossible for a job to complete.

Changes proposed in this pull request:

- Added missing `DATABASE_EMBEDDED` variable.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
