### PR TITLE
Metrics with time in the queue

### DIFF
--- a/internal/subaccountsync/metrics.go
+++ b/internal/subaccountsync/metrics.go
@@ -8,6 +8,7 @@ type Metrics struct {
 	cisRequests *prometheus.CounterVec
 	states      *prometheus.GaugeVec
 	informer    *prometheus.CounterVec
+	timeInQueue prometheus.Gauge
 }
 
 func NewMetrics(reg prometheus.Registerer, namespace string) *Metrics {
@@ -36,6 +37,11 @@ func NewMetrics(reg prometheus.Registerer, namespace string) *Metrics {
 			Namespace: namespace,
 			Name:      "priority_queue_size",
 			Help:      "Queue size.",
+		}),
+		timeInQueue: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "time_in_queue",
+			Help:      "Time spent in queue.",
 		}),
 	}
 	reg.MustRegister(m.queue, m.queueOps, m.states, m.informer, m.cisRequests)

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -114,6 +114,7 @@ func (s *SyncService) Run() {
 		OnExtract: func(queueSize int, timeEnqueued int64) {
 			metrics.queue.Set(float64(queueSize))
 			metrics.queueOps.With(prometheus.Labels{"operation": "extract"}).Inc()
+			metrics.timeInQueue.Set(float64(epochInMillis() - timeEnqueued))
 		},
 	})
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

To measure time spent in the queue appropriate metrics added.

Changes proposed in this pull request:

- when item is extracted from the queue metric is set

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#691 