### PR TITLE
Avoided Error Logs for Recoverable Cases in EDP Step

### DIFF
--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -41,6 +41,8 @@ func (om *OperationManager) OperationFailed(operation internal.Operation, descri
 		// keep the original err object for error categorizer
 		retErr = fmt.Errorf("%s: %w", description, err)
 	}
+
+	log.Errorf("Step execution failed: %w", retErr)
 	operation.EventErrorf(err, "operation failed")
 
 	return op, 0, retErr

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -102,13 +102,13 @@ func (s *EDPRegistrationStep) handleError(operation internal.Operation, err erro
 	if kebError.IsTemporaryError(err) {
 		since := time.Since(operation.UpdatedAt)
 		if since < time.Minute*30 {
-			log.Errorf("request to EDP failed: %s. Retry...", err)
+			log.Warnf("request to EDP failed: %s. Retry...", err)
 			return operation, 10 * time.Second, nil
 		}
 	}
 
 	if !s.config.Required {
-		log.Errorf("Step %s failed. Step is not required. Skip step.", s.Name())
+		log.Warnf("Step %s failed. Step is not required. Skip step.", s.Name())
 		return operation, 0, nil
 	}
 

--- a/internal/process/staged_manager.go
+++ b/internal/process/staged_manager.go
@@ -228,10 +228,11 @@ func (m *StagedManager) runStep(step Step, operation internal.Operation, logger 
 	for {
 		start = time.Now()
 		logger.Infof("Start step")
-		processedOperation, backoff, err = step.Run(processedOperation, logger)
+		stepLogger := logger.WithFields(logrus.Fields{"step": step.Name(), "operation": processedOperation.ID})
+		processedOperation, backoff, err = step.Run(processedOperation, stepLogger)
 		if err != nil {
 			processedOperation.LastError = kebError.ReasonForError(err)
-			logOperation := m.log.WithFields(logrus.Fields{"step": step.Name(), "operation": processedOperation.ID, "error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
+			logOperation := stepLogger.WithFields(logrus.Fields{"error_component": processedOperation.LastError.Component(), "error_reason": processedOperation.LastError.Reason()})
 			logOperation.Warnf("Last error from step: %s", processedOperation.LastError.Error())
 			// only save to storage, skip for alerting if error
 			_, err = m.operationStorage.UpdateOperation(processedOperation)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- passing logger with step label set to step Run method invocation to aviod setting `step` to each every log message explicitly,
- changing edp_registration's step error to warn wherever the step is not required or would be retried,
- logging a final error only in `OperationFailed` method to avoid its repetitions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
