### PR TITLE
Logging 500 Errors for Kubeconfig Handler

### DIFF
--- a/internal/kubeconfig/handler.go
+++ b/internal/kubeconfig/handler.go
@@ -72,6 +72,7 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 		h.handleResponse(w, http.StatusNotFound, fmt.Errorf("instance with ID %s does not exist", instanceID))
 		return
 	default:
+		h.log.Errorf("while getting instance for a kubeconfig, error: %s", err)
 		h.handleResponse(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -93,6 +94,7 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 		h.handleResponse(w, http.StatusNotFound, fmt.Errorf("provisioning operation for instance with ID %s does not exist", instanceID))
 		return
 	default:
+		h.log.Errorf("while getting provision operation for kubeconfig, error: %s", err)
 		h.handleResponse(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -118,6 +120,7 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 		newKubeconfig, err = h.kubeconfigBuilder.Build(instance)
 	}
 	if err != nil {
+		h.log.Errorf("while building kubeconfig, error: %s", err)
 		h.handleResponse(w, http.StatusInternalServerError, fmt.Errorf("cannot fetch SKR kubeconfig: %s", err))
 		return
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Logs for 500 errors returned from Kubeconfig endpoint are not logged.

Changes proposed in this pull request:

- logging unidentified errors.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
