### PR TITLE
Added Missing Upgrade Metrics

### DIFF
--- a/internal/metricsv2/operations_stats.go
+++ b/internal/metricsv2/operations_stats.go
@@ -170,7 +170,7 @@ func (s *OperationStats) Job(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			if err := s.updateMetrics(); err != nil {
-				s.logger.Error("failed to update operation stats metrics", err)
+				s.logger.Error("failed to update operation stats metrics: ", err)
 			}
 		case <-ctx.Done():
 			return
@@ -240,7 +240,7 @@ func (s *OperationStats) makeKey(opType internal.OperationType, opState domain.L
 	fmtState := formatOpState(opState)
 	fmtType := formatOpType(opType)
 	if fmtType == "" || fmtState == "" || plan == "" {
-		return "", fmt.Errorf("cannot build key for operation: type: %s, state: %s with planID: %s", opType, opState, plan)
+		return "", fmt.Errorf("cannot build key for operation: type - '%s', state - '%s' with planID - '%s'", opType, opState, plan)
 	}
 	return metricKey(fmt.Sprintf("%s_%s_%s", fmtType, fmtState, plan)), nil
 }
@@ -251,6 +251,10 @@ func formatOpType(opType internal.OperationType) string {
 		return string(opType + "ing")
 	case internal.OperationTypeUpdate:
 		return "updating"
+	case internal.OperationTypeUpgradeCluster:
+		return "upgrading_cluster"
+	case internal.OperationTypeUpgradeKyma:
+		return "upgrading_kyma"
 	default:
 		return ""
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We receive lots of following errors: `failed to update operation stats metricscannot build key for operation: type: upgradeKyma, state: in progress with planID: 4deee563-e5ec-4731-b9b1-53b42d855f0c`. The error suggests that either we are handling correct operation type in [operations_stats.go](https://github.com/kyma-project/kyma-environment-broker/blob/e5ea56e67ee7d2e89359c53c7c3fa269db7ef74b/internal/metricsv2/operations_stats.go#L248) or we are not ignoring operation types that error refers to. A solution from the PR assumes the former.

Changes proposed in this pull request:

- added missing operation types to `formatOpType` method,
- removed `:` from log message as it is conventionally used in our code as a separator between log appends from different invocation levels.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
