### PR TITLE
Fix Azure lites machine types

### DIFF
--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -478,7 +478,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	sapConvergedCloudRegionsDisplay := SapConvergedCloudRegionsDisplay()
 
 	if !useSmallerMachineTypes {
-		azureLiteMachinesNames = removeMachinesNamesFromList(awsMachineNames, "Standard_D2s_v5")
+		azureLiteMachinesNames = removeMachinesNamesFromList(azureLiteMachinesNames, "Standard_D2s_v5")
 		delete(azureLiteMachinesDisplay, "Standard_D2s_v5")
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

#788 introduced a bug that would assign the wrong machine types to Azure lite when using old machine types. 

Changes proposed in this pull request:
- Use proper machine types in Azure lite plan

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
