### PR TITLE
Not recreating states after deletion

### DIFF
--- a/internal/subaccountsync/state_reconciler.go
+++ b/internal/subaccountsync/state_reconciler.go
@@ -228,9 +228,8 @@ func (reconciler *stateReconcilerType) reconcileCisAccount(subaccountID subaccou
 
 	state, ok := reconciler.inMemoryState[subaccountID]
 	if !ok {
-		// possible case when subaccount was deleted from the state and then Kyma resource was created again
-		logs.Warn(fmt.Sprintf("subaccount %s not found in state when syncing accounts service", subaccountID))
-		state.cisState = newCisState
+		logs.Warn(fmt.Sprintf("subaccount %s not found in state when syncing accounts service - ignoring", subaccountID))
+		return
 	}
 	if newCisState.ModifiedDate >= state.cisState.ModifiedDate {
 		state.cisState = newCisState
@@ -249,8 +248,8 @@ func (reconciler *stateReconcilerType) reconcileCisEvent(event Event) {
 	subaccount := subaccountIDType(event.SubaccountID)
 	state, ok := reconciler.inMemoryState[subaccount]
 	if !ok {
-		// possible case when subaccount was deleted from the state and then Kyma resource was created again
-		logs.Warn(fmt.Sprintf("subaccount %s not found in state when syncing events service", subaccount))
+		logs.Warn(fmt.Sprintf("subaccount %s not found in state when syncing events service - ignoring", subaccount))
+		return
 	}
 	if event.ActionTime >= state.cisState.ModifiedDate {
 		cisState := CisStateType{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

If there are no runtimes left we remove state, but then we can get asynchronously responses for request preceding deletion.
We shall not create (recreate) the state in such a case.

Changes proposed in this pull request:

- not creating new state when response from CIS comes for non-tracked subaccount
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
