### PR TITLE
Timeout for k8s operations

### DIFF
--- a/internal/kymacustomresource/kyma_cr_updater_test.go
+++ b/internal/kymacustomresource/kyma_cr_updater_test.go
@@ -61,7 +61,7 @@ func TestUpdater(t *testing.T) {
 
 		queue := syncqueues.NewPriorityQueueWithCallbacksForSize(log, nil, 4)
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -96,7 +96,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -140,7 +140,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR1, mockKymaCR2)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -190,7 +190,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR1, mockKymaCR2)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -122,7 +122,14 @@ func (s *SyncService) Run() {
 	var err error
 	if s.cfg.UpdateResources {
 		logger.Debug("Resource update is enabled, creating updater")
-		updater, err = kymacustomresource.NewUpdater(s.k8sClient, priorityQueue, s.kymaGVR, s.cfg.SyncQueueSleepInterval, betaEnabledLabel, logger.With("component", "updater"))
+		updater, err = kymacustomresource.NewUpdater(
+			s.k8sClient,
+			priorityQueue,
+			s.kymaGVR,
+			s.cfg.SyncQueueSleepInterval,
+			betaEnabledLabel,
+			s.ctx,
+			logger.With("component", "updater"))
 		fatalOnError(err)
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We experienced that updater goroutine once "hung" and no updates were executed till the restart.
To avoid we added a timeout, if timeout is reached, item will be requeued.

Changes proposed in this pull request:

- Context with timeout used when listing kymas and when updating kymas

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
