### PR TITLE
Configurable strategy for runtimeID to subaccountID mapping

### DIFF
--- a/cmd/subaccountsync/main.go
+++ b/cmd/subaccountsync/main.go
@@ -56,6 +56,7 @@ func main() {
 	slog.Info(fmt.Sprintf("Configuration: events window size:%s, events sync interval:%s, accounts sync interval: %s, storage sync interval: %s, queue sleep interval: %s",
 		cfg.EventsWindowSize, cfg.EventsWindowInterval, cfg.AccountsSyncInterval, cfg.StorageSyncInterval, cfg.SyncQueueSleepInterval))
 	slog.Info(fmt.Sprintf("Configuration: updateResources: %t", cfg.UpdateResources))
+	slog.Info(fmt.Sprintf("Configuration: alwaysSubaccountFromDatabase: %t", cfg.AlwaysSubaccountFromDatabase))
 
 	if cfg.EventsWindowSize < cfg.EventsWindowInterval {
 		slog.Warn("Events window size is smaller than events sync interval. This might cause missing events so we set window size to the interval.")

--- a/internal/subaccountsync/config.go
+++ b/internal/subaccountsync/config.go
@@ -22,6 +22,7 @@ type (
 		MetricsPort                       string        `envconfig:"default=8081"`
 		LogLevel                          string        `envconfig:"default=info"`
 		RuntimeConfigurationConfigMapName string
+		AlwaysSubaccountFromDatabase      bool `envconfig:"default=false"`
 	}
 
 	CisEndpointConfig struct {

--- a/internal/subaccountsync/informer.go
+++ b/internal/subaccountsync/informer.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *stateReconcilerType, logger *slog.Logger, metrics *Metrics) {
+func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *stateReconcilerType, logger *slog.Logger, metrics *Metrics, alwaysUseDB bool) {
 	_, err := (*informer).AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			metrics.informer.With(prometheus.Labels{"event": "add"}).Inc()
@@ -19,7 +19,7 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("added Kyma resource is not an Unstructured: %s", obj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler)
+			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
 			if err != nil {
 				return
 			}
@@ -39,7 +39,7 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("updated Kyma resource is not an Unstructured: %s", newObj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler)
+			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
 			if err != nil {
 				return
 			}

--- a/resources/keb/templates/subaccount-sync-deployment.yaml
+++ b/resources/keb/templates/subaccount-sync-deployment.yaml
@@ -38,6 +38,8 @@ spec:
               value: {{ .Values.subaccountSync.logLevel | quote }}
             - name: SUBACCOUNT_SYNC_UPDATE_RESOURCES
               value: {{ .Values.subaccountSync.updateResources | quote }}
+            - name: SUBACCOUNT_SYNC_ALWAYS_SUBACCOUNT_FROM_DATABASE
+              value: {{ .Values.subaccountSync.alwaysSubaccountFromDatabase | quote }}
             - name: SUBACCOUNT_SYNC_ACCOUNTS_SYNC_INTERVAL
               value: {{ .Values.subaccountSync.accountSyncInterval | quote }}
             - name: SUBACCOUNT_SYNC_STORAGE_SYNC_INTERVAL

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -387,6 +387,7 @@ deprovisionRetrigger:
 subaccountSync:
   enabled: true
   updateResources: false
+  alwaysSubaccountFromDatabase: false
   accountSyncInterval: 24h
   storageSyncInterval: 5m
   eventsWindowSize: 20m
@@ -401,7 +402,6 @@ subaccountSync:
     accounts:
       rateLimitingInterval: 2s
       maxRequestsPerInterval: 5
-  alwaysSubaccountFromDatabase: false
 
 serviceMonitor:
   enabled: true

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -401,6 +401,7 @@ subaccountSync:
     accounts:
       rateLimitingInterval: 2s
       maxRequestsPerInterval: 5
+  alwaysSubaccountFromDatabase: false
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We fetch runtimeID and subaccountID label from Kyma CR. If subaccountID label is not present, we use DB (`instances` table) to get subaccountID.
Introduced flag allows to fetch subaccountID from DB always, disregarding label value.


Changes proposed in this pull request:

- Configuration flag (defaulting to false)
- logic based on flag value fetching subaccountID either always from DB or only in case this label is not present in Kyma CR 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
 #693 