### PR TITLE
Added Missing Region Parameter

### DIFF
--- a/internal/appinfo/runtime_info.go
+++ b/internal/appinfo/runtime_info.go
@@ -159,7 +159,7 @@ func (h *RuntimeInfoHandler) planNameOrDefault(inst internal.InstanceWithOperati
 	if inst.ServicePlanName != "" {
 		return inst.ServicePlanName
 	}
-	return broker.Plans(h.plansConfig, "", false, false, false, false, h.convergedRegionsProvider.GetRegions(inst.ProviderRegion))[inst.ServicePlanID].Name
+	return broker.PlanNamesMapping[inst.ServicePlanID]
 }
 
 func getIfNotZero(in time.Time) *time.Time {

--- a/internal/appinfo/runtime_info.go
+++ b/internal/appinfo/runtime_info.go
@@ -159,7 +159,7 @@ func (h *RuntimeInfoHandler) planNameOrDefault(inst internal.InstanceWithOperati
 	if inst.ServicePlanName != "" {
 		return inst.ServicePlanName
 	}
-	return broker.Plans(h.plansConfig, "", false, false, false, false, h.convergedRegionsProvider.GetRegions())[inst.ServicePlanID].Name
+	return broker.Plans(h.plansConfig, "", false, false, false, false, h.convergedRegionsProvider.GetRegions(inst.ProviderRegion))[inst.ServicePlanID].Name
 }
 
 func getIfNotZero(in time.Time) *time.Time {

--- a/internal/broker/converged_region_provider.go
+++ b/internal/broker/converged_region_provider.go
@@ -10,7 +10,7 @@ type RegionReader interface {
 }
 
 type ConvergedCloudRegionProvider interface {
-	GetRegions() []string
+	GetRegions(string) []string
 }
 
 type DefaultConvergedCloudRegionsProvider struct {
@@ -29,8 +29,8 @@ func NewPathBasedConvergedCloudRegionsProvider(regionConfigurationPath string, r
 	}, nil
 }
 
-func (c *DefaultConvergedCloudRegionsProvider) GetRegions(region string) []string {
-	item, found := c.regionConfiguration[region]
+func (c *DefaultConvergedCloudRegionsProvider) GetRegions(mappedRegion string) []string {
+	item, found := c.regionConfiguration[mappedRegion]
 
 	if !found {
 		return []string{}
@@ -42,6 +42,6 @@ func (c *DefaultConvergedCloudRegionsProvider) GetRegions(region string) []strin
 type OneForAllConvergedCloudRegionsProvider struct {
 }
 
-func (c *OneForAllConvergedCloudRegionsProvider) GetRegions() []string {
+func (c *OneForAllConvergedCloudRegionsProvider) GetRegions(mappedRegion string) []string {
 	return []string{"eu-de-1"}
 }

--- a/internal/broker/converged_region_provider_test.go
+++ b/internal/broker/converged_region_provider_test.go
@@ -12,7 +12,7 @@ func TestOneForAllConvergedCloudRegionsProvider_GetDefaultRegions(t *testing.T) 
 	c := &OneForAllConvergedCloudRegionsProvider{}
 
 	// when
-	result := c.GetRegions()
+	result := c.GetRegions("")
 
 	// then
 	assert.Equal(t, []string{"eu-de-1"}, result)

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -477,7 +477,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, b.config.EnableShootAndSeedSameRegion, b.convergedRegionsProvider.GetRegions())
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, b.config.EnableShootAndSeedSameRegion, b.convergedRegionsProvider.GetRegions(platformRegion))
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -387,7 +387,7 @@ func (b *UpdateEndpoint) isKyma2(instance *internal.Instance) (bool, string, err
 
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
 	// shootAndSeedSameRegion is never enabled for update
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, false, b.convergedRegionsProvider.GetRegions())
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, false, b.convergedRegionsProvider.GetRegions(platformRegion))
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -210,7 +210,7 @@ func TestSchemaGenerator(t *testing.T) {
 			name: "SapConvergedCloud schema is correct",
 			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				convergedCloudRegionProvider := &OneForAllConvergedCloudRegionsProvider{}
-				return SapConvergedCloudSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, additionalParams, convergedCloudRegionProvider.GetRegions())
+				return SapConvergedCloudSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, additionalParams, convergedCloudRegionProvider.GetRegions(""))
 			},
 			machineTypes:        SapConvergedCloudMachinesNames(),
 			machineTypesDisplay: SapConvergedCloudMachinesDisplay(),

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -62,7 +62,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 		euaccess.IsEURestrictedAccess(platformRegion),
 		b.cfg.UseSmallerMachineTypes,
 		b.cfg.EnableShootAndSeedSameRegion,
-		b.convergedRegionsProvider.GetRegions(),
+		b.convergedRegionsProvider.GetRegions(platformRegion),
 	) {
 
 		// filter out not enabled plans

--- a/internal/provider/sap-converged-cloud_provider_test.go
+++ b/internal/provider/sap-converged-cloud_provider_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestZonesForSapConvergedCloudZones(t *testing.T) {
 	convergedCloudRegionProvider := broker.OneForAllConvergedCloudRegionsProvider{}
-	regions := convergedCloudRegionProvider.GetRegions()
+	regions := convergedCloudRegionProvider.GetRegions("")
 	for _, region := range regions {
 		_, exists := sapConvergedCloudZones[region]
 		assert.True(t, exists)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Missing parameter for passing region and making mapping selection based on its value.

Changes proposed in this pull request:

- missing region parameter in region provider interface,
- additional: runtime info simplification - loading plan name with the usage of mapping struct instead of invoking `Plans` method.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/kyma-environment-broker/issues/793
