### PR TITLE
Conditional Converged Plan Rendering

### DIFF
--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -473,7 +473,6 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	gcpMachinesNames := GcpMachinesNames()
 	gcpMachinesDisplay := GcpMachinesDisplay()
 	gcpRegionsDisplay := GcpRegionsDisplay()
-	
 
 	if !useSmallerMachineTypes {
 		azureLiteMachinesNames = removeMachinesNamesFromList(azureLiteMachinesNames, "Standard_D2s_v5")
@@ -488,18 +487,18 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag)
 	ownClusterSchema := OwnClusterSchema(false)
 	previewCatalogSchema := PreviewSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, false, euAccessRestricted)
-	
+
 	trialSchema := TrialSchema(includeAdditionalParamsInSchema, false)
 
 	outputPlans := map[string]domain.ServicePlan{
-		AWSPlanID:               defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
-		GCPPlanID:               defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag)),
-		AzurePlanID:             defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureRegionsDisplay, azureMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
-		AzureLitePlanID:         defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureRegionsDisplay, azureLiteMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
-		FreemiumPlanID:          defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, true, euAccessRestricted)),
-		TrialPlanID:             defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
-		OwnClusterPlanID:        defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
-		PreviewPlanID:           defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, previewCatalogSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, false)),
+		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
+		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag)),
+		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureRegionsDisplay, azureMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
+		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureRegionsDisplay, azureLiteMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
+		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, true, euAccessRestricted)),
+		TrialPlanID:      defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
+		OwnClusterPlanID: defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
+		PreviewPlanID:    defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, previewCatalogSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, false)),
 	}
 
 	if len(sapConvergedCloudRegions) != 0 {

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -473,9 +473,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	gcpMachinesNames := GcpMachinesNames()
 	gcpMachinesDisplay := GcpMachinesDisplay()
 	gcpRegionsDisplay := GcpRegionsDisplay()
-	sapConvergedCloudMachinesNames := SapConvergedCloudMachinesNames()
-	sapConvergedCloudMachinesDisplay := SapConvergedCloudMachinesDisplay()
-	sapConvergedCloudRegionsDisplay := SapConvergedCloudRegionsDisplay()
+	
 
 	if !useSmallerMachineTypes {
 		azureLiteMachinesNames = removeMachinesNamesFromList(azureLiteMachinesNames, "Standard_D2s_v5")
@@ -490,19 +488,26 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag)
 	ownClusterSchema := OwnClusterSchema(false)
 	previewCatalogSchema := PreviewSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, false, euAccessRestricted)
-	sapConvergedCloudSchema := SapConvergedCloudSchema(sapConvergedCloudMachinesDisplay, sapConvergedCloudRegionsDisplay, sapConvergedCloudMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag, sapConvergedCloudRegions)
+	
 	trialSchema := TrialSchema(includeAdditionalParamsInSchema, false)
 
 	outputPlans := map[string]domain.ServicePlan{
 		AWSPlanID:               defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
 		GCPPlanID:               defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag)),
-		SapConvergedCloudPlanID: defaultServicePlan(SapConvergedCloudPlanID, SapConvergedCloudPlanName, plans, sapConvergedCloudSchema, SapConvergedCloudSchema(sapConvergedCloudMachinesDisplay, sapConvergedCloudRegionsDisplay, sapConvergedCloudMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag, sapConvergedCloudRegions)),
 		AzurePlanID:             defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureRegionsDisplay, azureMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
 		AzureLitePlanID:         defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureRegionsDisplay, azureLiteMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
 		FreemiumPlanID:          defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, true, euAccessRestricted)),
 		TrialPlanID:             defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
 		OwnClusterPlanID:        defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
 		PreviewPlanID:           defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, previewCatalogSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, false)),
+	}
+
+	if len(sapConvergedCloudRegions) != 0 {
+		sapConvergedCloudMachinesNames := SapConvergedCloudMachinesNames()
+		sapConvergedCloudMachinesDisplay := SapConvergedCloudMachinesDisplay()
+		sapConvergedCloudRegionsDisplay := SapConvergedCloudRegionsDisplay()
+		sapConvergedCloudSchema := SapConvergedCloudSchema(sapConvergedCloudMachinesDisplay, sapConvergedCloudRegionsDisplay, sapConvergedCloudMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag, sapConvergedCloudRegions)
+		outputPlans[SapConvergedCloudPlanID] = defaultServicePlan(SapConvergedCloudPlanID, SapConvergedCloudPlanName, plans, sapConvergedCloudSchema, SapConvergedCloudSchema(sapConvergedCloudMachinesDisplay, sapConvergedCloudRegionsDisplay, sapConvergedCloudMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag, sapConvergedCloudRegions))
 	}
 
 	return outputPlans

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -262,41 +262,39 @@ func TestSchemaGenerator(t *testing.T) {
 	}
 }
 
-func TestSapConvergedSchema(t* testing.T) {
+func TestSapConvergedSchema(t *testing.T) {
 
 	t.Run("SapConvergedCloud schema uses regions from parameter to display region list", func(t *testing.T) {
 		// given
 		regions := []string{"region1", "region2"}
-	
-		// when 
+
+		// when
 		schema := Plans(nil, "", false, false, false, false, regions)
 		convergedSchema, found := schema[SapConvergedCloudPlanID]
-		schemaRegionsCreate := convergedSchema.Schemas.Instance.Create.Parameters["properties"].
-			(map[string]interface{})["region"].
-			(map[string]interface{})["enum"]
-	
+		schemaRegionsCreate := convergedSchema.Schemas.Instance.Create.Parameters["properties"].(map[string]interface{})["region"].(map[string]interface{})["enum"]
+
 		// then
 		assert.NotNil(t, schema)
 		assert.True(t, found)
-		assert.Equal(t, []interface {}([]interface {}{"region1", "region2"}), schemaRegionsCreate)		
+		assert.Equal(t, []interface{}([]interface{}{"region1", "region2"}), schemaRegionsCreate)
 	})
 
 	t.Run("SapConvergedCloud schema not generated if empty region list", func(t *testing.T) {
 		// given
 		regions := []string{}
-	
-		// when 
+
+		// when
 		schema := Plans(nil, "", false, false, false, false, regions)
 		_, found := schema[SapConvergedCloudPlanID]
-	
+
 		// then
 		assert.NotNil(t, schema)
 		assert.False(t, found)
-	
-		// when 
+
+		// when
 		schema = Plans(nil, "", false, false, false, false, nil)
 		_, found = schema[SapConvergedCloudPlanID]
-	
+
 		// then
 		assert.NotNil(t, schema)
 		assert.False(t, found)

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -156,7 +156,7 @@ func TestSchemaGenerator(t *testing.T) {
 			updateFileOIDC: "update-free-azure-schema-additional-params.json",
 		},
 		{
-			name: " Freemium schema is correct",
+			name: "Freemium schema is correct",
 			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return FreemiumSchema(internal.AWS, regionsDisplay, additionalParams, update, false)
 			},
@@ -260,6 +260,47 @@ func TestSchemaGenerator(t *testing.T) {
 			validateSchema(t, Marshal(got), tt.path+"/"+tt.updateFileOIDC)
 		})
 	}
+}
+
+func TestSapConvergedSchema(t* testing.T) {
+
+	t.Run("SapConvergedCloud schema uses regions from parameter to display region list", func(t *testing.T) {
+		// given
+		regions := []string{"region1", "region2"}
+	
+		// when 
+		schema := Plans(nil, "", false, false, false, false, regions)
+		convergedSchema, found := schema[SapConvergedCloudPlanID]
+		schemaRegionsCreate := convergedSchema.Schemas.Instance.Create.Parameters["properties"].
+			(map[string]interface{})["region"].
+			(map[string]interface{})["enum"]
+	
+		// then
+		assert.NotNil(t, schema)
+		assert.True(t, found)
+		assert.Equal(t, []interface {}([]interface {}{"region1", "region2"}), schemaRegionsCreate)		
+	})
+
+	t.Run("SapConvergedCloud schema not generated if empty region list", func(t *testing.T) {
+		// given
+		regions := []string{}
+	
+		// when 
+		schema := Plans(nil, "", false, false, false, false, regions)
+		_, found := schema[SapConvergedCloudPlanID]
+	
+		// then
+		assert.NotNil(t, schema)
+		assert.False(t, found)
+	
+		// when 
+		schema = Plans(nil, "", false, false, false, false, nil)
+		_, found = schema[SapConvergedCloudPlanID]
+	
+		// then
+		assert.NotNil(t, schema)
+		assert.False(t, found)
+	})
 }
 
 func validateSchema(t *testing.T, got []byte, file string) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

This PR introduced conditional rendering of sap-converged-cloud plan schema if regions parameter is empty. Otherwise it is filled with the contents of that parameter.

**Description**

Changes proposed in this pull request:

- plans.go modifications,
- tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/kyma-environment-broker/issues/793