### PR TITLE
KIM Integration - handle existing Runtime CR during retry

### DIFF
--- a/internal/kim/config.go
+++ b/internal/kim/config.go
@@ -5,7 +5,7 @@ type Config struct {
 	DryRun       bool     `envconfig:"default=true"`
 	ViewOnly     bool     `envconfig:"default=true"`
 	Plans        []string `envconfig:"default=preview"`
-	KimOnlyPlans []string `envconfig:"default="`
+	KimOnlyPlans []string `envconfig:"default=,"`
 }
 
 func (c *Config) IsEnabledForPlan(planName string) bool {

--- a/internal/process/provisioning/create_kyma_name_step.go
+++ b/internal/process/provisioning/create_kyma_name_step.go
@@ -31,8 +31,7 @@ func (s *CreateKymaNameStep) Run(operation internal.Operation, log logrus.FieldL
 	if operation.RuntimeID == "" {
 		return s.operationManager.OperationFailed(operation, fmt.Sprint("RuntimeID not set, cannot create Kyma name"), nil, log)
 	}
-
 	return s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
-		operation.KymaResourceName = steps.CreateKymaNameFromOperation(operation)
+		op.KymaResourceName = steps.CreateKymaNameFromOperation(operation)
 	}, log)
 }

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -3,9 +3,10 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/networking"
 

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -3,6 +3,8 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/networking"
@@ -72,51 +74,61 @@ func (s *CreateRuntimeResourceStep) Run(operation internal.Operation, log logrus
 
 	kymaResourceName := operation.KymaResourceName
 	kymaResourceNamespace := operation.KymaResourceNamespace
-
-	runtimeCR, err := s.createRuntimeResourceObject(operation, kymaResourceName, kymaResourceNamespace)
-	if err != nil {
-		return s.operationManager.OperationFailed(operation, fmt.Sprintf("while creating Runtime CR object: %s", err), err, log)
-	}
+	runtimeResourceName := steps.KymaRuntimeResourceName(operation)
+	log.Infof("KymaResourceName: %s, KymaResourceNamespace: %s, RuntimeResourceName: %s", kymaResourceName, kymaResourceNamespace, runtimeResourceName)
 
 	if s.kimConfig.DryRun {
+		runtimeCR := &imv1.Runtime{}
+		err := s.updateRuntimeResourceObject(runtimeCR, operation, runtimeResourceName, kymaResourceName, kymaResourceNamespace)
+		if err != nil {
+			return s.operationManager.OperationFailed(operation, fmt.Sprintf("while updating Runtime resource object: %s", err), err, log)
+		}
 		yaml, err := RuntimeToYaml(runtimeCR)
 		if err != nil {
-			log.Errorf("failed to encode Runtime CR as yaml: %s", err)
+			log.Errorf("failed to encode Runtime resource as yaml: %s", err)
 		} else {
 			fmt.Println(yaml)
 		}
 	} else {
-		err := s.k8sClient.Create(context.Background(), runtimeCR)
+		runtimeCR, err := s.getEmptyOrExistingRuntimeResource(runtimeResourceName, kymaResourceNamespace)
 		if err != nil {
-			log.Error("unable to create Runtime resource: %s", err)
-			return s.operationManager.OperationFailed(operation, fmt.Sprintf("unable to Runtime resource: %s", err), err, log)
+			log.Errorf("unable to get Runtime resource %s/%s", operation.KymaResourceNamespace, runtimeResourceName)
+			return s.operationManager.RetryOperation(operation, "unable to get Runtime resource", err, 3*time.Second, 20*time.Second, log)
 		}
-		log.Infof("Runtime CR %s creation process finished successfully", operation.RuntimeID)
+		if runtimeCR.GetResourceVersion() != "" {
+			log.Infof("Runtime resource already created %s/%s: ", operation.KymaResourceNamespace, runtimeResourceName)
+			return operation, 0, nil
+		} else {
+			err := s.updateRuntimeResourceObject(runtimeCR, operation, runtimeResourceName, kymaResourceName, kymaResourceNamespace)
+			if err != nil {
+				return s.operationManager.OperationFailed(operation, fmt.Sprintf("while creating Runtime CR object: %s", err), err, log)
+			}
+			err = s.k8sClient.Create(context.Background(), runtimeCR)
+			if err != nil {
+				log.Errorf("unable to create Runtime resource: %s/%s: %s", operation.KymaResourceNamespace, runtimeResourceName, err.Error())
+				return s.operationManager.RetryOperation(operation, "unable to create Runtime resource", err, 3*time.Second, 20*time.Second, log)
+			}
+		}
+		log.Infof("Runtime resource %s/%s creation process finished successfully", operation.KymaResourceNamespace, runtimeResourceName)
 	}
 	return operation, 0, nil
 }
 
-func (s *CreateRuntimeResourceStep) CreateResource(cr *imv1.Runtime) error {
-	logrus.Info("Creating Runtime CR - TO BE IMPLEMENTED")
-	return nil
-}
+func (s *CreateRuntimeResourceStep) updateRuntimeResourceObject(runtime *imv1.Runtime, operation internal.Operation, runtimeName, kymaName, kymaNamespace string) error {
 
-func (s *CreateRuntimeResourceStep) createRuntimeResourceObject(operation internal.Operation, kymaName, kymaNamespace string) (*imv1.Runtime, error) {
-
-	runtime := imv1.Runtime{}
-	runtime.ObjectMeta.Name = operation.RuntimeID
+	runtime.ObjectMeta.Name = runtimeName
 	runtime.ObjectMeta.Namespace = kymaNamespace
 	runtime.ObjectMeta.Labels = s.createLabelsForRuntime(operation, kymaName)
 
 	// get plan specific values (like zones, default machine type etc.
 	values, err := s.providerValues(&operation)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	providerObj, err := s.createShootProvider(&operation, values)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	runtime.Spec.Shoot.Provider = providerObj
@@ -128,7 +140,7 @@ func (s *CreateRuntimeResourceStep) createRuntimeResourceObject(operation intern
 	runtime.Spec.Shoot.ControlPlane.HighAvailability = s.createHighAvailabilityConfiguration()
 	runtime.Spec.Security = s.createSecurityConfiguration(operation)
 	runtime.Spec.Shoot.Networking = s.createNetworkingConfiguration(operation)
-	return &runtime, nil
+	return nil
 }
 
 func (s *CreateRuntimeResourceStep) createLabelsForRuntime(operation internal.Operation, kymaName string) map[string]string {
@@ -282,6 +294,19 @@ func (s *CreateRuntimeResourceStep) createNetworkingConfiguration(operation inte
 		Services: DefaultIfParamNotSet(networking.DefaultServicesCIDR, networkingParams.ServicesCidr),
 		Nodes:    nodes,
 	}
+}
+
+func (s *CreateRuntimeResourceStep) getEmptyOrExistingRuntimeResource(name, namespace string) (*imv1.Runtime, error) {
+	runtime := imv1.Runtime{}
+	err := s.k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &runtime)
+
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	return &runtime, nil
 }
 
 func DefaultIfParamNotSet[T interface{}](d T, param *T) T {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Check if Runtime CR already exists - skipping creation
- filling Runtime object structure in-place
- fix for kyma name setting

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#791 
#905 