### PR TITLE
Changing Eval State Only if Changed in AVS

### DIFF
--- a/internal/avs/delegator.go
+++ b/internal/avs/delegator.go
@@ -169,7 +169,7 @@ func (del *Delegator) SetStatus(log logrus.FieldLogger, lifecycleData *internal.
 			log.Errorf("%s: %s", errMsg, err)
 			return err
 		}
-	
+
 		// update operation with newly configured status
 		evalAssistant.SetEvalStatus(lifecycleData, status)
 	}

--- a/internal/avs/delegator.go
+++ b/internal/avs/delegator.go
@@ -169,9 +169,10 @@ func (del *Delegator) SetStatus(log logrus.FieldLogger, lifecycleData *internal.
 			log.Errorf("%s: %s", errMsg, err)
 			return err
 		}
+	
+		// update operation with newly configured status
+		evalAssistant.SetEvalStatus(lifecycleData, status)
 	}
-	// update operation with newly configured status
-	evalAssistant.SetEvalStatus(lifecycleData, status)
 
 	return nil
 }

--- a/internal/avs/delegator_test.go
+++ b/internal/avs/delegator_test.go
@@ -307,7 +307,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		assert.NoError(t, err)
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusMaintenance, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	// Since logic is the same for both internal and external monitors,
@@ -343,7 +343,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
 		// restores original status from current, which is restored from Avs
-		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusInactive, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	t.Run("reset from invalid fields (current invalid)", func(t *testing.T) {

--- a/internal/avs/delegator_test.go
+++ b/internal/avs/delegator_test.go
@@ -186,7 +186,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		// Then
 		assert.NoError(t, err)
 		assert.Equal(t, params.internalMonitor.Status, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, params.internalMonitor.Status, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusMaintenance, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	t.Run("set for empty fields", func(t *testing.T) {
@@ -290,7 +290,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		assert.NoError(t, err)
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, "", internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	// Since logic is the same for both internal and external monitors,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Orchestration logic in KEB keeps AVS maintenance mode in [operation's Instance Details](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/model.go#L206) in [operation.Avs.AvsInternalEvaluationStatus](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/model.go#L58) in its Original and Current fields.

Current behaviour is as follows:
1. Orchestration is initiated.
1. KEB creates first operation for given instance - instance details field on operation is initialized with the value from a previous operation.
1. KEB call [setMaintenanceStatus method](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/process/upgrade_cluster/initialisation.go#L165)
1. In the set [maintenance call](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/avs/delegator.go#L152) - KEB refreshes current AVS state by calling AVS client.
1. In the set maintenance call - [If state is different then current KEB state](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/avs/delegator.go#L157) then KEB sets maintenance mode in AVS client.
1. In the set maintenance call - Regardless of the change in instance details state KEB [sets maintenance mode](https://github.com/kyma-project/kyma-environment-broker/blob/743c16331fec2d124827451d3a754bbdfd3866f7/internal/avs/delegator.go#L174) on current operation's Instance Details.
1. Current Instance details status is *MAINTENANCE* and original one is *ACTIVE*
1. Operation Failes.
1. Orchestration is retries, new operation is created,
1. KEB repeats points 4 and 5.
1. Current Instance details status is *MAINTENANCE* and previous one is *MAINTENANCE*
1. On operation success KEB sets maintenance mode to previous value which is *MAINTENANCE*

The following fix corrects this behaviour by invoking `evalAssistant.SetEvalStatus(lifecycleData, status)` only if current KEB state is different then AVS state.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
