### PR TITLE
Handling missing subaccount label in Kyma CR

### DIFF
--- a/internal/subaccountsync/informer.go
+++ b/internal/subaccountsync/informer.go
@@ -19,11 +19,11 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("added Kyma resource is not an Unstructured: %s", obj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled := getDataFromLabels(u)
-			if subaccountID == "" {
-				logger.Error(fmt.Sprintf("added Kyma resource has no subaccount label: %s", u.GetName()))
+			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler)
+			if err != nil {
 				return
 			}
+
 			stateReconciler.reconcileResourceUpdate(subaccountIDType(subaccountID), runtimeIDType(runtimeID), runtimeStateType{betaEnabled: betaEnabled})
 			data, err := stateReconciler.accountsClient.GetSubaccountData(subaccountID)
 			if err != nil {
@@ -39,9 +39,8 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("updated Kyma resource is not an Unstructured: %s", newObj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled := getDataFromLabels(u)
-			if subaccountID == "" {
-				logger.Error(fmt.Sprintf("updated Kyma resource has no subaccount label: %s", u.GetName()))
+			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler)
+			if err != nil {
 				return
 			}
 			if !reflect.DeepEqual(oldObj.(*unstructured.Unstructured).GetLabels(), u.GetLabels()) {

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -3,6 +3,7 @@ package subaccountsync
 import (
 	"context"
 	"fmt"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -189,11 +190,42 @@ func CreateEventsClient(ctx context.Context, eventsConfig CisEndpointConfig, log
 }
 
 func getDataFromLabels(u *unstructured.Unstructured) (subaccountID string, runtimeID string, betaEnabled string) {
-	labels := u.GetLabels()
-	subaccountID = labels[subaccountIDLabel]
-	runtimeID = labels[runtimeIDLabel]
-	betaEnabled = labels[betaEnabledLabel]
 	return
+}
+
+func getSubaccountIDFromDB(runtimeID string, db storage.BrokerStorage) (string, error) {
+	runtimeIDFilter := dbmodel.InstanceFilter{RuntimeIDs: []string{runtimeID}}
+	instances, _, _, err := db.Instances().List(runtimeIDFilter)
+	if err != nil {
+		return "", err
+	}
+	if len(instances) == 0 {
+		return "", fmt.Errorf("no instances found for runtime ID %s", runtimeID)
+	}
+	if len(instances) > 1 {
+		return "", fmt.Errorf("multiple instances found for runtime ID %s", runtimeID)
+	}
+	subaccountID := instances[0].SubAccountID
+	return subaccountID, nil
+}
+
+func getRequiredData(u *unstructured.Unstructured, logger *slog.Logger, stateReconciler *stateReconcilerType) (string, string, string, error) {
+	labels := u.GetLabels()
+	subaccountID := labels[subaccountIDLabel]
+	runtimeID := labels[runtimeIDLabel]
+	betaEnabled := labels[betaEnabledLabel]
+	if runtimeID == "" {
+		logger.Warn(fmt.Sprintf("Kyma resource has no runtime label, falling back to resource name: %s", u.GetName()))
+		runtimeID = u.GetName()
+	}
+	var err error
+	if subaccountID == "" {
+		subaccountID, err = getSubaccountIDFromDB(runtimeID, stateReconciler.db)
+		if err != nil {
+			return "", "", "", fmt.Errorf("cannot determine subaccountID for Kyma resource: %s - %s", u.GetName(), err)
+		}
+	}
+	return subaccountID, runtimeID, betaEnabled, nil
 }
 
 func fatalOnError(err error) {

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -3,11 +3,12 @@ package subaccountsync
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/kymacustomresource"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

On non-dev landscapes there are Kyma CRs without subaccountID label, so we need to get the subaccountID from DB.

Changes proposed in this pull request:

- Getting subaccountID from DB as fallback (if label is not present)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
