### PR TITLE
COnfig for plan is not Kyma version oriented

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -166,7 +166,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	}
 
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), defaultKymaVer),
+		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/cmd/broker/deprovisioning_suite_test.go
+++ b/cmd/broker/deprovisioning_suite_test.go
@@ -121,7 +121,7 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(defaultKymaVer, []string{})...).Build()
 
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), defaultKymaVer),
+		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -170,6 +170,8 @@ type Config struct {
 	CleaningDryRun  bool `envconfig:"default=true"`
 
 	KymaResourceDeletionTimeout time.Duration `envconfig:"default=30s"`
+
+	RuntimeConfigurationConfigMapName string `envconfig:"default=runtime-config"`
 }
 
 type ProfilerConfig struct {

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -171,7 +171,7 @@ type Config struct {
 
 	KymaResourceDeletionTimeout time.Duration `envconfig:"default=30s"`
 
-	RuntimeConfigurationConfigMapName string `envconfig:"default=runtime-config"`
+	RuntimeConfigurationConfigMapName string `envconfig:"default=keb-runtime-config"`
 }
 
 type ProfilerConfig struct {
@@ -298,7 +298,7 @@ func main() {
 
 	// provides configuration for specified Kyma version and plan
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logs, cfg.KymaVersion),
+		kebConfig.NewConfigMapReader(ctx, cli, logs, cfg.RuntimeConfigurationConfigMapName),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	gardenerClusterConfig, err := gardener.NewGardenerClusterConfig(cfg.Gardener.KubeconfigPath)

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -495,7 +495,7 @@ func fixK8sResources(defaultKymaVersion string, additionalKymaVersions []string)
 
 	kebCfg := &coreV1.ConfigMap{
 		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "keb-config",
+			Name:      "keb-runtime-config",
 			Namespace: "kcp-system",
 			Labels: map[string]string{
 				"keb-config": "true",

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -136,7 +136,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 	kymaVer := "2.4.0"
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(kymaVer, additionalKymaVersions)...).Build()
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), defaultKymaVer),
+		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	inputFactory, err := input.NewInputBuilderFactory(configProvider, input.Config{
@@ -587,7 +587,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 	additionalKymaVersions := []string{"1.19", "1.20", "main"}
 	cli := fake.NewFakeClientWithScheme(sch, fixK8sResources(defaultKymaVer, additionalKymaVersions)...)
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), defaultKymaVer),
+		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	inputFactory, err := input.NewInputBuilderFactory(configProvider, input.Config{

--- a/cmd/subaccountsync/main.go
+++ b/cmd/subaccountsync/main.go
@@ -64,12 +64,12 @@ func main() {
 
 	// create config provider - provider still uses logrus logger
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.WithField("service", "storage"), cfg.KymaVersion),
+		kebConfig.NewConfigMapReader(ctx, cli, logrus.WithField("service", "storage"), cfg.RuntimeConfigurationConfigMapName),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 
 	// create Kyma GVR
-	kymaGVR := getResourceKindProvider(cfg.KymaVersion, configProvider)
+	kymaGVR := getResourceKindProvider(cfg.RuntimeConfigurationConfigMapName, configProvider)
 
 	// create DB connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -6,7 +6,7 @@ import (
 
 type (
 	ConfigReader interface {
-		Read(kymaVersion, planName string) (string, error)
+		Read(planName string) (string, error)
 	}
 
 	ConfigValidator interface {
@@ -28,8 +28,8 @@ func NewConfigProvider(reader ConfigReader, validator ConfigValidator, converter
 	return &ConfigProvider{Reader: reader, Validator: validator, Converter: converter}
 }
 
-func (p *ConfigProvider) ProvideForGivenVersionAndPlan(kymaVersion, planName string) (*internal.ConfigForPlan, error) {
-	cfgString, err := p.Reader.Read(kymaVersion, planName)
+func (p *ConfigProvider) ProvideForGivenPlan(planName string) (*internal.ConfigForPlan, error) {
+	cfgString, err := p.Reader.Read(planName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -51,7 +51,6 @@ func TestConfigProvider(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		assert.Len(t, cfg.AdditionalComponents, len(expectedCfg.AdditionalComponents))
 		assert.ObjectsAreEqual(expectedCfg, cfg)
 	})
 

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -27,7 +27,7 @@ func TestConfigProvider(t *testing.T) {
 	fakeK8sClient := fake.NewClientBuilder().WithRuntimeObjects(cfgMap).Build()
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
-	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, kymaVersion)
+	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, "keb-config")
 	cfgValidator := config.NewConfigMapKeysValidator()
 	cfgConverter := config.NewConfigMapConverter()
 	cfgProvider := config.NewConfigProvider(cfgReader, cfgValidator, cfgConverter)
@@ -36,7 +36,7 @@ func TestConfigProvider(t *testing.T) {
 		// given
 		expectedCfg := fixAzureConfig()
 		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(kymaVersion, broker.AzurePlanName)
+		cfg, err := cfgProvider.ProvideForGivenPlan(broker.AzurePlanName)
 
 		// then
 		require.NoError(t, err)
@@ -47,34 +47,11 @@ func TestConfigProvider(t *testing.T) {
 		// given
 		expectedCfg := fixDefault()
 		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(kymaVersion, broker.AWSPlanName)
+		cfg, err := cfgProvider.ProvideForGivenPlan(broker.AWSPlanName)
 
 		// then
 		require.NoError(t, err)
-		assert.ObjectsAreEqual(expectedCfg, cfg)
-	})
-
-	t.Run("should provide config for default Kyma version and azure plan when PR-* Kyma version is passed", func(t *testing.T) {
-		// given
-		expectedCfg := fixAzureConfig()
-		customKymaVer := "PR-1234"
-		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(customKymaVer, broker.AzurePlanName)
-
-		// then
-		require.NoError(t, err)
-		assert.ObjectsAreEqual(expectedCfg, cfg)
-	})
-
-	t.Run("should provide config for default Kyma version and azure plan when main-* Kyma version is passed", func(t *testing.T) {
-		// given
-		expectedCfg := fixAzureConfig()
-		customKymaVer := "main-fffff"
-		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(customKymaVer, broker.AzurePlanName)
-
-		// then
-		require.NoError(t, err)
+		assert.Len(t, cfg.AdditionalComponents, len(expectedCfg.AdditionalComponents))
 		assert.ObjectsAreEqual(expectedCfg, cfg)
 	})
 
@@ -85,7 +62,7 @@ func TestConfigProvider(t *testing.T) {
 		}
 		expectedErrMsg := fmt.Sprintf("missing required configuration entires: %s", strings.Join(expectedMissingConfigKeys, ","))
 		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(kymaVersion, wrongConfigPlan)
+		cfg, err := cfgProvider.ProvideForGivenPlan(wrongConfigPlan)
 
 		// then
 		require.Error(t, err)
@@ -99,11 +76,11 @@ func TestConfigProvider(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		cfg, err := cfgProvider.ProvideForGivenVersionAndPlan(kymaVersion, broker.AzurePlanName)
+		cfg, err := cfgProvider.ProvideForGivenPlan(broker.AzurePlanName)
 
 		// then
 		require.Error(t, err)
-		assert.Equal(t, "configmap with configuration does not exist", errors.Unwrap(err).Error())
+		assert.Equal(t, "configmap keb-config with configuration does not exist", errors.Unwrap(err).Error())
 		assert.Nil(t, cfg)
 	})
 }

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -3,57 +3,43 @@ package config
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/sirupsen/logrus"
 	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	namespace                 = "kcp-system"
 	runtimeVersionLabelPrefix = "runtime-version-"
-	kebConfigLabel            = "keb-config"
+	kebConfigLabel            = "keb-config-runtime-configuration"
 	defaultConfigKey          = "default"
 )
 
 type ConfigMapReader struct {
-	ctx                context.Context
-	k8sClient          client.Client
-	logger             logrus.FieldLogger
-	defaultKymaVersion string
+	ctx           context.Context
+	k8sClient     client.Client
+	logger        logrus.FieldLogger
+	configMapName string
 }
 
-func NewConfigMapReader(ctx context.Context, k8sClient client.Client, logger logrus.FieldLogger, defaultKymaVersion string) *ConfigMapReader {
+func NewConfigMapReader(ctx context.Context, k8sClient client.Client, logger logrus.FieldLogger, cmName string) *ConfigMapReader {
 	return &ConfigMapReader{
-		ctx:                ctx,
-		k8sClient:          k8sClient,
-		logger:             logger,
-		defaultKymaVersion: defaultKymaVersion,
+		ctx:           ctx,
+		k8sClient:     k8sClient,
+		logger:        logger,
+		configMapName: cmName,
 	}
 }
 
-func (r *ConfigMapReader) Read(kymaVersion, planName string) (string, error) {
-	r.logger.Infof("getting configuration for Kyma version %v and %v plan", kymaVersion, planName)
-	var cfgMapList *coreV1.ConfigMapList
-	cfgMapList, err := r.getConfigMapList(kymaVersion)
+func (r *ConfigMapReader) Read(planName string) (string, error) {
+	r.logger.Infof("getting configuration for %v plan", planName)
+
+	cfgMap, err := r.getConfigMap()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("while getting configuration configmap: %w", err)
 	}
-	if len(cfgMapList.Items) == 0 && isCustomVersion(kymaVersion) {
-		r.logger.Infof("configuration for Kyma version %v does not exist. Getting configuration for the latest official release version: %v", kymaVersion, r.defaultKymaVersion)
-		cfgMapList, err = r.getConfigMapList(r.defaultKymaVersion)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if err = r.verifyConfigMapExistence(cfgMapList); err != nil {
-		return "", fmt.Errorf("while verifying configuration configmap existence: %w", err)
-	}
-
-	cfgMap := cfgMapList.Items[0]
-	cfgString, err := r.getConfigStringForPlanOrDefaults(&cfgMap, planName)
+	cfgString, err := r.getConfigStringForPlanOrDefaults(cfgMap, planName)
 	if err != nil {
 		return "", fmt.Errorf("while getting configuration string: %w", err)
 	}
@@ -61,39 +47,13 @@ func (r *ConfigMapReader) Read(kymaVersion, planName string) (string, error) {
 	return cfgString, nil
 }
 
-func (r *ConfigMapReader) getConfigMapList(kymaVersion string) (*coreV1.ConfigMapList, error) {
-	cfgMapList := &coreV1.ConfigMapList{}
-	listOptions := configMapListOptions(kymaVersion)
-	if err := r.k8sClient.List(r.ctx, cfgMapList, listOptions...); err != nil {
-		return nil, fmt.Errorf("while fetching configmap with configuration for Kyma version %v: %w",
-			kymaVersion, err)
+func (r *ConfigMapReader) getConfigMap() (*coreV1.ConfigMap, error) {
+	cfgMap := &coreV1.ConfigMap{}
+	err := r.k8sClient.Get(r.ctx, client.ObjectKey{Namespace: namespace, Name: r.configMapName}, cfgMap)
+	if errors.IsNotFound(err) {
+		return nil, fmt.Errorf("configmap %s with configuration does not exist", r.configMapName)
 	}
-	return cfgMapList, nil
-}
-
-func configMapListOptions(version string) []client.ListOption {
-	versionLabel := runtimeVersionLabelPrefix + strings.ToLower(version)
-
-	labels := map[string]string{
-		versionLabel:   "true",
-		kebConfigLabel: "true",
-	}
-
-	return []client.ListOption{
-		client.InNamespace(namespace),
-		client.MatchingLabels(labels),
-	}
-}
-
-func (r *ConfigMapReader) verifyConfigMapExistence(cfgMapList *coreV1.ConfigMapList) error {
-	switch n := len(cfgMapList.Items); n {
-	case 1:
-		return nil
-	case 0:
-		return fmt.Errorf("configmap with configuration does not exist")
-	default:
-		return fmt.Errorf("allowed number of configuration configmaps: 1, found: %d", n)
-	}
+	return cfgMap, err
 }
 
 func (r *ConfigMapReader) getConfigStringForPlanOrDefaults(cfgMap *coreV1.ConfigMap, planName string) (string, error) {
@@ -106,8 +66,4 @@ func (r *ConfigMapReader) getConfigStringForPlanOrDefaults(cfgMap *coreV1.Config
 		}
 	}
 	return cfgString, nil
-}
-
-func isCustomVersion(version string) bool {
-	return strings.HasPrefix(version, "PR-") || strings.HasPrefix(version, "main-")
 }

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -26,7 +26,6 @@ const (
 	namespace                 = "kcp-system"
 	runtimeVersionLabelPrefix = "runtime-version-"
 	kebConfigLabel            = "keb-config"
-	kymaVersion               = "2.4.0"
 	defaultConfigKey          = "default"
 )
 
@@ -39,85 +38,39 @@ func TestConfigReaderSuccessFlow(t *testing.T) {
 	fakeK8sClient := fake.NewClientBuilder().WithRuntimeObjects(cfgMap).Build()
 	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
-	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, kymaVersion)
+	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, "keb-config")
 
-	t.Run("should read default KEB config for Kyma version 2.4.0", func(t *testing.T) {
+	t.Run("should read default KEB config", func(t *testing.T) {
 		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.AWSPlanName)
+		rawCfg, err := cfgReader.Read(broker.AWSPlanName)
 
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, cfgMap.Data[defaultConfigKey], rawCfg)
 	})
 
-	t.Run("should read KEB config for Kyma version 2.4.0 and azure plan", func(t *testing.T) {
+	t.Run("should read KEB config for azure plan", func(t *testing.T) {
 		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.AzurePlanName)
+		rawCfg, err := cfgReader.Read(broker.AzurePlanName)
 
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, cfgMap.Data[broker.AzurePlanName], rawCfg)
 	})
 
-	t.Run("should read KEB config for Kyma version 2.4.0 and trial plan", func(t *testing.T) {
+	t.Run("should read KEB config for Kyma trial plan", func(t *testing.T) {
 		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.TrialPlanName)
+		rawCfg, err := cfgReader.Read(broker.TrialPlanName)
 
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, cfgMap.Data[broker.TrialPlanName], rawCfg)
-	})
-
-	t.Run("should read KEB config for custom Kyma version and azure plan", func(t *testing.T) {
-		// when
-		customVersion := "PR-1000"
-		rawCfg, err := cfgReader.Read(customVersion, broker.AzurePlanName)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, cfgMap.Data[broker.AzurePlanName], rawCfg)
-	})
-
-	t.Run("should read KEB config for the latest official Kyma version and azure plan when config for custom main-* version is missing", func(t *testing.T) {
-		// when
-		customVersion := "main-fffff"
-		rawCfg, err := cfgReader.Read(customVersion, broker.AzurePlanName)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, cfgMap.Data[broker.AzurePlanName], rawCfg)
-	})
-
-	t.Run("should read KEB config for the latest official Kyma version and azure plan when config for custom PR-* version is missing", func(t *testing.T) {
-		// when
-		customVersion := "PR-1234"
-		rawCfg, err := cfgReader.Read(customVersion, broker.AzurePlanName)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, cfgMap.Data[broker.AzurePlanName], rawCfg)
 	})
 }
 
 func TestConfigReaderErrors(t *testing.T) {
 	// setup
 	ctx := context.TODO()
-	redundantCfgMap := &coreV1.ConfigMap{
-		TypeMeta: metaV1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metaV1.ObjectMeta{
-			Name:      "redundant-configmap",
-			Namespace: namespace,
-			Labels: map[string]string{
-				fmt.Sprintf("%s%s", runtimeVersionLabelPrefix, kymaVersion): "true",
-				kebConfigLabel: "true",
-			},
-		},
-	}
-	cfgMap, err := fixConfigMap()
-	require.NoError(t, err)
 
 	k8sClient := failingK8sClient{}
 	fakeK8sClient := fake.NewClientBuilder().Build()
@@ -126,38 +79,10 @@ func TestConfigReaderErrors(t *testing.T) {
 
 	t.Run("should return error while fetching configmap on List() of K8s client", func(t *testing.T) {
 		// given
-		cfgReader := config.NewConfigMapReader(ctx, k8sClient, logger, kymaVersion)
+		cfgReader := config.NewConfigMapReader(ctx, k8sClient, logger, "keb-config")
 
 		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.AzurePlanName)
-
-		// then
-		require.Error(t, err)
-		logger.Error(err)
-		assert.Equal(t, "", rawCfg)
-	})
-
-	t.Run("should return error while verifying configuration configmap existence", func(t *testing.T) {
-		// given
-		cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, kymaVersion)
-
-		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.AzurePlanName)
-
-		// then
-		require.Error(t, err)
-		logger.Error(err)
-		assert.Equal(t, "", rawCfg)
-
-		// given
-		err = fakeK8sClient.Create(ctx, cfgMap)
-		require.NoError(t, err)
-
-		err = fakeK8sClient.Create(ctx, redundantCfgMap)
-		require.NoError(t, err)
-
-		// when
-		rawCfg, err = cfgReader.Read(kymaVersion, broker.AzurePlanName)
+		rawCfg, err := cfgReader.Read(broker.AzurePlanName)
 
 		// then
 		require.Error(t, err)
@@ -167,13 +92,10 @@ func TestConfigReaderErrors(t *testing.T) {
 
 	t.Run("should return error while getting config string for a plan", func(t *testing.T) {
 		// given
-		err = fakeK8sClient.Delete(ctx, cfgMap)
-		require.NoError(t, err)
-
-		cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, kymaVersion)
+		cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, "keb-config")
 
 		// when
-		rawCfg, err := cfgReader.Read(kymaVersion, broker.AzurePlanName)
+		rawCfg, err := cfgReader.Read(broker.AzurePlanName)
 
 		// then
 		require.Error(t, err)

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	kebConfigYaml             = "keb-config.yaml"
+	expectedKebConfigYaml     = "keb-config-expected.yaml"
 	namespace                 = "kcp-system"
 	runtimeVersionLabelPrefix = "runtime-version-"
 	kebConfigLabel            = "keb-config"
@@ -105,7 +106,7 @@ func TestConfigReaderErrors(t *testing.T) {
 }
 
 func fixConfigMap() (*coreV1.ConfigMap, error) {
-	yamlFilePath := path.Join("testdata", kebConfigYaml)
+	yamlFilePath := path.Join("testdata", expectedKebConfigYaml)
 	contents, err := os.ReadFile(yamlFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("while reading configmap")

--- a/internal/config/testdata/keb-config-expected.yaml
+++ b/internal/config/testdata/keb-config-expected.yaml
@@ -11,7 +11,7 @@ data:
   default: |-
     kyma-template: |-
       apiVersion: operator.kyma-project.io/v1beta2
-      Kind: Kyma
+      kind: Kyma
       metadata:
         name: tbd
         namespace: kyma-system

--- a/internal/kymacustomresource/resource_kind_provider.go
+++ b/internal/kymacustomresource/resource_kind_provider.go
@@ -12,8 +12,8 @@ import (
 const defaultPlan = "default"
 
 type ResourceKindProvider struct {
-	defaultKymaVersion string
-	cfgProvider        input.ConfigurationProvider
+	runtimeConfigurationConfigMapName string
+	cfgProvider                       input.ConfigurationProvider
 }
 
 type apiVersionKind struct {
@@ -21,10 +21,10 @@ type apiVersionKind struct {
 	Kind       string `yaml:"kind"`
 }
 
-func NewResourceKindProvider(defaultKymaVersion string, cfgProvider input.ConfigurationProvider) *ResourceKindProvider {
+func NewResourceKindProvider(configMapName string, cfgProvider input.ConfigurationProvider) *ResourceKindProvider {
 	return &ResourceKindProvider{
-		defaultKymaVersion: defaultKymaVersion,
-		cfgProvider:        cfgProvider,
+		runtimeConfigurationConfigMapName: configMapName,
+		cfgProvider:                       cfgProvider,
 	}
 }
 

--- a/internal/kymacustomresource/resource_kind_provider.go
+++ b/internal/kymacustomresource/resource_kind_provider.go
@@ -42,7 +42,7 @@ func (p *ResourceKindProvider) DefaultGvr() (schema.GroupVersionResource, error)
 }
 
 func (p *ResourceKindProvider) DefaultGvk() (schema.GroupVersionKind, error) {
-	kymaCfg, err := p.cfgProvider.ProvideForGivenVersionAndPlan(p.defaultKymaVersion, defaultPlan)
+	kymaCfg, err := p.cfgProvider.ProvideForGivenPlan(defaultPlan)
 	if err != nil {
 		return schema.GroupVersionKind{}, fmt.Errorf("while getting Kyma config: %w", err)
 	}

--- a/internal/kymacustomresource/resource_kind_provider_test.go
+++ b/internal/kymacustomresource/resource_kind_provider_test.go
@@ -49,6 +49,6 @@ func TestResourceKindProvider(t *testing.T) {
 
 type fakeConfigProvider struct{}
 
-func (f fakeConfigProvider) ProvideForGivenVersionAndPlan(version, plan string) (*internal.ConfigForPlan, error) {
+func (f fakeConfigProvider) ProvideForGivenPlan(plan string) (*internal.ConfigForPlan, error) {
 	return &internal.ConfigForPlan{KymaTemplate: kymaTemplate}, nil
 }

--- a/internal/process/deprovisioning/delete_kyma_resource_step.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step.go
@@ -51,7 +51,7 @@ func (step *DeleteKymaResourceStep) Name() string {
 func (step *DeleteKymaResourceStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	// read the KymaTemplate from the config if needed
 	if operation.KymaTemplate == "" {
-		cfg, err := step.configProvider.ProvideForGivenVersionAndPlan(step.defaultKymaVersion, broker.PlanNamesMapping[operation.Plan])
+		cfg, err := step.configProvider.ProvideForGivenPlan(broker.PlanNamesMapping[operation.Plan])
 		if err != nil {
 			return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to get config for given version and plan", 5*time.Second, 30*time.Second, logger,
 				fmt.Errorf("unable to get config for given version and plan"))

--- a/internal/process/deprovisioning/delete_kyma_resource_step_test.go
+++ b/internal/process/deprovisioning/delete_kyma_resource_step_test.go
@@ -77,7 +77,7 @@ func TestDeleteKymaResource_EmptyRuntimeIDAndKymaResourceName(t *testing.T) {
 type fakeConfigProvider struct {
 }
 
-func (fakeConfigProvider) ProvideForGivenVersionAndPlan(_, _ string) (*internal.ConfigForPlan, error) {
+func (fakeConfigProvider) ProvideForGivenPlan(_ string) (*internal.ConfigForPlan, error) {
 	return &internal.ConfigForPlan{
 		KymaTemplate: kymaTemplate,
 	}, nil

--- a/internal/process/input/automock/configuration_provider.go
+++ b/internal/process/input/automock/configuration_provider.go
@@ -13,12 +13,12 @@ type ConfigurationProvider struct {
 }
 
 // ProvideForGivenVersionAndPlan provides a mock function with given fields: kymaVersion, planName
-func (_m *ConfigurationProvider) ProvideForGivenVersionAndPlan(kymaVersion string, planName string) (*internal.ConfigForPlan, error) {
-	ret := _m.Called(kymaVersion, planName)
+func (_m *ConfigurationProvider) ProvideForGivenPlan(planName string) (*internal.ConfigForPlan, error) {
+	ret := _m.Called(planName)
 
 	var r0 *internal.ConfigForPlan
-	if rf, ok := ret.Get(0).(func(string, string) *internal.ConfigForPlan); ok {
-		r0 = rf(kymaVersion, planName)
+	if rf, ok := ret.Get(0).(func(string) *internal.ConfigForPlan); ok {
+		r0 = rf(planName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*internal.ConfigForPlan)
@@ -26,8 +26,8 @@ func (_m *ConfigurationProvider) ProvideForGivenVersionAndPlan(kymaVersion strin
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(kymaVersion, planName)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(planName)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/process/input/builder.go
+++ b/internal/process/input/builder.go
@@ -29,7 +29,7 @@ type (
 	}
 
 	ConfigurationProvider interface {
-		ProvideForGivenVersionAndPlan(kymaVersion, planName string) (*internal.ConfigForPlan, error)
+		ProvideForGivenPlan(planName string) (*internal.ConfigForPlan, error)
 	}
 )
 
@@ -138,7 +138,7 @@ func (f *InputBuilderFactory) CreateProvisionInput(provisioningParameters intern
 
 	planName := broker.PlanNamesMapping[provisioningParameters.PlanID]
 
-	cfg, err := f.configProvider.ProvideForGivenVersionAndPlan(version.Version, planName)
+	cfg, err := f.configProvider.ProvideForGivenPlan(planName)
 	if err != nil {
 		return nil, fmt.Errorf("while getting configuration for given version and plan: %w", err)
 	}
@@ -231,7 +231,7 @@ func (f *InputBuilderFactory) CreateUpgradeInput(provisioningParameters internal
 
 	planName := broker.PlanNamesMapping[provisioningParameters.PlanID]
 
-	cfg, err := f.configProvider.ProvideForGivenVersionAndPlan(version.Version, planName)
+	cfg, err := f.configProvider.ProvideForGivenPlan(planName)
 	if err != nil {
 		return nil, fmt.Errorf("while getting configuration for given version and plan: %w", err)
 	}
@@ -283,7 +283,7 @@ func (f *InputBuilderFactory) CreateUpgradeShootInput(provisioningParameters int
 
 	planName := broker.PlanNamesMapping[provisioningParameters.PlanID]
 
-	cfg, err := f.configProvider.ProvideForGivenVersionAndPlan(version.Version, planName)
+	cfg, err := f.configProvider.ProvideForGivenPlan(planName)
 	if err != nil {
 		return nil, fmt.Errorf("while getting configuration for given version and plan: %w", err)
 	}

--- a/internal/process/input/input_test.go
+++ b/internal/process/input/input_test.go
@@ -633,7 +633,7 @@ func TestShootAndSeedSameRegion(t *testing.T) {
 
 func mockConfigProvider() ConfigurationProvider {
 	configProvider := &automock.ConfigurationProvider{}
-	configProvider.On("ProvideForGivenVersionAndPlan",
+	configProvider.On("ProvideForGivenPlan",
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).
 		Return(&internal.ConfigForPlan{}, nil)

--- a/internal/process/provisioning/create_runtime_for_own_cluster_step_test.go
+++ b/internal/process/provisioning/create_runtime_for_own_cluster_step_test.go
@@ -128,7 +128,7 @@ func fixProvisioningParametersWithPlanID(planID, region string, platformRegion s
 func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	cli := fake.NewClientBuilder().WithRuntimeObjects(fixConfigMap(kymaVersion)).Build()
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(context.TODO(), cli, logrus.New(), kymaVersion),
+		kebConfig.NewConfigMapReader(context.TODO(), cli, logrus.New(), "keb-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	ibf, err := input.NewInputBuilderFactory(configProvider, input.Config{

--- a/internal/process/update/upgrade_shoot_step_test.go
+++ b/internal/process/update/upgrade_shoot_step_test.go
@@ -81,7 +81,7 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	const kymaVersion = "1.20"
 
 	configProvider := &inputAutomock.ConfigurationProvider{}
-	configProvider.On("ProvideForGivenVersionAndPlan",
+	configProvider.On("ProvideForGivenPlan",
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).
 		Return(&internal.ConfigForPlan{}, nil)

--- a/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -121,7 +121,7 @@ func fixUpgradeClusterOperationWithInputCreator(t *testing.T) internal.UpgradeCl
 
 func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	configProvider := &automock.ConfigurationProvider{}
-	configProvider.On("ProvideForGivenVersionAndPlan",
+	configProvider.On("ProvideForGivenPlan",
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).
 		Return(&internal.ConfigForPlan{}, nil)

--- a/internal/subaccountsync/config.go
+++ b/internal/subaccountsync/config.go
@@ -10,18 +10,18 @@ import (
 
 type (
 	Config struct {
-		CisAccounts            CisEndpointConfig
-		CisEvents              CisEndpointConfig
-		Database               storage.Config
-		UpdateResources        bool          `envconfig:"default=false"`
-		EventsWindowSize       time.Duration `envconfig:"default=20m"`
-		EventsWindowInterval   time.Duration `envconfig:"default=15m"`
-		AccountsSyncInterval   time.Duration `envconfig:"default=24h"`
-		StorageSyncInterval    time.Duration `envconfig:"default=10m"`
-		SyncQueueSleepInterval time.Duration `envconfig:"default=30s"`
-		MetricsPort            string        `envconfig:"default=8081"`
-		LogLevel               string        `envconfig:"default=info"`
-		KymaVersion            string
+		CisAccounts                       CisEndpointConfig
+		CisEvents                         CisEndpointConfig
+		Database                          storage.Config
+		UpdateResources                   bool          `envconfig:"default=false"`
+		EventsWindowSize                  time.Duration `envconfig:"default=20m"`
+		EventsWindowInterval              time.Duration `envconfig:"default=15m"`
+		AccountsSyncInterval              time.Duration `envconfig:"default=24h"`
+		StorageSyncInterval               time.Duration `envconfig:"default=10m"`
+		SyncQueueSleepInterval            time.Duration `envconfig:"default=30s"`
+		MetricsPort                       string        `envconfig:"default=8081"`
+		LogLevel                          string        `envconfig:"default=info"`
+		RuntimeConfigurationConfigMapName string
 	}
 
 	CisEndpointConfig struct {

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
           image: "{{ .Values.global.images.container_registry.path }}/{{ .Values.global.images.kyma_environment_broker.dir }}kyma-environment-broker:{{ .Values.global.images.kyma_environment_broker.version }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           env:
+            - name: APP_RUNTIME_CONFIGURATION_CONFIG_MAP_NAME
+              value: "{{ include "kyma-env-broker.fullname" . }}-runtime-configuration"
             - name: APP_DISABLE_PROCESS_OPERATIONS_IN_PROGRESS
               value: "{{ .Values.disableProcessOperationsInProgress }}"
             - name: APP_BROKER_ENABLE_PLANS

--- a/resources/keb/templates/keb-runtime-configuration.yaml
+++ b/resources/keb/templates/keb-runtime-configuration.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kyma-env-broker.fullname" . }}-runtime-configuration
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+data:
+  {{- with .Values.runtimeConfiguration }}
+  {{ tpl . $ | indent 6 }}
+  {{- end }}

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -451,3 +451,18 @@ freemiumWhitelistedGlobalAccountIds: |-
   whitelist:
 
 kymaResourceDeletionTimeout: 30s
+
+runtimeConfiguration: |-
+  default: |-
+    kyma-template: |-
+      apiVersion: operator.kyma-project.io/v1beta2
+      kind: Kyma
+      metadata:
+        labels:
+          "operator.kyma-project.io/managed-by": "lifecycle-manager"
+        name: tbd
+        namespace: kcp-system
+      spec:
+        channel: fast
+        modules: []
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
Kyma version is no longer used, the runtime config, which is currently versioned, is moved to non-versioned config in the KEB chart (before the PR the config was not a part of the chart)

1. Runtime configuration is a part of KEB chart, as a config map `kcp-kyma-environment-broker-runtime-configuration`
2. Kyma version is not used to find the config map, only the CM name is used to find the proper one
3. Management plane changes done in https://github.tools.sap/kyma/management-plane-config/pull/5313

**Related issue(s)**
Related: https://github.com/kyma-project/kyma-environment-broker/issues/536
