### PR TITLE
Metrics for `subaccount-sync` continued

### DIFF
--- a/internal/subaccountsync/metrics.go
+++ b/internal/subaccountsync/metrics.go
@@ -4,11 +4,11 @@ import "github.com/prometheus/client_golang/prometheus"
 
 type Metrics struct {
 	queue       prometheus.Gauge
+	timeInQueue prometheus.Gauge
 	queueOps    *prometheus.CounterVec
 	cisRequests *prometheus.CounterVec
 	states      *prometheus.GaugeVec
 	informer    *prometheus.CounterVec
-	timeInQueue prometheus.Gauge
 }
 
 func NewMetrics(reg prometheus.Registerer, namespace string) *Metrics {
@@ -44,6 +44,6 @@ func NewMetrics(reg prometheus.Registerer, namespace string) *Metrics {
 			Help:      "Time spent in queue.",
 		}),
 	}
-	reg.MustRegister(m.queue, m.queueOps, m.states, m.informer, m.cisRequests)
+	reg.MustRegister(m.queue, m.queueOps, m.states, m.informer, m.cisRequests, m.timeInQueue)
 	return m
 }

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -115,6 +115,7 @@ func (s *SyncService) Run() {
 			metrics.queue.Set(float64(queueSize))
 			metrics.queueOps.With(prometheus.Labels{"operation": "extract"}).Inc()
 			timeEnqueuedMillis := timeEnqueuedNano / int64(time.Millisecond)
+			logger.Debug(fmt.Sprintf("Item extracted from the queue after %d ms", timeEnqueuedMillis))
 			metrics.timeInQueue.Set(float64(timeEnqueuedMillis))
 		},
 	})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

To visualize `subaccount-sync` activity and to create base for future alerting.

Changes proposed in this pull request:

- Missing metric registered (time in the queue)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#691 