### PR TITLE
Change condition for retrying kubeconfig init in SKR tests

### DIFF
--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -26,7 +26,7 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
     try {
       await getSecret('sap-btp-manager', 'kyma-system');
     } catch (error) {
-      console.log('An error occurred while fetching the secret');
+      console.log('An error occurred while testing the K8s client');
       console.log('Downloading the kubeconfig once again. Trying to initialize the client one last time');
       const kubeconfigPath = kcp.getKubeconfig(shoot.name);
       await initializeK8sClient({kubeconfigPath: kubeconfigPath});

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -26,14 +26,10 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
     try {
       await getSecret('sap-btp-manager', 'kyma-system');
     } catch (error) {
-      if (error.response && error.response.status === 403) {
-        console.log('Access to secrets is forbidden.');
-        console.log('Downloading the kubeconfig once again. Trying to initialize the client one last time');
-        const kubeconfigPath = kcp.getKubeconfig(shoot.name);
-        await initializeK8sClient({kubeconfigPath: kubeconfigPath});
-      } else {
-        console.log('An error occurred while fetching the secret');
-      }
+      console.log('An error occurred while fetching the secret');
+      console.log('Downloading the kubeconfig once again. Trying to initialize the client one last time');
+      const kubeconfigPath = kcp.getKubeconfig(shoot.name);
+      await initializeK8sClient({kubeconfigPath: kubeconfigPath});
     }
   }
   console.log('Initialization of K8s finished...');


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Retry kubeconfig init in case of any error.

Changes proposed in this pull request:


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
