### PR TITLE
EU Whitelist Refactoring

### DIFF
--- a/internal/utils/testdata/embedded_object.yaml
+++ b/internal/utils/testdata/embedded_object.yaml
@@ -1,0 +1,5 @@
+obj:
+  prop1: 
+    another_obj:
+      prop2: value2
+      prop3: value3

--- a/internal/utils/testdata/list_of_string_in_property.yaml
+++ b/internal/utils/testdata/list_of_string_in_property.yaml
@@ -1,0 +1,3 @@
+prop:
+  - string-1
+  - string-2

--- a/internal/utils/testdata/multiple_mappings.yaml
+++ b/internal/utils/testdata/multiple_mappings.yaml
@@ -1,0 +1,6 @@
+key1:
+  - value1
+  - value2
+key2:
+  - value3
+  - value4

--- a/internal/utils/testdata/multiple_mappings_override.yaml
+++ b/internal/utils/testdata/multiple_mappings_override.yaml
@@ -1,0 +1,9 @@
+key1:
+  - value1
+  - value2
+key2:
+  - value3
+  - value4
+key1:
+  - value5
+  - value6

--- a/internal/utils/yaml.go
+++ b/internal/utils/yaml.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+func UnmarshalYamlFile(filename string, out interface{}) error {
+	var fileBytes, err = os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("while reading a %s file : %w", filename, err)
+	}
+
+	err = yaml.Unmarshal(fileBytes, out)
+	if err != nil {
+		return fmt.Errorf("while unmarshaling yaml data: %w", err)
+	}
+
+	return nil
+}

--- a/internal/utils/yaml_test.go
+++ b/internal/utils/yaml_test.go
@@ -10,34 +10,33 @@ import (
 func TestUnmarshalingFromYamlFile(t *testing.T) {
 
 	tests := []struct {
-		name string
+		name     string
 		filename string
 		expected interface{}
-		data interface{}
+		data     interface{}
 	}{
 		{
-			name: "correctly unmarshals yaml file with list of strings",
+			name:     "correctly unmarshals yaml file with list of strings",
 			filename: "testdata/list_of_string_in_property.yaml",
-			data: &map[string][]string{},
+			data:     &map[string][]string{},
 			expected: &map[string][]string{"prop": {"string-1", "string-2"}},
 		},
 		{
-			name: "correctly unmarshals yaml file with embedded object",
+			name:     "correctly unmarshals yaml file with embedded object",
 			filename: "testdata/embedded_object.yaml",
-			data: &map[string]interface{}{},
-			expected: &map[string]interface{}{"obj": map[interface{}]interface{}{"prop1": 
-				map[interface{}]interface{} {"another_obj": map[interface{}]interface{}{"prop2": "value2", "prop3":"value3"}}}},
+			data:     &map[string]interface{}{},
+			expected: &map[string]interface{}{"obj": map[interface{}]interface{}{"prop1": map[interface{}]interface{}{"another_obj": map[interface{}]interface{}{"prop2": "value2", "prop3": "value3"}}}},
 		},
 		{
-			name: "correctly unmarshals yaml file with mapping of strings to list of strings",
+			name:     "correctly unmarshals yaml file with mapping of strings to list of strings",
 			filename: "testdata/multiple_mappings.yaml",
-			data: &map[string][]string{},
+			data:     &map[string][]string{},
 			expected: &map[string][]string{"key1": {"value1", "value2"}, "key2": {"value3", "value4"}},
 		},
 		{
-			name: "overrides already defined keys wile unmarshalling yaml file with mapping of strings to list of strings",
+			name:     "overrides already defined keys wile unmarshalling yaml file with mapping of strings to list of strings",
 			filename: "testdata/multiple_mappings_override.yaml",
-			data: &map[string][]string{},
+			data:     &map[string][]string{},
 			expected: &map[string][]string{"key1": {"value5", "value6"}, "key2": {"value3", "value4"}},
 		},
 	}
@@ -45,11 +44,10 @@ func TestUnmarshalingFromYamlFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// given/when
 			err := UnmarshalYamlFile(tt.filename, tt.data)
-	
+
 			// then
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, tt.data)
 		})
 	}
 }
-

--- a/internal/utils/yaml_test.go
+++ b/internal/utils/yaml_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalingFromYamlFile(t *testing.T) {
+
+	tests := []struct {
+		name string
+		filename string
+		expected interface{}
+		data interface{}
+	}{
+		{
+			name: "correctly unmarshals yaml file with list of strings",
+			filename: "testdata/list_of_string_in_property.yaml",
+			data: &map[string][]string{},
+			expected: &map[string][]string{"prop": {"string-1", "string-2"}},
+		},
+		{
+			name: "correctly unmarshals yaml file with embedded object",
+			filename: "testdata/embedded_object.yaml",
+			data: &map[string]interface{}{},
+			expected: &map[string]interface{}{"obj": map[interface{}]interface{}{"prop1": 
+				map[interface{}]interface{} {"another_obj": map[interface{}]interface{}{"prop2": "value2", "prop3":"value3"}}}},
+		},
+		{
+			name: "correctly unmarshals yaml file with mapping of strings to list of strings",
+			filename: "testdata/multiple_mappings.yaml",
+			data: &map[string][]string{},
+			expected: &map[string][]string{"key1": {"value1", "value2"}, "key2": {"value3", "value4"}},
+		},
+		{
+			name: "overrides already defined keys wile unmarshalling yaml file with mapping of strings to list of strings",
+			filename: "testdata/multiple_mappings_override.yaml",
+			data: &map[string][]string{},
+			expected: &map[string][]string{"key1": {"value5", "value6"}, "key2": {"value3", "value4"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given/when
+			err := UnmarshalYamlFile(tt.filename, tt.data)
+	
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, tt.data)
+		})
+	}
+}
+

--- a/internal/whitelist/whitelisted_globalaccounts.go
+++ b/internal/whitelist/whitelisted_globalaccounts.go
@@ -2,9 +2,8 @@ package whitelist
 
 import (
 	"fmt"
-	"os"
 
-	"gopkg.in/yaml.v2"
+	"github.com/kyma-project/kyma-environment-broker/internal/utils"
 )
 
 const (
@@ -20,15 +19,12 @@ func IsNotWhitelisted(globalAccountId string, whitelist Set) bool {
 
 func ReadWhitelistedGlobalAccountIdsFromFile(filename string) (Set, error) {
 	yamlData := make(map[string][]string)
+	err := utils.UnmarshalYamlFile(filename, &yamlData)
+	if err != nil {
+		return Set{}, fmt.Errorf("while unmarshalling a file with whitelisted GlobalAccountIds config: %w", err)
+	}
+
 	whitelistSet := Set{}
-	var whitelist, err = os.ReadFile(filename)
-	if err != nil {
-		return whitelistSet, fmt.Errorf("while reading %s file with whitelisted GlobalAccountIds config: %w", filename, err)
-	}
-	err = yaml.Unmarshal(whitelist, &yamlData)
-	if err != nil {
-		return whitelistSet, fmt.Errorf("while unmarshalling a file with whitelisted GlobalAccountIds config: %w", err)
-	}
 	for _, id := range yamlData[Key] {
 		whitelistSet[id] = struct{}{}
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Refactoring of eu whitelists to reuse marshalling implemented in `UnmarshalYamlFile` (current branch, previously part of `ReadWhitelistedGlobalAccountIdsFromFile`) in https://github.com/kyma-project/kyma-environment-broker/issues/793

Changes proposed in this pull request:

- extracted `UnmarshalYamlFile` func from `ReadWhitelistedGlobalAccountIdsFromFile`,
- tests.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/kyma-environment-broker/issues/793
