### PR TITLE
Make `cloudsql-proxy` exit zero on SIGTERM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/kyma-incubator/compass/components/director v0.0.0-20240329103248-7710e72be80a
 	github.com/kyma-project/control-plane/components/provisioner v0.0.0-20240529135026-c4ef757de24f
-	github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240222095836-b3942869fc28
+	github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240612080429-83a7c0eb13b8
 	github.com/lib/pq v1.10.9
 	github.com/matryer/is v1.4.1
 	github.com/pivotal-cf/brokerapi/v8 v8.2.3

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/kyma-incubator/compass/components/director v0.0.0-20240329103248-7710
 github.com/kyma-incubator/compass/components/director v0.0.0-20240329103248-7710e72be80a/go.mod h1:2Ix9woiwr/5t76zzMF4PJAxcDj/wNgdK+wGvm9zVzGI=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20240529135026-c4ef757de24f h1:UHFgnYuj1ScmQZwLww06Q3sXHVqnMRkUqUe1y8RLgEs=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20240529135026-c4ef757de24f/go.mod h1:X+h9AdPV8nPmhgTg82BpFKEFsSL7OGSGG4D8+G3giPM=
-github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240222095836-b3942869fc28 h1:MptO0pv3+BjTxfQFF0YGR+/YL42jlNY3wi9Lq+kNr84=
-github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240222095836-b3942869fc28/go.mod h1:vABrhytVuZpchbdlIVdUDlhB/Q/3GIZld2JmdS2rZ6I=
+github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240612080429-83a7c0eb13b8 h1:btliPhcS1pF+AlQbmLjkV8GuPnTS1VbZ+m9DkPsxDCA=
+github.com/kyma-project/control-plane/components/schema-migrator v0.0.0-20240612080429-83a7c0eb13b8/go.mod h1:vABrhytVuZpchbdlIVdUDlhB/Q/3GIZld2JmdS2rZ6I=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -460,11 +460,13 @@ spec:
           {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                    "--exit-zero-on-sigterm",
                     "--private-ip"]
           {{- else }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
                     "--private-ip",
+                    "--exit-zero-on-sigterm",
                     "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -461,7 +461,7 @@ spec:
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
                     "--exit-zero-on-sigterm",
-                    "--private-ip"]europe-docker.pkg.dev/kyma-project/prod/control-plane/schema-migrator:v20240612-83a7c0eb
+                    "--private-ip"]
           {{- else }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -461,7 +461,7 @@ spec:
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
                     "--exit-zero-on-sigterm",
-                    "--private-ip"]
+                    "--private-ip"]europe-docker.pkg.dev/kyma-project/prod/control-plane/schema-migrator:v20240612-83a7c0eb
           {{- else }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",

--- a/resources/keb/templates/deprovision-retrigger-job.yaml
+++ b/resources/keb/templates/deprovision-retrigger-job.yaml
@@ -84,10 +84,12 @@ spec:
               {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip"]
               {{- else }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip",
                         "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
               volumeMounts:

--- a/resources/keb/templates/free-cleanup-job.yaml
+++ b/resources/keb/templates/free-cleanup-job.yaml
@@ -92,10 +92,12 @@ spec:
               {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip"]
               {{- else }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip",
                         "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
               volumeMounts:

--- a/resources/keb/templates/keb-db-job.yaml
+++ b/resources/keb/templates/keb-db-job.yaml
@@ -110,10 +110,12 @@ spec:
             {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
             command: ["/cloud-sql-proxy",
                       "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                      "--exit-zero-on-sigterm",
                       "--private-ip"]
             {{- else }}
             command: ["/cloud-sql-proxy",
                       "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                      "--exit-zero-on-sigterm",
                       "--private-ip",
                       "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
             volumeMounts:

--- a/resources/keb/templates/migrator-job.yaml
+++ b/resources/keb/templates/migrator-job.yaml
@@ -45,6 +45,7 @@ spec:
             - "/cloud-sql-proxy"
             - "{{ .Values.global.database.managedGCP.instanceConnectionName }}"
             - "--private-ip"
+            - "--exit-zero-on-sigterm",
             - "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"
           volumeMounts:
             - name: cloudsql-instance-credentials

--- a/resources/keb/templates/runtime-reconciler-deployment.yaml
+++ b/resources/keb/templates/runtime-reconciler-deployment.yaml
@@ -88,10 +88,12 @@ spec:
           {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                    "--exit-zero-on-sigterm",
                     "--private-ip"]
           {{- else }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                    "--exit-zero-on-sigterm",
                     "--private-ip",
                     "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
           volumeMounts:

--- a/resources/keb/templates/subaccount-cleanup-job.yaml
+++ b/resources/keb/templates/subaccount-cleanup-job.yaml
@@ -112,10 +112,12 @@ spec:
               {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip"]
               {{- else }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip",
                         "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
               volumeMounts:

--- a/resources/keb/templates/subaccount-sync-deployment.yaml
+++ b/resources/keb/templates/subaccount-sync-deployment.yaml
@@ -136,10 +136,12 @@ spec:
           {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                    "--exit-zero-on-sigterm",
                     "--private-ip"]
           {{- else }}
           command: ["/cloud-sql-proxy",
                     "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                    "--exit-zero-on-sigterm",
                     "--private-ip",
                     "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
           volumeMounts:

--- a/resources/keb/templates/trial-cleanup-job.yaml
+++ b/resources/keb/templates/trial-cleanup-job.yaml
@@ -92,10 +92,12 @@ spec:
               {{- if .Values.global.database.cloudsqlproxy.workloadIdentity.enabled }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip"]
               {{- else }}
               command: ["/cloud-sql-proxy",
                         "{{ .Values.global.database.managedGCP.instanceConnectionName }}",
+                        "--exit-zero-on-sigterm",
                         "--private-ip",
                         "--credentials-file=/secrets/cloudsql-instance-credentials/credentials.json"]
               volumeMounts:

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -10,7 +10,7 @@ global:
       path: europe-docker.pkg.dev/kyma-project/prod
     schema_migrator:
       dir: "control-plane"
-      version: "v20240610-ea747dbf" # do not update along with the other images
+      version: "v20240612-83a7c0eb" # do not update along with the other images
     kyma_environment_broker:
       dir:
       version: "1.5.31"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We send SIGINT to `cloudsql-proxy` sidecar to terminate it.
But then `cloudsql-proxy` exits with non-zero code (130). 
We usually can ignore it, but sometimes we need e.g. job to terminate with success.


Changes proposed in this pull request:

- Add parameter as a prerequisite - sending SIGTERM has to be done in other repo.
- Schema-migrator image and go mod update.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
