### PR TITLE
KIM Integration - conditionally handling GardenerCluster

### DIFF
--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -50,6 +50,12 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 			step:     deprovisioning.NewCheckKymaResourceDeletedStep(db.Operations(), cli, cfg.KymaResourceDeletionTimeout),
 		},
 		{
+			step: deprovisioning.NewDeleteRuntimeResourceStep(db.Operations(), cli),
+		},
+		{
+			step: deprovisioning.NewCheckRuntimeResourceDeletionStep(db.Operations(), cli),
+		},
+		{
 			step: deprovisioning.NewDeleteGardenerClusterStep(db.Operations(), cli, db.Instances()),
 		},
 		{
@@ -60,12 +66,6 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 		},
 		{
 			step: deprovisioning.NewCheckRuntimeRemovalStep(db.Operations(), db.Instances(), provisionerClient, cfg.Provisioner.DeprovisioningTimeout),
-		},
-		{
-			step: deprovisioning.NewDeleteRuntimeResourceStep(db.Operations(), cli),
-		},
-		{
-			step: deprovisioning.NewCheckRuntimeResourceDeletionStep(db.Operations(), cli),
 		},
 		{
 			step: deprovisioning.NewReleaseSubscriptionStep(db.Operations(), db.Instances(), accountProvider),

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -112,13 +112,13 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		{
 			stage:     createRuntimeStageName,
 			disabled:  cfg.InfrastructureManagerIntegrationDisabled,
-			step:      steps.NewSyncGardenerCluster(db.Operations(), cli),
+			step:      steps.NewSyncGardenerCluster(db.Operations(), cli, cfg.Broker.KimConfig),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{
 			stage:     createRuntimeStageName,
 			disabled:  cfg.InfrastructureManagerIntegrationDisabled,
-			step:      steps.NewCheckGardenerCluster(db.Operations(), cli, cfg.Provisioner.GardenerClusterStepTimeout),
+			step:      steps.NewCheckGardenerCluster(db.Operations(), cli, cfg.Broker.KimConfig, cfg.Provisioner.GardenerClusterStepTimeout),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{ // TODO: this step must be removed when kubeconfig is created by IM only

--- a/internal/kim/config.go
+++ b/internal/kim/config.go
@@ -1,9 +1,9 @@
 package kim
 
 type Config struct {
-	Enabled      bool     `envconfig:"default=false"`
-	DryRun       bool     `envconfig:"default=true"`
-	ViewOnly     bool     `envconfig:"default=true"`
+	Enabled      bool     `envconfig:"default=false"` // if true, KIM will be used
+	DryRun       bool     `envconfig:"default=true"`  // if true, only yamls are generated, no resources are created
+	ViewOnly     bool     `envconfig:"default=true"`  // if true, provisioner will control the process
 	Plans        []string `envconfig:"default=preview"`
 	KimOnlyPlans []string `envconfig:"default=,"`
 }
@@ -20,7 +20,7 @@ func (c *Config) IsEnabledForPlan(planName string) bool {
 	return false
 }
 
-func (c *Config) DrivenByKimOnly(planName string) bool {
+func (c *Config) IsDrivenByKimOnly(planName string) bool {
 	if !c.IsEnabledForPlan(planName) {
 		return false
 	}
@@ -30,4 +30,8 @@ func (c *Config) DrivenByKimOnly(planName string) bool {
 		}
 	}
 	return false
+}
+
+func (c *Config) IsDrivenByKim(planName string) bool {
+	return (c.IsEnabledForPlan(planName) && !c.ViewOnly && !c.DryRun) || c.IsDrivenByKimOnly(planName)
 }

--- a/internal/kim/config_test.go
+++ b/internal/kim/config_test.go
@@ -15,6 +15,10 @@ func TestIsEnabled_KimDisabled(t *testing.T) {
 
 	assert.False(t, config.IsEnabledForPlan("gcp"))
 	assert.False(t, config.IsEnabledForPlan("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.False(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
 }
 
 func TestIsEnabled_KimEnabledForPreview(t *testing.T) {
@@ -22,13 +26,34 @@ func TestIsEnabled_KimEnabledForPreview(t *testing.T) {
 		Enabled:  true,
 		Plans:    []string{"preview"},
 		ViewOnly: false,
+		DryRun:   false,
 	}
 
 	assert.False(t, config.IsEnabledForPlan("gcp"))
 	assert.True(t, config.IsEnabledForPlan("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.True(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
 }
 
-func TestDrivenByKim_KimDisabled(t *testing.T) {
+func TestIsEnabled_KimEnabledForPreview_DryRun(t *testing.T) {
+	config := &Config{
+		Enabled:  true,
+		Plans:    []string{"preview"},
+		ViewOnly: false,
+		DryRun:   true,
+	}
+
+	assert.False(t, config.IsEnabledForPlan("gcp"))
+	assert.True(t, config.IsEnabledForPlan("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.False(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
+}
+
+func TestDrivenByKimOnly_KimDisabled(t *testing.T) {
 	config := &Config{
 		Enabled:      false,
 		Plans:        []string{"gcp", "preview"},
@@ -36,11 +61,15 @@ func TestDrivenByKim_KimDisabled(t *testing.T) {
 		ViewOnly:     false,
 	}
 
-	assert.False(t, config.DrivenByKimOnly("gcp"))
-	assert.False(t, config.DrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.False(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
 }
 
-func TestDrivenByKim_PreviewByKimOnly(t *testing.T) {
+func TestDrivenByKimOnly_PreviewByKimOnly(t *testing.T) {
 	config := &Config{
 		Enabled:      true,
 		Plans:        []string{"preview"},
@@ -49,10 +78,14 @@ func TestDrivenByKim_PreviewByKimOnly(t *testing.T) {
 	}
 
 	assert.False(t, config.IsEnabledForPlan("gcp"))
-	assert.True(t, config.DrivenByKimOnly("preview"))
+	assert.True(t, config.IsDrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.True(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.True(t, config.IsDrivenByKimOnly("preview"))
 }
 
-func TestDrivenByKim_PreviewByKimOnlyButNotEnabled(t *testing.T) {
+func TestDrivenByKimOnly_PreviewByKimOnlyButNotEnabled(t *testing.T) {
 	config := &Config{
 		Enabled:      true,
 		KimOnlyPlans: []string{"preview"},
@@ -60,5 +93,26 @@ func TestDrivenByKim_PreviewByKimOnlyButNotEnabled(t *testing.T) {
 	}
 
 	assert.False(t, config.IsEnabledForPlan("gcp"))
-	assert.False(t, config.DrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.False(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
+}
+
+func TestDrivenByKim_ButNotByKimOnly(t *testing.T) {
+	config := &Config{
+		Enabled:      true,
+		KimOnlyPlans: []string{"no-plan"},
+		Plans:        []string{"preview"},
+		ViewOnly:     false,
+		DryRun:       false,
+	}
+
+	assert.False(t, config.IsEnabledForPlan("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
+	assert.False(t, config.IsDrivenByKim("gcp"))
+	assert.True(t, config.IsDrivenByKim("preview"))
+	assert.False(t, config.IsDrivenByKimOnly("gcp"))
+	assert.False(t, config.IsDrivenByKimOnly("preview"))
 }

--- a/internal/process/steps/gardener_cluster.go
+++ b/internal/process/steps/gardener_cluster.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"strings"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"

--- a/internal/process/steps/gardener_cluster_test.go
+++ b/internal/process/steps/gardener_cluster_test.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"testing"
 	"time"
 
@@ -51,6 +52,13 @@ spec:
 func TestSyncGardenerCluster_RunWithExistingResource(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: true,
+		DryRun:   false,
+	}
+
 	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
 	err := existingGC.SetShootName("abcd")
 	assert.NoError(t, err)
@@ -63,7 +71,7 @@ func TestSyncGardenerCluster_RunWithExistingResource(t *testing.T) {
 	operation.ShootName = "c-12345"
 	err = os.InsertOperation(operation)
 	assert.NoError(t, err)
-	svc := NewSyncGardenerCluster(os, k8sClient)
+	svc := NewSyncGardenerCluster(os, k8sClient, kimConfig)
 
 	// when
 	_, backoff, err := svc.Run(operation, logrus.New())
@@ -98,9 +106,15 @@ spec:
 func TestSyncGardenerCluster_Run(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: true,
+		DryRun:   false,
+	}
 
 	k8sClient := fake.NewClientBuilder().Build()
-	svc := NewSyncGardenerCluster(os, k8sClient)
+	svc := NewSyncGardenerCluster(os, k8sClient, kimConfig)
 	operation := fixture.FixProvisioningOperation("op", "instance-id")
 	operation.KymaResourceNamespace = "kcp-system"
 	operation.RuntimeID = "runtime-id-000"
@@ -134,11 +148,18 @@ spec:
 func TestCheckGardenerCluster_RunWhenReady(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: true,
+		DryRun:   false,
+	}
+
 	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
 	err := existingGC.SetState("Ready")
 	assert.NoError(t, err)
 	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(existingGC.ToUnstructured()).Build()
-	step := NewCheckGardenerCluster(os, k8sClient, time.Second)
+	step := NewCheckGardenerCluster(os, k8sClient, kimConfig, time.Second)
 	operation := fixture.FixProvisioningOperation("op", "instance-id")
 	operation.KymaResourceNamespace = "kcp-system"
 	operation.RuntimeID = "runtime-id-000"
@@ -157,13 +178,19 @@ func TestCheckGardenerCluster_RunWhenReady(t *testing.T) {
 func TestCheckGardenerCluster_RunWhenNotReady_OperationFail(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: true,
+		DryRun:   false,
+	}
 	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
 	err := existingGC.SetState("In progress")
 	assert.NoError(t, err)
 	err = existingGC.SetStatusConditions("some condition")
 	assert.NoError(t, err)
 	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(existingGC.ToUnstructured()).Build()
-	step := NewCheckGardenerCluster(os, k8sClient, time.Second)
+	step := NewCheckGardenerCluster(os, k8sClient, kimConfig, time.Second)
 	operation := fixture.FixProvisioningOperation("op", "instance-id")
 	operation.KymaResourceNamespace = "kcp-system"
 	operation.RuntimeID = "runtime-id-000"
@@ -181,16 +208,87 @@ func TestCheckGardenerCluster_RunWhenNotReady_OperationFail(t *testing.T) {
 	assert.Equal(t, domain.Failed, op.State)
 }
 
-func TestCheckGardenerCluster_RunWhenNotReady_Retry(t *testing.T) {
+func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimDrives(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: false,
+		DryRun:   false,
+	}
 	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
 	err := existingGC.SetState("In progress")
 	assert.NoError(t, err)
 	err = existingGC.SetStatusConditions("some condition")
 	assert.NoError(t, err)
 	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(existingGC.ToUnstructured()).Build()
-	step := NewCheckGardenerCluster(os, k8sClient, time.Second)
+	step := NewCheckGardenerCluster(os, k8sClient, kimConfig, time.Second)
+	operation := fixture.FixProvisioningOperation("op", "instance-id")
+	operation.KymaResourceNamespace = "kcp-system"
+	operation.RuntimeID = "runtime-id-000"
+	operation.ShootName = "c-12345"
+	operation.UpdatedAt = time.Now().Add(-1 * time.Hour)
+	err = os.InsertOperation(operation)
+	assert.NoError(t, err)
+
+	// when
+	_, backoff, err := step.Run(operation, logrus.New())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, backoff)
+}
+
+func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimOnlyPlanUsed(t *testing.T) {
+	// given
+	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:      true,
+		Plans:        []string{"azure"},
+		KimOnlyPlans: []string{"azure"},
+		ViewOnly:     true,
+		DryRun:       true,
+	}
+	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
+	err := existingGC.SetState("In progress")
+	assert.NoError(t, err)
+	err = existingGC.SetStatusConditions("some condition")
+	assert.NoError(t, err)
+	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(existingGC.ToUnstructured()).Build()
+	step := NewCheckGardenerCluster(os, k8sClient, kimConfig, time.Second)
+	operation := fixture.FixProvisioningOperation("op", "instance-id")
+	operation.KymaResourceNamespace = "kcp-system"
+	operation.RuntimeID = "runtime-id-000"
+	operation.ShootName = "c-12345"
+	operation.UpdatedAt = time.Now().Add(-1 * time.Hour)
+	err = os.InsertOperation(operation)
+	assert.NoError(t, err)
+
+	// when
+	_, backoff, err := step.Run(operation, logrus.New())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, backoff)
+}
+
+func TestCheckGardenerCluster_RunWhenNotReady_Retry(t *testing.T) {
+	// given
+	os := storage.NewMemoryStorage().Operations()
+	kimConfig := kim.Config{
+		Enabled:  true,
+		Plans:    []string{"azure"},
+		ViewOnly: true,
+		DryRun:   false,
+	}
+	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
+	err := existingGC.SetState("In progress")
+	assert.NoError(t, err)
+	err = existingGC.SetStatusConditions("some condition")
+	assert.NoError(t, err)
+	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(existingGC.ToUnstructured()).Build()
+	step := NewCheckGardenerCluster(os, k8sClient, kimConfig, time.Second)
 	operation := fixture.FixProvisioningOperation("op", "instance-id")
 	operation.KymaResourceNamespace = "kcp-system"
 	operation.RuntimeID = "runtime-id-000"

--- a/internal/process/steps/gardener_cluster_test.go
+++ b/internal/process/steps/gardener_cluster_test.go
@@ -2,9 +2,10 @@ package steps
 
 import (
 	"context"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"testing"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -52,7 +52,6 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log logrus.Fiel
 	if s.kimConfig.ViewOnly {
 		log.Infof("Provisioner is controlling provisioning process, skipping")
 		return operation, 0, nil
-
 	}
 
 	if s.kimConfig.DryRun {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We do not create nor sync GardenerCluster when KIM is driving provisioning process for given plan

Changes proposed in this pull request:

- auxiliary functions
- skipping SyncGardenerCluster step if KIM is provisioning for the plan
- skipping checkGardenerCluster step if KIM is provisioning for the plan
- during deprovisioning we remove Runtime CR first, then we remove GardenerCluster

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#905 
#791 