### PR TITLE
Retry kubeconfig init in SKR tests

### DIFF
--- a/testing/e2e/skr/skr-test/oidc/index.js
+++ b/testing/e2e/skr/skr-test/oidc/index.js
@@ -11,6 +11,7 @@ const {
 const {keb, kcp, gardener} = require('../helpers');
 
 const updateTimeout = 1000 * 60 * 20; // 20m
+const k8sCallTimeout = 1000 * 60 * 1; // 1m
 
 function oidcE2ETest(getShootOptionsFunc, getShootInfoFunc) {
   describe('OIDC Test', function() {
@@ -73,6 +74,7 @@ function oidcE2ETest(getShootOptionsFunc, getShootInfoFunc) {
     });
 
     it('Assure cluster admin is preserved', async function() {
+      this.timeout(k8sCallTimeout);
       await ensureKymaAdminBindingExistsForUser(options.kebUserId);
     });
 

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -28,7 +28,7 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
     } catch (error) {
       if (error.response && error.response.status === 403) {
         console.log("Access to secrets is forbidden. Downloading the kubeconfig once again. Trying to initialize the client one last time");
-        const kubeconfigPath = kcp.getKubeconfig(shootName);
+        const kubeconfigPath = kcp.getKubeconfig(shoot.name);
         await initializeK8sClient({kubeconfigPath: kubeconfigPath});
       } else {
         console.log("An error occurred while fetching the secret");

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -27,7 +27,8 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
       getSecret('sap-btp-manager', 'kyma-system');
     } catch (error) {
       if (error.response && error.response.status === 403) {
-        console.log('Access to secrets is forbidden. Downloading the kubeconfig once again. Trying to initialize the client one last time');
+        console.log('Access to secrets is forbidden.');
+        console.log('Downloading the kubeconfig once again. Trying to initialize the client one last time');
         const kubeconfigPath = kcp.getKubeconfig(shoot.name);
         await initializeK8sClient({kubeconfigPath: kubeconfigPath});
       } else {

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -31,7 +31,7 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
         const kubeconfigPath = kcp.getKubeconfig(shootName);
         await initializeK8sClient({kubeconfigPath: kubeconfigPath});
       } else {
-        console.log("An error occurred while fetching the secret:", error.message);
+        console.log("An error occurred while fetching the secret");
       }
     }
 

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -10,7 +10,7 @@ const {
 
 const {provisionSKR}= require('../../kyma-environment-broker');
 const {BTPOperatorCreds} = require('../../smctl/helpers');
-const { getSecret } = require('../../utils');
+const {getSecret} = require('../../utils');
 
 async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
@@ -24,17 +24,16 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
     await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
 
     try {
-      getSecret("sap-btp-manager", "kyma-system");
+      getSecret('sap-btp-manager', 'kyma-system');
     } catch (error) {
       if (error.response && error.response.status === 403) {
-        console.log("Access to secrets is forbidden. Downloading the kubeconfig once again. Trying to initialize the client one last time");
+        console.log('Access to secrets is forbidden. Downloading the kubeconfig once again. Trying to initialize the client one last time');
         const kubeconfigPath = kcp.getKubeconfig(shoot.name);
         await initializeK8sClient({kubeconfigPath: kubeconfigPath});
       } else {
-        console.log("An error occurred while fetching the secret");
+        console.log('An error occurred while fetching the secret');
       }
     }
-
   }
   console.log('Initialization of K8s finished...');
 

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -10,6 +10,7 @@ const {
 
 const {provisionSKR}= require('../../kyma-environment-broker');
 const {BTPOperatorCreds} = require('../../smctl/helpers');
+const { getSecret } = require('../../utils');
 
 async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
@@ -21,10 +22,21 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   } else {
     console.log('Initiating K8s client...');
     await initializeK8sClient({kubeconfigPath: shoot.kubeconfig});
+
+    try {
+      getSecret("sap-btp-manager", "kyma-system");
+    } catch (error) {
+      if (error.response && error.response.status === 403) {
+        console.log("Access to secrets is forbidden. Downloading the kubeconfig once again. Trying to initialize the client one last time");
+        const kubeconfigPath = kcp.getKubeconfig(shootName);
+        await initializeK8sClient({kubeconfigPath: kubeconfigPath});
+      } else {
+        console.log("An error occurred while fetching the secret:", error.message);
+      }
+    }
+
   }
-
   console.log('Initialization of K8s finished...');
-
 
   return {
     options,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Do once a retry with the kubeconfig download and init if we can't access the SKR with error 403.
- Increase timeout in a test where sometimes the k8s api is too slow.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
