### PR TITLE
Adjust time sleeps and pooling intervals in metrics tests

### DIFF
--- a/internal/metricsv2/operations_result_test.go
+++ b/internal/metricsv2/operations_result_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	tries = 100000
+	tries = 1000
 )
 
 func TestOperationsResult(t *testing.T) {
-	t.Run("1000000 metrics should be published with 1 or 0", func(t *testing.T) {
+	t.Run("1000 metrics should be published with 1 or 0", func(t *testing.T) {
 		operations := storage.NewMemoryStorage().Operations()
 		for i := 0; i < tries; i++ {
 			op := internal.Operation{
@@ -41,15 +41,15 @@ func TestOperationsResult(t *testing.T) {
 
 		operationResult := NewOperationResult(
 			context.Background(), operations, Config{
-				Enabled: true, OperationResultPoolingInterval: 1 * time.Second,
-				OperationStatsPoolingInterval: 1 * time.Second, OperationResultRetentionPeriod: 24 * time.Hour,
+				Enabled: true, OperationResultPoolingInterval: 10 * time.Millisecond,
+				OperationStatsPoolingInterval: 10 * time.Millisecond, OperationResultRetentionPeriod: 24 * time.Hour,
 			}, logrus.New(),
 		)
 
 		eventBroker := event.NewPubSub(logrus.New())
 		eventBroker.Subscribe(process.OperationFinished{}, operationResult.Handler)
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 
 		ops, err := operations.GetAllOperations()
 		assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestOperationsResult(t *testing.T) {
 
 		newOp := getRandomOp(time.Now().UTC(), domain.InProgress)
 		err = operations.InsertOperation(newOp)
-		time.Sleep(1 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 
 		assert.NoError(t, err)
 		assert.Equal(t, float64(1), testutil.ToFloat64(operationResult.metrics.With(GetLabels(newOp))))
@@ -78,12 +78,12 @@ func TestOperationsResult(t *testing.T) {
 
 		opEvent := getRandomOp(randomCreatedAt(), domain.InProgress)
 		eventBroker.Publish(context.Background(), process.OperationFinished{Operation: opEvent})
-		time.Sleep(1 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 		assert.Equal(t, float64(1), testutil.ToFloat64(operationResult.metrics.With(GetLabels(opEvent))))
 
 		nonExistingOp1 := getRandomOp(randomCreatedAt(), domain.InProgress)
 		nonExistingOp2 := getRandomOp(randomCreatedAt(), domain.Failed)
-		time.Sleep(1 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 
 		assert.Equal(t, float64(0), testutil.ToFloat64(operationResult.metrics.With(GetLabels(nonExistingOp1))))
 		assert.Equal(t, float64(0), testutil.ToFloat64(operationResult.metrics.With(GetLabels(nonExistingOp2))))
@@ -104,7 +104,7 @@ func TestOperationsResult(t *testing.T) {
 		err = operations.InsertOperation(existingOp4)
 		assert.NoError(t, err)
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 
 		assert.Equal(t, float64(1), testutil.ToFloat64(operationResult.metrics.With(GetLabels(existingOp1))))
 		assert.Equal(t, float64(1), testutil.ToFloat64(operationResult.metrics.With(GetLabels(existingOp2))))


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- fix the test with proper time settings

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
