### PR TITLE
Use smaller machine types in trial, freemium and azure lite plans

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -196,7 +196,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 			URL:                         "http://localhost",
 			DefaultGardenerShootPurpose: "testing",
 			DefaultTrialProvider:        internal.AWS,
-		}, defaultKymaVer, map[string]string{"cf-eu10": "europe", "cf-us10": "us"}, cfg.FreemiumProviders, defaultOIDCValues())
+		}, defaultKymaVer, map[string]string{"cf-eu10": "europe", "cf-us10": "us"}, cfg.FreemiumProviders, defaultOIDCValues(), cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
 
 	storageCleanup, db, err := GetStorageForE2ETests()
 	assert.NoError(t, err)

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -196,7 +196,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 			URL:                         "http://localhost",
 			DefaultGardenerShootPurpose: "testing",
 			DefaultTrialProvider:        internal.AWS,
-		}, defaultKymaVer, map[string]string{"cf-eu10": "europe", "cf-us10": "us"}, cfg.FreemiumProviders, defaultOIDCValues(), cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
+		}, defaultKymaVer, map[string]string{"cf-eu10": "europe", "cf-us10": "us"}, cfg.FreemiumProviders, defaultOIDCValues(), cfg.Broker.UseSmallerMachineTypes)
 
 	storageCleanup, db, err := GetStorageForE2ETests()
 	assert.NoError(t, err)

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -336,7 +336,7 @@ func main() {
 	oidcDefaultValues, err := runtime.ReadOIDCDefaultValuesFromYAML(cfg.SkrOidcDefaultValuesYAMLFilePath)
 	fatalOnError(err, logs)
 	inputFactory, err := input.NewInputBuilderFactory(optComponentsSvc, disabledComponentsProvider, componentsProvider,
-		configProvider, cfg.Provisioner, cfg.KymaVersion, regions, cfg.FreemiumProviders, oidcDefaultValues)
+		configProvider, cfg.Provisioner, cfg.KymaVersion, regions, cfg.FreemiumProviders, oidcDefaultValues, cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
 	fatalOnError(err, logs)
 
 	edpClient := edp.NewClient(cfg.EDP)

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -336,7 +336,7 @@ func main() {
 	oidcDefaultValues, err := runtime.ReadOIDCDefaultValuesFromYAML(cfg.SkrOidcDefaultValuesYAMLFilePath)
 	fatalOnError(err, logs)
 	inputFactory, err := input.NewInputBuilderFactory(optComponentsSvc, disabledComponentsProvider, componentsProvider,
-		configProvider, cfg.Provisioner, cfg.KymaVersion, regions, cfg.FreemiumProviders, oidcDefaultValues, cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
+		configProvider, cfg.Provisioner, cfg.KymaVersion, regions, cfg.FreemiumProviders, oidcDefaultValues, cfg.Broker.UseSmallerMachineTypes)
 	fatalOnError(err, logs)
 
 	edpClient := edp.NewClient(cfg.EDP)

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -74,7 +74,7 @@ func TestCatalog(t *testing.T) {
 
 func TestProvisioning_HappyPath(t *testing.T) {
 	// given
-	suite := NewProvisioningSuite(t, false, "")
+	suite := NewProvisioningSuite(t, false, "", false)
 	defer suite.TearDown()
 
 	// when
@@ -678,12 +678,13 @@ func TestProvisioning_HandleExistingOperation(t *testing.T) {
 
 func TestProvisioning_ClusterParameters(t *testing.T) {
 	for tn, tc := range map[string]struct {
-		planID                       string
-		platformRegion               string
-		platformProvider             internal.CloudProvider
-		region                       string
-		multiZone                    bool
-		controlPlaneFailureTolerance string
+		planID                                 string
+		platformRegion                         string
+		platformProvider                       internal.CloudProvider
+		region                                 string
+		multiZone                              bool
+		controlPlaneFailureTolerance           string
+		useSmallerTrialAndFreemiumMachineTypes bool
 
 		expectedZonesCount                  *int
 		expectedProvider                    string
@@ -703,6 +704,17 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedSharedSubscription:          true,
 			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
 		},
+		"Regular trial with smaller machines": {
+			planID:                                 broker.TrialPlanID,
+			useSmallerTrialAndFreemiumMachineTypes: true,
+
+			expectedMinimalNumberOfNodes:        1,
+			expectedMaximumNumberOfNodes:        1,
+			expectedMachineType:                 "Standard_D2s_v5",
+			expectedProvider:                    "azure",
+			expectedSharedSubscription:          true,
+			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
+		},
 		"Freemium aws": {
 			planID:           broker.FreemiumPlanID,
 			platformProvider: internal.AWS,
@@ -714,6 +726,18 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedMachineType:                 "m5.xlarge",
 			expectedSubscriptionHyperscalerType: hyperscaler.AWS(),
 		},
+		"Freemium aws with smaller machines": {
+			planID:                                 broker.FreemiumPlanID,
+			platformProvider:                       internal.AWS,
+			useSmallerTrialAndFreemiumMachineTypes: true,
+
+			expectedMinimalNumberOfNodes:        1,
+			expectedMaximumNumberOfNodes:        1,
+			expectedProvider:                    "aws",
+			expectedSharedSubscription:          false,
+			expectedMachineType:                 "m6i.large",
+			expectedSubscriptionHyperscalerType: hyperscaler.AWS(),
+		},
 		"Freemium azure": {
 			planID:           broker.FreemiumPlanID,
 			platformProvider: internal.Azure,
@@ -723,6 +747,18 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedProvider:                    "azure",
 			expectedSharedSubscription:          false,
 			expectedMachineType:                 "Standard_D4s_v5",
+			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
+		},
+		"Freemium azure with smaller machines": {
+			planID:                                 broker.FreemiumPlanID,
+			platformProvider:                       internal.Azure,
+			useSmallerTrialAndFreemiumMachineTypes: true,
+
+			expectedMinimalNumberOfNodes:        1,
+			expectedMaximumNumberOfNodes:        1,
+			expectedProvider:                    "azure",
+			expectedSharedSubscription:          false,
+			expectedMachineType:                 "Standard_D2s_v5",
 			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
 		},
 		"Production Azure": {
@@ -809,7 +845,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 	} {
 		t.Run(tn, func(t *testing.T) {
 			// given
-			suite := NewProvisioningSuite(t, tc.multiZone, tc.controlPlaneFailureTolerance)
+			suite := NewProvisioningSuite(t, tc.multiZone, tc.controlPlaneFailureTolerance, tc.useSmallerTrialAndFreemiumMachineTypes)
 			defer suite.TearDown()
 
 			// when
@@ -847,7 +883,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 
 	t.Run("should apply default OIDC values when OIDC object is nil", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		defaultOIDC := fixture.FixOIDCConfigDTO()
 		expectedOIDC := gqlschema.OIDCConfigInput{
@@ -878,7 +914,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 
 	t.Run("should apply default OIDC values when all OIDC object's fields are empty", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		defaultOIDC := fixture.FixOIDCConfigDTO()
 		expectedOIDC := gqlschema.OIDCConfigInput{
@@ -912,7 +948,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 
 	t.Run("should apply provided OIDC configuration", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		providedOIDC := internal.OIDCConfigDTO{
 			ClientID:       "fake-client-id-1",
@@ -951,7 +987,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 
 	t.Run("should apply default OIDC values on empty OIDC params from input", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		providedOIDC := internal.OIDCConfigDTO{
 			ClientID:  "fake-client-id-1",
@@ -989,7 +1025,7 @@ func TestProvisioning_OIDCValues(t *testing.T) {
 func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 	t.Run("should use UserID as default value for admins list", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID: "fake-user-id",
@@ -1015,7 +1051,7 @@ func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 
 	t.Run("should apply new admins list", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID:        "fake-user-id",
@@ -1042,7 +1078,7 @@ func TestProvisioning_RuntimeAdministrators(t *testing.T) {
 
 	t.Run("should apply empty admin value (list is not empty)", func(t *testing.T) {
 		// given
-		suite := NewProvisioningSuite(t, false, "")
+		suite := NewProvisioningSuite(t, false, "", false)
 		defer suite.TearDown()
 		options := RuntimeOptions{
 			UserID:        "fake-user-id",

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -678,13 +678,13 @@ func TestProvisioning_HandleExistingOperation(t *testing.T) {
 
 func TestProvisioning_ClusterParameters(t *testing.T) {
 	for tn, tc := range map[string]struct {
-		planID                                 string
-		platformRegion                         string
-		platformProvider                       internal.CloudProvider
-		region                                 string
-		multiZone                              bool
-		controlPlaneFailureTolerance           string
-		useSmallerTrialAndFreemiumMachineTypes bool
+		planID                       string
+		platformRegion               string
+		platformProvider             internal.CloudProvider
+		region                       string
+		multiZone                    bool
+		controlPlaneFailureTolerance string
+		useSmallerMachineTypes       bool
 
 		expectedZonesCount                  *int
 		expectedProvider                    string
@@ -705,8 +705,8 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
 		},
 		"Regular trial with smaller machines": {
-			planID:                                 broker.TrialPlanID,
-			useSmallerTrialAndFreemiumMachineTypes: true,
+			planID:                 broker.TrialPlanID,
+			useSmallerMachineTypes: true,
 
 			expectedMinimalNumberOfNodes:        1,
 			expectedMaximumNumberOfNodes:        1,
@@ -727,9 +727,9 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedSubscriptionHyperscalerType: hyperscaler.AWS(),
 		},
 		"Freemium aws with smaller machines": {
-			planID:                                 broker.FreemiumPlanID,
-			platformProvider:                       internal.AWS,
-			useSmallerTrialAndFreemiumMachineTypes: true,
+			planID:                 broker.FreemiumPlanID,
+			platformProvider:       internal.AWS,
+			useSmallerMachineTypes: true,
 
 			expectedMinimalNumberOfNodes:        1,
 			expectedMaximumNumberOfNodes:        1,
@@ -750,9 +750,9 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedSubscriptionHyperscalerType: hyperscaler.Azure(),
 		},
 		"Freemium azure with smaller machines": {
-			planID:                                 broker.FreemiumPlanID,
-			platformProvider:                       internal.Azure,
-			useSmallerTrialAndFreemiumMachineTypes: true,
+			planID:                 broker.FreemiumPlanID,
+			platformProvider:       internal.Azure,
+			useSmallerMachineTypes: true,
 
 			expectedMinimalNumberOfNodes:        1,
 			expectedMaximumNumberOfNodes:        1,
@@ -845,7 +845,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 	} {
 		t.Run(tn, func(t *testing.T) {
 			// given
-			suite := NewProvisioningSuite(t, tc.multiZone, tc.controlPlaneFailureTolerance, tc.useSmallerTrialAndFreemiumMachineTypes)
+			suite := NewProvisioningSuite(t, tc.multiZone, tc.controlPlaneFailureTolerance, tc.useSmallerMachineTypes)
 			defer suite.TearDown()
 
 			// when

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -163,7 +163,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 			ProvisioningTimeout:         time.Minute,
 			URL:                         "http://localhost",
 			DefaultGardenerShootPurpose: "testing",
-		}, kymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults)
+		}, kymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
 	require.NoError(t, err)
 
 	reconcilerClient := reconciler.NewFakeClient()
@@ -576,7 +576,7 @@ func (s *ProvisioningSuite) TearDown() {
 	}
 }
 
-func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailureTolerance string) *ProvisioningSuite {
+func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailureTolerance string, useSmallerTrialAndFreemiumMachineTypes bool) *ProvisioningSuite {
 	defer func() {
 		if r := recover(); r != nil {
 			err := cleanupContainer()
@@ -628,7 +628,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 			DefaultGardenerShootPurpose:  "testing",
 			MultiZoneCluster:             multiZoneCluster,
 			ControlPlaneFailureTolerance: controlPlaneFailureTolerance,
-		}, defaultKymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults)
+		}, defaultKymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, useSmallerTrialAndFreemiumMachineTypes)
 	require.NoError(t, err)
 
 	server := avs.NewMockAvsServer(t)

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -163,7 +163,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 			ProvisioningTimeout:         time.Minute,
 			URL:                         "http://localhost",
 			DefaultGardenerShootPurpose: "testing",
-		}, kymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, cfg.Broker.UseSmallerTrialAndFreemiumMachineTypes)
+		}, kymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, cfg.Broker.UseSmallerMachineTypes)
 	require.NoError(t, err)
 
 	reconcilerClient := reconciler.NewFakeClient()
@@ -576,7 +576,7 @@ func (s *ProvisioningSuite) TearDown() {
 	}
 }
 
-func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailureTolerance string, useSmallerTrialAndFreemiumMachineTypes bool) *ProvisioningSuite {
+func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailureTolerance string, useSmallerMachineTypes bool) *ProvisioningSuite {
 	defer func() {
 		if r := recover(); r != nil {
 			err := cleanupContainer()
@@ -628,7 +628,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 			DefaultGardenerShootPurpose:  "testing",
 			MultiZoneCluster:             multiZoneCluster,
 			ControlPlaneFailureTolerance: controlPlaneFailureTolerance,
-		}, defaultKymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, useSmallerTrialAndFreemiumMachineTypes)
+		}, defaultKymaVer, map[string]string{"cf-eu10": "europe"}, cfg.FreemiumProviders, oidcDefaults, useSmallerMachineTypes)
 	require.NoError(t, err)
 
 	server := avs.NewMockAvsServer(t)

--- a/internal/appinfo/runtime_info.go
+++ b/internal/appinfo/runtime_info.go
@@ -157,7 +157,7 @@ func (h *RuntimeInfoHandler) planNameOrDefault(inst internal.InstanceWithOperati
 	if inst.ServicePlanName != "" {
 		return inst.ServicePlanName
 	}
-	return broker.Plans(h.plansConfig, "", false, false)[inst.ServicePlanID].Name
+	return broker.Plans(h.plansConfig, "", false, false, false)[inst.ServicePlanID].Name
 }
 
 func getIfNotZero(in time.Time) *time.Time {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -47,7 +47,8 @@ type Config struct {
 	SubaccountsIdsToShowTrialExpirationInfo string        `envconfig:"default="`
 	TrialDocsURL                            string        `envconfig:"default="`
 
-	Binding BindingConfig
+	Binding                                BindingConfig
+	UseSmallerTrialAndFreemiumMachineTypes bool `envconfig:"default=false"`
 }
 
 type ServicesConfig map[string]Service

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -47,8 +47,8 @@ type Config struct {
 	SubaccountsIdsToShowTrialExpirationInfo string        `envconfig:"default="`
 	TrialDocsURL                            string        `envconfig:"default="`
 
-	Binding                                BindingConfig
-	UseSmallerTrialAndFreemiumMachineTypes bool `envconfig:"default=false"`
+	Binding                BindingConfig
+	UseSmallerMachineTypes bool `envconfig:"default=false"`
 }
 
 type ServicesConfig map[string]Service

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -481,7 +481,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerTrialAndFreemiumMachineTypes)
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes)
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -481,7 +481,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerTrialAndFreemiumMachineTypes)
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -382,7 +382,7 @@ func (b *UpdateEndpoint) isKyma2(instance *internal.Instance) (bool, string, err
 }
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerTrialAndFreemiumMachineTypes)
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -382,7 +382,7 @@ func (b *UpdateEndpoint) isKyma2(instance *internal.Instance) (bool, string, err
 }
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerTrialAndFreemiumMachineTypes)
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes)
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -461,7 +461,7 @@ func unmarshalSchema(schema *RootSchema) *map[string]interface{} {
 
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
-func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, useSmallerTrialAndFreemiumMachineTypes bool) map[string]domain.ServicePlan {
+func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, useSmallerMachineTypes bool) map[string]domain.ServicePlan {
 	awsMachineNames := AwsMachinesNames()
 	awsMachinesDisplay := AwsMachinesDisplay()
 	awsRegionsDisplay := AWSRegionsDisplay()
@@ -477,7 +477,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	sapConvergedCloudMachinesDisplay := SapConvergedCloudMachinesDisplay()
 	sapConvergedCloudRegionsDisplay := SapConvergedCloudRegionsDisplay()
 
-	if !useSmallerTrialAndFreemiumMachineTypes {
+	if !useSmallerMachineTypes {
 		azureLiteMachinesNames = removeMachinesNamesFromList(awsMachineNames, "Standard_D2s_v5")
 		delete(azureLiteMachinesDisplay, "Standard_D2s_v5")
 	}

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -228,6 +228,7 @@ func AzureMachinesDisplay() map[string]string {
 
 func AzureLiteMachinesNames() []string {
 	return []string{
+		"Standard_D2s_v5",
 		"Standard_D4s_v5",
 		"Standard_D4_v3",
 	}
@@ -235,6 +236,7 @@ func AzureLiteMachinesNames() []string {
 
 func AzureLiteMachinesDisplay() map[string]string {
 	return map[string]string{
+		"Standard_D2s_v5": "Standard_D2s_v5 (2vCPU, 8GB RAM)",
 		"Standard_D4s_v5": "Standard_D4s_v5 (4vCPU, 16GB RAM)",
 		"Standard_D4_v3":  "Standard_D4_v3 (4vCPU, 16GB RAM)",
 	}
@@ -286,6 +288,20 @@ func SapConvergedCloudMachinesDisplay() map[string]string {
 		"g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
 		"g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)",
 	}
+}
+
+func removeMachinesNamesFromList(machinesNames []string, machinesNamesToRemove ...string) []string {
+	for i, machineName := range machinesNames {
+		for _, machineNameToRemove := range machinesNamesToRemove {
+			if machineName == machineNameToRemove {
+				copy(machinesNames[i:], machinesNames[i+1:])
+				machinesNames[len(machinesNames)-1] = ""
+				machinesNames = machinesNames[:len(machinesNames)-1]
+			}
+		}
+	}
+
+	return machinesNames
 }
 
 func requiredSchemaProperties() []string {
@@ -445,7 +461,7 @@ func unmarshalSchema(schema *RootSchema) *map[string]interface{} {
 
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
-func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool) map[string]domain.ServicePlan {
+func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, useSmallerTrialAndFreemiumMachineTypes bool) map[string]domain.ServicePlan {
 	awsMachineNames := AwsMachinesNames()
 	awsMachinesDisplay := AwsMachinesDisplay()
 	awsRegionsDisplay := AWSRegionsDisplay()
@@ -460,6 +476,11 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	sapConvergedCloudMachinesNames := SapConvergedCloudMachinesNames()
 	sapConvergedCloudMachinesDisplay := SapConvergedCloudMachinesDisplay()
 	sapConvergedCloudRegionsDisplay := SapConvergedCloudRegionsDisplay()
+
+	if !useSmallerTrialAndFreemiumMachineTypes {
+		azureLiteMachinesNames = removeMachinesNamesFromList(awsMachineNames, "Standard_D2s_v5")
+		delete(azureLiteMachinesDisplay, "Standard_D2s_v5")
+	}
 
 	awsSchema := AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, false, euAccessRestricted)
 	// awsHASchema := AWSHASchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false)

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -14,6 +14,12 @@ import (
 )
 
 func TestSchemaGenerator(t *testing.T) {
+	azureLiteMachineNamesReduced := AzureLiteMachinesNames()
+	azureLiteMachinesDisplayReduced := AzureLiteMachinesDisplay()
+
+	azureLiteMachineNamesReduced = removeMachinesNamesFromList(azureLiteMachineNamesReduced, "Standard_D2s_v5")
+	delete(azureLiteMachinesDisplayReduced, "Standard_D2s_v5")
+
 	tests := []struct {
 		name                string
 		generator           func(map[string]string, map[string]string, []string, bool, bool) *map[string]interface{}
@@ -95,6 +101,20 @@ func TestSchemaGenerator(t *testing.T) {
 			updateFileOIDC:      "update-azure-lite-schema-additional-params.json",
 		},
 		{
+			name: "AzureLite reduced schema is correct",
+			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, false)
+			},
+			machineTypes:        azureLiteMachineNamesReduced,
+			machineTypesDisplay: azureLiteMachinesDisplayReduced,
+			regionDisplay:       AzureRegionsDisplay(false),
+			path:                "azure",
+			file:                "azure-lite-schema-reduced.json",
+			updateFile:          "update-azure-lite-schema-reduced.json",
+			fileOIDC:            "azure-lite-schema-additional-params-reduced.json",
+			updateFileOIDC:      "update-azure-lite-schema-additional-params-reduced.json",
+		},
+		{
 			name: "AzureLite schema with EU access restriction is correct",
 			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return AzureLiteSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, true)
@@ -107,6 +127,20 @@ func TestSchemaGenerator(t *testing.T) {
 			updateFile:          "update-azure-lite-schema.json",
 			fileOIDC:            "azure-lite-schema-additional-params-eu.json",
 			updateFileOIDC:      "update-azure-lite-schema-additional-params.json",
+		},
+		{
+			name: "AzureLite reduced schema with EU access restriction is correct",
+			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return AzureLiteSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, true)
+			},
+			machineTypes:        azureLiteMachineNamesReduced,
+			machineTypesDisplay: azureLiteMachinesDisplayReduced,
+			regionDisplay:       AzureRegionsDisplay(true),
+			path:                "azure",
+			file:                "azure-lite-schema-eu-reduced.json",
+			updateFile:          "update-azure-lite-schema-reduced.json",
+			fileOIDC:            "azure-lite-schema-additional-params-eu-reduced.json",
+			updateFileOIDC:      "update-azure-lite-schema-additional-params-reduced.json",
 		},
 		{
 			name: "Freemium schema is correct",

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -54,7 +54,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion)) {
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.cfg.UseSmallerTrialAndFreemiumMachineTypes) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -54,7 +54,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 
 	provider, ok := middleware.ProviderFromContext(ctx)
 	platformRegion, ok := middleware.RegionFromContext(ctx)
-	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.cfg.UseSmallerTrialAndFreemiumMachineTypes) {
+	for _, plan := range Plans(class.Plans, provider, b.cfg.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.cfg.UseSmallerMachineTypes) {
 		// filter out not enabled plans
 		if _, exists := b.enabledPlanIDs[plan.ID]; !exists {
 			continue

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -7,10 +7,20 @@
     "autoScalerMin",
     "autoScalerMax",
     "modules",
-    "networking"
+    "networking",
+    "oidc",
+    "administrators"
   ],
   "_show_form_view": true,
   "properties": {
+    "administrators": {
+      "description": "Specifies the list of runtime administrators",
+      "items": {
+        "type": "string"
+      },
+      "title": "Administrators",
+      "type": "array"
+    },
     "autoScalerMax": {
       "default": 10,
       "description": "Specifies the maximum number of virtual machines to create",
@@ -26,12 +36,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],
@@ -147,28 +155,49 @@
       ],
       "type": "object"
     },
-    "region": {
-      "_enumDisplayName": {
-        "eastus": "eastus (US East, VA)",
-        "centralus": "centralus (US Central, IA)",
-        "westus2": "westus2 (US West, WA)",
-        "uksouth": "uksouth (UK South, London)",
-        "northeurope": "northeurope (Europe, Ireland)",
-        "westeurope": "westeurope (Europe, Netherlands)",
-        "japaneast": "japaneast (Japan, Tokyo)",
-        "southeastasia": "southeastasia (Asia Pacific, Singapore)",
-        "australiaeast": "australiaeast (Australia, Sydney)"
+    "oidc": {
+      "description": "OIDC configuration",
+      "properties": {
+        "clientID": {
+          "description": "The client ID for the OpenID Connect client.",
+          "type": "string"
+        },
+        "groupsClaim": {
+          "description": "If provided, the name of a custom OpenID Connect claim for specifying user groups.",
+          "type": "string"
+        },
+        "issuerURL": {
+          "description": "The URL of the OpenID issuer, only HTTPS scheme will be accepted.",
+          "type": "string"
+        },
+        "signingAlgs": {
+          "description": "Comma separated list of allowed JOSE asymmetric signing algorithms, for example, RS256, ES256",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "usernameClaim": {
+          "description": "The OpenID claim to use as the user name.",
+          "type": "string"
+        },
+        "usernamePrefix": {
+          "description": "If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-' (dash character without additional characters).",
+          "type": "string"
+        }
       },
+      "required": [
+        "clientID",
+        "issuerURL"
+      ],
+      "type": "object"
+    },
+    "region": {
+        "_enumDisplayName": {
+            "switzerlandnorth": "switzerlandnorth (Switzerland, Zurich)"
+        },
       "enum": [
-        "eastus",
-        "centralus",
-        "westus2",
-        "uksouth",
-        "northeurope",
-        "westeurope",
-        "japaneast",
-        "southeastasia",
-        "australiaeast"
+        "switzerlandnorth"
       ],
       "minLength": 1,
       "type": "string"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -36,10 +36,12 @@
     },
     "machineType":{
       "_enumDisplayName":{
+        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
+        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -7,10 +7,20 @@
     "autoScalerMin",
     "autoScalerMax",
     "modules",
-    "networking"
+    "networking",
+    "oidc",
+    "administrators"
   ],
   "_show_form_view": true,
   "properties": {
+    "administrators": {
+      "description": "Specifies the list of runtime administrators",
+      "items": {
+        "type": "string"
+      },
+      "title": "Administrators",
+      "type": "array"
+    },
     "autoScalerMax": {
       "default": 10,
       "description": "Specifies the maximum number of virtual machines to create",
@@ -26,12 +36,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],
@@ -144,6 +152,43 @@
       },
       "required": [
         "nodes"
+      ],
+      "type": "object"
+    },
+    "oidc": {
+      "description": "OIDC configuration",
+      "properties": {
+        "clientID": {
+          "description": "The client ID for the OpenID Connect client.",
+          "type": "string"
+        },
+        "groupsClaim": {
+          "description": "If provided, the name of a custom OpenID Connect claim for specifying user groups.",
+          "type": "string"
+        },
+        "issuerURL": {
+          "description": "The URL of the OpenID issuer, only HTTPS scheme will be accepted.",
+          "type": "string"
+        },
+        "signingAlgs": {
+          "description": "Comma separated list of allowed JOSE asymmetric signing algorithms, for example, RS256, ES256",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "usernameClaim": {
+          "description": "The OpenID claim to use as the user name.",
+          "type": "string"
+        },
+        "usernamePrefix": {
+          "description": "If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-' (dash character without additional characters).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientID",
+        "issuerURL"
       ],
       "type": "object"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -36,10 +36,12 @@
     },
     "machineType":{
       "_enumDisplayName":{
+        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
+        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -26,12 +26,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],
@@ -148,27 +146,11 @@
       "type": "object"
     },
     "region": {
-      "_enumDisplayName": {
-        "eastus": "eastus (US East, VA)",
-        "centralus": "centralus (US Central, IA)",
-        "westus2": "westus2 (US West, WA)",
-        "uksouth": "uksouth (UK South, London)",
-        "northeurope": "northeurope (Europe, Ireland)",
-        "westeurope": "westeurope (Europe, Netherlands)",
-        "japaneast": "japaneast (Japan, Tokyo)",
-        "southeastasia": "southeastasia (Asia Pacific, Singapore)",
-        "australiaeast": "australiaeast (Australia, Sydney)"
-      },
+        "_enumDisplayName": {
+            "switzerlandnorth": "switzerlandnorth (Switzerland, Zurich)"
+        },
       "enum": [
-        "eastus",
-        "centralus",
-        "westus2",
-        "uksouth",
-        "northeurope",
-        "westeurope",
-        "japaneast",
-        "southeastasia",
-        "australiaeast"
+        "switzerlandnorth"
       ],
       "minLength": 1,
       "type": "string"

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -26,10 +26,12 @@
     },
     "machineType":{
       "_enumDisplayName":{
+        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
+        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -26,12 +26,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -30,12 +30,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -20,12 +20,10 @@
     },
     "machineType":{
       "_enumDisplayName":{
-        "Standard_D2s_v5":"Standard_D2s_v5 (2vCPU, 8GB RAM)",
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
       "enum":[
-        "Standard_D2s_v5",
         "Standard_D4s_v5",
         "Standard_D4_v3"
       ],

--- a/internal/process/input/builder.go
+++ b/internal/process/input/builder.go
@@ -57,22 +57,22 @@ type (
 )
 
 type InputBuilderFactory struct {
-	kymaVersion                            string
-	config                                 Config
-	optComponentsSvc                       OptionalComponentService
-	componentsProvider                     ComponentListProvider
-	disabledComponentsProvider             DisabledComponentsProvider
-	configProvider                         ConfigurationProvider
-	trialPlatformRegionMapping             map[string]string
-	enabledFreemiumProviders               map[string]struct{}
-	oidcDefaultValues                      internal.OIDCConfigDTO
-	useSmallerTrialAndFreemiumMachineTypes bool
+	kymaVersion                string
+	config                     Config
+	optComponentsSvc           OptionalComponentService
+	componentsProvider         ComponentListProvider
+	disabledComponentsProvider DisabledComponentsProvider
+	configProvider             ConfigurationProvider
+	trialPlatformRegionMapping map[string]string
+	enabledFreemiumProviders   map[string]struct{}
+	oidcDefaultValues          internal.OIDCConfigDTO
+	useSmallerMachineTypes     bool
 }
 
 func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, disabledComponentsProvider DisabledComponentsProvider,
 	componentsListProvider ComponentListProvider, configProvider ConfigurationProvider,
 	config Config, defaultKymaVersion string, trialPlatformRegionMapping map[string]string,
-	enabledFreemiumProviders []string, oidcValues internal.OIDCConfigDTO, useSmallerTrialAndFreemiumMachineTypes bool) (CreatorForPlan, error) {
+	enabledFreemiumProviders []string, oidcValues internal.OIDCConfigDTO, useSmallerMachineTypes bool) (CreatorForPlan, error) {
 
 	freemiumProviders := map[string]struct{}{}
 	for _, p := range enabledFreemiumProviders {
@@ -80,16 +80,16 @@ func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, disabledC
 	}
 
 	return &InputBuilderFactory{
-		kymaVersion:                            defaultKymaVersion,
-		config:                                 config,
-		optComponentsSvc:                       optComponentsSvc,
-		componentsProvider:                     componentsListProvider,
-		disabledComponentsProvider:             disabledComponentsProvider,
-		configProvider:                         configProvider,
-		trialPlatformRegionMapping:             trialPlatformRegionMapping,
-		enabledFreemiumProviders:               freemiumProviders,
-		oidcDefaultValues:                      oidcValues,
-		useSmallerTrialAndFreemiumMachineTypes: useSmallerTrialAndFreemiumMachineTypes,
+		kymaVersion:                defaultKymaVersion,
+		config:                     config,
+		optComponentsSvc:           optComponentsSvc,
+		componentsProvider:         componentsListProvider,
+		disabledComponentsProvider: disabledComponentsProvider,
+		configProvider:             configProvider,
+		trialPlatformRegionMapping: trialPlatformRegionMapping,
+		enabledFreemiumProviders:   freemiumProviders,
+		oidcDefaultValues:          oidcValues,
+		useSmallerMachineTypes:     useSmallerMachineTypes,
 	}, nil
 }
 
@@ -218,13 +218,13 @@ func (f *InputBuilderFactory) forTrialPlan(provider *internal.CloudProvider) Hyp
 		}
 	case internal.AWS:
 		return &cloudProvider.AWSTrialInput{
-			PlatformRegionMapping:                  f.trialPlatformRegionMapping,
-			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+			PlatformRegionMapping:  f.trialPlatformRegionMapping,
+			UseSmallerMachineTypes: f.useSmallerMachineTypes,
 		}
 	default:
 		return &cloudProvider.AzureTrialInput{
-			PlatformRegionMapping:                  f.trialPlatformRegionMapping,
-			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+			PlatformRegionMapping:  f.trialPlatformRegionMapping,
+			UseSmallerMachineTypes: f.useSmallerMachineTypes,
 		}
 	}
 
@@ -429,11 +429,11 @@ func (f *InputBuilderFactory) forFreemiumPlan(provider internal.CloudProvider) (
 	switch provider {
 	case internal.AWS:
 		return &cloudProvider.AWSFreemiumInput{
-			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+			UseSmallerMachineTypes: f.useSmallerMachineTypes,
 		}, nil
 	case internal.Azure:
 		return &cloudProvider.AzureFreemiumInput{
-			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+			UseSmallerMachineTypes: f.useSmallerMachineTypes,
 		}, nil
 	default:
 		return nil, fmt.Errorf("provider %s is not supported", provider)

--- a/internal/process/input/builder.go
+++ b/internal/process/input/builder.go
@@ -57,21 +57,22 @@ type (
 )
 
 type InputBuilderFactory struct {
-	kymaVersion                string
-	config                     Config
-	optComponentsSvc           OptionalComponentService
-	componentsProvider         ComponentListProvider
-	disabledComponentsProvider DisabledComponentsProvider
-	configProvider             ConfigurationProvider
-	trialPlatformRegionMapping map[string]string
-	enabledFreemiumProviders   map[string]struct{}
-	oidcDefaultValues          internal.OIDCConfigDTO
+	kymaVersion                            string
+	config                                 Config
+	optComponentsSvc                       OptionalComponentService
+	componentsProvider                     ComponentListProvider
+	disabledComponentsProvider             DisabledComponentsProvider
+	configProvider                         ConfigurationProvider
+	trialPlatformRegionMapping             map[string]string
+	enabledFreemiumProviders               map[string]struct{}
+	oidcDefaultValues                      internal.OIDCConfigDTO
+	useSmallerTrialAndFreemiumMachineTypes bool
 }
 
 func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, disabledComponentsProvider DisabledComponentsProvider,
 	componentsListProvider ComponentListProvider, configProvider ConfigurationProvider,
 	config Config, defaultKymaVersion string, trialPlatformRegionMapping map[string]string,
-	enabledFreemiumProviders []string, oidcValues internal.OIDCConfigDTO) (CreatorForPlan, error) {
+	enabledFreemiumProviders []string, oidcValues internal.OIDCConfigDTO, useSmallerTrialAndFreemiumMachineTypes bool) (CreatorForPlan, error) {
 
 	freemiumProviders := map[string]struct{}{}
 	for _, p := range enabledFreemiumProviders {
@@ -79,15 +80,16 @@ func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, disabledC
 	}
 
 	return &InputBuilderFactory{
-		kymaVersion:                defaultKymaVersion,
-		config:                     config,
-		optComponentsSvc:           optComponentsSvc,
-		componentsProvider:         componentsListProvider,
-		disabledComponentsProvider: disabledComponentsProvider,
-		configProvider:             configProvider,
-		trialPlatformRegionMapping: trialPlatformRegionMapping,
-		enabledFreemiumProviders:   freemiumProviders,
-		oidcDefaultValues:          oidcValues,
+		kymaVersion:                            defaultKymaVersion,
+		config:                                 config,
+		optComponentsSvc:                       optComponentsSvc,
+		componentsProvider:                     componentsListProvider,
+		disabledComponentsProvider:             disabledComponentsProvider,
+		configProvider:                         configProvider,
+		trialPlatformRegionMapping:             trialPlatformRegionMapping,
+		enabledFreemiumProviders:               freemiumProviders,
+		oidcDefaultValues:                      oidcValues,
+		useSmallerTrialAndFreemiumMachineTypes: useSmallerTrialAndFreemiumMachineTypes,
 	}, nil
 }
 
@@ -216,11 +218,13 @@ func (f *InputBuilderFactory) forTrialPlan(provider *internal.CloudProvider) Hyp
 		}
 	case internal.AWS:
 		return &cloudProvider.AWSTrialInput{
-			PlatformRegionMapping: f.trialPlatformRegionMapping,
+			PlatformRegionMapping:                  f.trialPlatformRegionMapping,
+			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
 		}
 	default:
 		return &cloudProvider.AzureTrialInput{
-			PlatformRegionMapping: f.trialPlatformRegionMapping,
+			PlatformRegionMapping:                  f.trialPlatformRegionMapping,
+			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
 		}
 	}
 
@@ -424,9 +428,13 @@ func (f *InputBuilderFactory) forFreemiumPlan(provider internal.CloudProvider) (
 	}
 	switch provider {
 	case internal.AWS:
-		return &cloudProvider.AWSFreemiumInput{}, nil
+		return &cloudProvider.AWSFreemiumInput{
+			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+		}, nil
 	case internal.Azure:
-		return &cloudProvider.AzureFreemiumInput{}, nil
+		return &cloudProvider.AzureFreemiumInput{
+			UseSmallerTrialAndFreemiumMachineTypes: f.useSmallerTrialAndFreemiumMachineTypes,
+		}, nil
 	default:
 		return nil, fmt.Errorf("provider %s is not supported", provider)
 	}

--- a/internal/process/input/builder_test.go
+++ b/internal/process/input/builder_test.go
@@ -24,7 +24,7 @@ func TestInputBuilderFactory_IsPlanSupport(t *testing.T) {
 	configProvider := mockConfigProvider()
 
 	ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-		configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+		configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 
 	// when/then
@@ -46,7 +46,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 
@@ -76,7 +76,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 
@@ -101,7 +101,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 
@@ -125,7 +125,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "PR-1")
 
@@ -147,7 +147,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 
@@ -186,7 +186,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 
@@ -229,7 +229,7 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		configProvider := mockConfigProvider()
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
-			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			configProvider, Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")
 		provider = &cloudProvider.GcpInput{} // for broker.GCPPlanID

--- a/internal/process/input/input_test.go
+++ b/internal/process/input/input_test.go
@@ -45,7 +45,7 @@ func TestShouldEnableComponents(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(runtime.NewOptionalComponentsService(optionalComponentsDisablers), runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		pp := fixProvisioningParameters(broker.AzurePlanID, "")
@@ -89,7 +89,7 @@ func TestShouldEnableComponents(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(runtime.NewOptionalComponentsService(optionalComponentsDisablers), runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		pp := fixProvisioningParameters(broker.AzurePlanID, "1.14.0")
@@ -134,7 +134,7 @@ func TestShouldDisableComponents(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(runtime.NewOptionalComponentsService(optionalComponentsDisablers), runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "1.10.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestShouldDisableComponents(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(runtime.NewOptionalComponentsService(optionalComponentsDisablers), runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateUpgradeInput(pp, internal.RuntimeVersionData{Version: "1.14.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestDisabledComponentsForPlanNotExist(t *testing.T) {
 
 	builder, err := NewInputBuilderFactory(runtime.NewOptionalComponentsService(optionalComponentsDisablers), runtime.NewDisabledComponentsProvider(),
 		componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-		fixture.FixOIDCConfigDTO())
+		fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 	// when
 	_, err = builder.CreateProvisionInput(pp, emptyVersion)
@@ -238,7 +238,7 @@ func TestInputBuilderFactoryOverrides(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(dummyOptComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "1.10.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestInputBuilderFactoryOverrides(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "1.10.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -322,7 +322,7 @@ func TestInputBuilderFactoryOverrides(t *testing.T) {
 		pp := fixProvisioningParameters(broker.AzurePlanID, "1.14.0")
 		builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateUpgradeInput(pp, internal.RuntimeVersionData{Version: "1.14.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestInputBuilderFactoryOverrides(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(dummyOptComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important", fixTrialRegionMapping(), fixTrialProviders(),
-			fixture.FixOIDCConfigDTO())
+			fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "1.10.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 
 	factory, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 		componentsProvider, configProvider, config, "1.10.0",
-		fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+		fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 	pp := fixProvisioningParameters(broker.AzurePlanID, "")
 
@@ -515,7 +515,7 @@ func TestShouldAdjustRuntimeName(t *testing.T) {
 
 			builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 				componentsProvider, configProvider, Config{TrialNodesNumber: 0}, "not-important", fixTrialRegionMapping(),
-				fixTrialProviders(), fixture.FixOIDCConfigDTO())
+				fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 			assert.NoError(t, err)
 
 			pp := fixProvisioningParameters(broker.TrialPlanID, "")
@@ -554,7 +554,7 @@ func TestShouldSetNumberOfNodesForTrialPlan(t *testing.T) {
 
 	builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 		componentsProvider, configProvider, Config{TrialNodesNumber: 2}, "not-important",
-		fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+		fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 
 	pp := fixProvisioningParameters(broker.TrialPlanID, "")
@@ -585,7 +585,7 @@ func TestShouldSetGlobalConfiguration(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		pp := fixProvisioningParameters(broker.TrialPlanID, "")
@@ -613,7 +613,7 @@ func TestShouldSetGlobalConfiguration(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		pp := fixProvisioningParameters(broker.TrialPlanID, "")
@@ -658,7 +658,7 @@ func TestCreateProvisionRuntimeInput_ConfigureDNS(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.4", fixTrialRegionMapping(),
-			fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -694,7 +694,7 @@ func TestCreateProvisionRuntimeInput_ConfigureDNS(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.4",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -740,7 +740,7 @@ func TestCreateProvisionRuntimeInput_ConfigureOIDC(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -780,7 +780,7 @@ func TestCreateProvisionRuntimeInput_ConfigureOIDC(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -821,7 +821,7 @@ func TestCreateProvisionRuntimeInput_ConfigureOIDC(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -872,7 +872,7 @@ func TestCreateClusterConfiguration_Overrides(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -954,7 +954,7 @@ func TestCreateClusterConfiguration_Overrides(t *testing.T) {
 
 		builder, err := NewInputBuilderFactory(dummyOptComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "not-important",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 		creator, err := builder.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "1.10.0", Origin: internal.Defaults})
 		require.NoError(t, err)
@@ -1005,7 +1005,7 @@ func TestCreateProvisionRuntimeInput_ConfigureAdmins(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -1040,7 +1040,7 @@ func TestCreateProvisionRuntimeInput_ConfigureAdmins(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -1099,7 +1099,7 @@ func TestCreateUpgradeRuntimeInput_ConfigureAdmins(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -1137,7 +1137,7 @@ func TestCreateUpgradeRuntimeInput_ConfigureAdmins(t *testing.T) {
 
 		inputBuilder, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		provisioningParams := fixture.FixProvisioningParameters(id)
@@ -1173,7 +1173,7 @@ func TestCreateUpgradeShootInput_ConfigureAutoscalerParams(t *testing.T) {
 
 		ibf, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		//ar provider HyperscalerInputProvider
@@ -1215,7 +1215,7 @@ func TestCreateUpgradeShootInput_ConfigureAutoscalerParams(t *testing.T) {
 
 		ibf, err := NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(),
 			componentsProvider, configProvider, Config{}, "1.24.0",
-			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+			fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO(), false)
 		assert.NoError(t, err)
 
 		pp := fixProvisioningParameters(broker.GCPPlanID, "")

--- a/internal/process/provisioning/create_runtime_for_own_cluster_step_test.go
+++ b/internal/process/provisioning/create_runtime_for_own_cluster_step_test.go
@@ -178,7 +178,7 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 			AutoUpdateMachineImageVersion: autoUpdateMachineImageVersion,
 			MultiZoneCluster:              true,
 			ControlPlaneFailureTolerance:  "zone",
-		}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO())
+		}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 
 	pp := internal.ProvisioningParameters{

--- a/internal/process/update/upgrade_shoot_step_test.go
+++ b/internal/process/update/upgrade_shoot_step_test.go
@@ -123,7 +123,7 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 		componentsProvider, configProvider, input.Config{
 			KubernetesVersion:           k8sVersion,
 			DefaultGardenerShootPurpose: "test",
-		}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO())
+		}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO(), false)
 	assert.NoError(t, err)
 
 	pp := internal.ProvisioningParameters{

--- a/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -144,7 +144,7 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 			TrialNodesNumber:              1,
 			AutoUpdateKubernetesVersion:   fixAutoUpdateKubernetesVersion,
 			AutoUpdateMachineImageVersion: fixAutoUpdateMachineImageVersion,
-		}, fixKymaVersion, nil, nil, fixture.FixOIDCConfigDTO())
+		}, fixKymaVersion, nil, nil, fixture.FixOIDCConfigDTO(), false)
 	require.NoError(t, err, "Input factory creation error")
 
 	ver := internal.RuntimeVersionData{

--- a/internal/provider/aws_provider.go
+++ b/internal/provider/aws_provider.go
@@ -23,7 +23,6 @@ const (
 	DefaultAWSMultiZoneCount      = 3
 	DefaultAWSMachineType         = "m6i.large"
 	DefaultOldAWSTrialMachineType = "m5.xlarge"
-	DefaultAWSTrialMachineType    = "m6i.large"
 )
 
 var europeAWS = "eu-west-1"

--- a/internal/provider/aws_provider.go
+++ b/internal/provider/aws_provider.go
@@ -42,11 +42,11 @@ type (
 		ControlPlaneFailureTolerance string
 	}
 	AWSTrialInput struct {
-		PlatformRegionMapping                  map[string]string
-		UseSmallerTrialAndFreemiumMachineTypes bool
+		PlatformRegionMapping  map[string]string
+		UseSmallerMachineTypes bool
 	}
 	AWSFreemiumInput struct {
-		UseSmallerTrialAndFreemiumMachineTypes bool
+		UseSmallerMachineTypes bool
 	}
 )
 
@@ -241,12 +241,12 @@ func (p *AWSInput) Provider() internal.CloudProvider {
 }
 
 func (p *AWSTrialInput) Defaults() *gqlschema.ClusterConfigInput {
-	return awsLiteDefaults(DefaultAWSTrialRegion, p.UseSmallerTrialAndFreemiumMachineTypes)
+	return awsLiteDefaults(DefaultAWSTrialRegion, p.UseSmallerMachineTypes)
 }
 
-func awsLiteDefaults(region string, useSmallerTrialAndFreemiumMachineTypes bool) *gqlschema.ClusterConfigInput {
+func awsLiteDefaults(region string, useSmallerMachineTypes bool) *gqlschema.ClusterConfigInput {
 	machineType := DefaultOldAWSTrialMachineType
-	if useSmallerTrialAndFreemiumMachineTypes {
+	if useSmallerMachineTypes {
 		machineType = DefaultAWSMachineType
 	}
 	return &gqlschema.ClusterConfigInput{
@@ -310,7 +310,7 @@ func (p *AWSTrialInput) Provider() internal.CloudProvider {
 
 func (p *AWSFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
 	// Lite (freemium) must have the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
-	defaults := awsLiteDefaults(DefaultAWSRegion, p.UseSmallerTrialAndFreemiumMachineTypes)
+	defaults := awsLiteDefaults(DefaultAWSRegion, p.UseSmallerMachineTypes)
 
 	return defaults
 }

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -40,7 +40,9 @@ type (
 		MultiZone                    bool
 		ControlPlaneFailureTolerance string
 	}
-	AzureLiteInput  struct{}
+	AzureLiteInput struct {
+		UseSmallerTrialAndFreemiumMachineTypes bool
+	}
 	AzureTrialInput struct {
 		PlatformRegionMapping                  map[string]string
 		UseSmallerTrialAndFreemiumMachineTypes bool
@@ -124,11 +126,15 @@ func (p *AzureInput) Provider() internal.CloudProvider {
 }
 
 func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
+	machineType := DefaultOldAzureTrialMachineType
+	if p.UseSmallerTrialAndFreemiumMachineTypes {
+		machineType = DefaultAzureMachineType
+	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("Standard_LRS"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "Standard_D4s_v5",
+			MachineType:    machineType,
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",
 			WorkerCidr:     networking.DefaultNodesCIDR,

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -20,7 +20,6 @@ const (
 	DefaultAzureMultiZoneCount      = 3
 	DefaultAzureMachineType         = "Standard_D2s_v5"
 	DefaultOldAzureTrialMachineType = "Standard_D4s_v5"
-	DefaultAzureTrialMachineType    = "Standard_D2s_v5"
 )
 
 var europeAzure = "westeurope"

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -41,14 +41,14 @@ type (
 		ControlPlaneFailureTolerance string
 	}
 	AzureLiteInput struct {
-		UseSmallerTrialAndFreemiumMachineTypes bool
+		UseSmallerMachineTypes bool
 	}
 	AzureTrialInput struct {
-		PlatformRegionMapping                  map[string]string
-		UseSmallerTrialAndFreemiumMachineTypes bool
+		PlatformRegionMapping  map[string]string
+		UseSmallerMachineTypes bool
 	}
 	AzureFreemiumInput struct {
-		UseSmallerTrialAndFreemiumMachineTypes bool
+		UseSmallerMachineTypes bool
 	}
 )
 
@@ -127,7 +127,7 @@ func (p *AzureInput) Provider() internal.CloudProvider {
 
 func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
 	machineType := DefaultOldAzureTrialMachineType
-	if p.UseSmallerTrialAndFreemiumMachineTypes {
+	if p.UseSmallerMachineTypes {
 		machineType = DefaultAzureMachineType
 	}
 	return &gqlschema.ClusterConfigInput{
@@ -185,12 +185,12 @@ func (p *AzureLiteInput) Provider() internal.CloudProvider {
 }
 
 func (p *AzureTrialInput) Defaults() *gqlschema.ClusterConfigInput {
-	return azureTrialDefaults(p.UseSmallerTrialAndFreemiumMachineTypes)
+	return azureTrialDefaults(p.UseSmallerMachineTypes)
 }
 
-func azureTrialDefaults(useSmallerTrialAndFreemiumMachineTypes bool) *gqlschema.ClusterConfigInput {
+func azureTrialDefaults(useSmallerMachineTypes bool) *gqlschema.ClusterConfigInput {
 	machineType := DefaultOldAzureTrialMachineType
-	if useSmallerTrialAndFreemiumMachineTypes {
+	if useSmallerMachineTypes {
 		machineType = DefaultAzureMachineType
 	}
 	return &gqlschema.ClusterConfigInput{
@@ -255,7 +255,7 @@ func (p *AzureTrialInput) Profile() gqlschema.KymaProfile {
 }
 
 func (p *AzureFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
-	return azureTrialDefaults(p.UseSmallerTrialAndFreemiumMachineTypes)
+	return azureTrialDefaults(p.UseSmallerMachineTypes)
 }
 
 func (p *AzureFreemiumInput) ApplyParameters(input *gqlschema.ClusterConfigInput, params internal.ProvisioningParameters) {

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -414,6 +414,8 @@ spec:
               value: /config/freemiumWhitelistedGlobalAccountIds.yaml
             - name: APP_KYMA_RESOURCE_DELETION_TIMEOUT
               value: "{{ .Values.kymaResourceDeletionTimeout }}"
+            - name: APP_BROKER_USE_SMALLER_TRIAL_AND_FREEMIUM_MACHINE_TYPES
+              value: "{{ .Values.includeNewMachineTypesInSchema }}"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -414,8 +414,8 @@ spec:
               value: /config/freemiumWhitelistedGlobalAccountIds.yaml
             - name: APP_KYMA_RESOURCE_DELETION_TIMEOUT
               value: "{{ .Values.kymaResourceDeletionTimeout }}"
-            - name: APP_BROKER_USE_SMALLER_TRIAL_AND_FREEMIUM_MACHINE_TYPES
-              value: "{{ .Values.includeNewMachineTypesInSchema }}"
+            - name: APP_BROKER_USE_SMALLER_MACHINE_TYPES
+              value: "{{ .Values.useSmallerMachineTypes }}"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -228,7 +228,7 @@ freeExpirationPeriod: 720h
 onlyOneFreePerGA: "false"
 subaccountsIdsToShowTrialExpirationInfo: "a45be5d8-eddc-4001-91cf-48cc644d571f"
 trialDocsURL: "https://help.sap.com/docs/"
-useSmallerTrialAndFreemiumMachineTypes: "false"
+useSmallerMachineTypes: "false"
 
 osbUpdateProcessingEnabled: "false"
 

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -228,6 +228,7 @@ freeExpirationPeriod: 720h
 onlyOneFreePerGA: "false"
 subaccountsIdsToShowTrialExpirationInfo: "a45be5d8-eddc-4001-91cf-48cc644d571f"
 trialDocsURL: "https://help.sap.com/docs/"
+useSmallerTrialAndFreemiumMachineTypes: "false"
 
 osbUpdateProcessingEnabled: "false"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Use Standard_D2s_v5 in Azure freemium and trial plan
- Use Standard_D2s_v5 in Azure lite as the default machine
- Use m6i.large in AWS freemium and trial plan
- Add a feature flag for this change

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #745 