### PR TITLE
New metrics signalling dry run mode

### DIFF
--- a/internal/subaccountsync/metrics.go
+++ b/internal/subaccountsync/metrics.go
@@ -5,6 +5,7 @@ import "github.com/prometheus/client_golang/prometheus"
 type Metrics struct {
 	queue       prometheus.Gauge
 	timeInQueue prometheus.Gauge
+	dryRun      prometheus.Gauge
 	queueOps    *prometheus.CounterVec
 	cisRequests *prometheus.CounterVec
 	states      *prometheus.GaugeVec
@@ -43,7 +44,12 @@ func NewMetrics(reg prometheus.Registerer, namespace string) *Metrics {
 			Name:      "time_in_queue",
 			Help:      "Time spent in queue.",
 		}),
+		dryRun: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "dry_run",
+			Help:      "Resources are not updated.",
+		}),
 	}
-	reg.MustRegister(m.queue, m.queueOps, m.states, m.informer, m.cisRequests, m.timeInQueue)
+	reg.MustRegister(m.queue, m.queueOps, m.states, m.informer, m.cisRequests, m.timeInQueue, m.dryRun)
 	return m
 }

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -133,6 +133,9 @@ func (s *SyncService) Run() {
 			s.ctx,
 			logger.With("component", "updater"))
 		fatalOnError(err)
+		metrics.dryRun.Set(0)
+	} else {
+		metrics.dryRun.Set(1)
 	}
 
 	// create state reconciler


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

To avoid triggering alerts when in dry run mode (i.e. queue size would only increase, no updater hence no extracts)

Changes proposed in this pull request:

- `dry_run` metric added

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
