### PR TITLE
KCP CLI - deprovisioned instances fetch limit

### DIFF
--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -981,7 +981,8 @@ func (r readSession) ListInstancesArchived(filter dbmodel.InstanceFilter) ([]dbm
 
 	stmt := r.session.Select("*").
 		From(InstancesArchivedTableName).
-		OrderBy("last_deprovisioning_finished_at")
+		OrderBy("last_deprovisioning_finished_at").
+		Limit(1000)
 
 	if filter.Page > 0 && filter.PageSize > 0 {
 		stmt.Paginate(uint64(filter.Page), uint64(filter.PageSize))


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- reduce instances archived fetch limit to 1000.

**Related issue(s)**
See also #1021
