### PR TITLE
add provider label to Kyma CR

### DIFF
--- a/internal/process/provisioning/apply_kyma_step_test.go
+++ b/internal/process/provisioning/apply_kyma_step_test.go
@@ -291,6 +291,7 @@ spec:
     channel: stable
     modules: []
 `
+	operation.InputCreator = fixture.FixInputCreator("Test")
 	var cli client.Client
 	if len(os.Getenv("KUBECONFIG")) > 0 && strings.ToLower(os.Getenv("USE_KUBECONFIG")) == "true" {
 		config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -27,6 +27,7 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 	if operation.ProvisioningParameters.PlatformRegion != "" {
 		l["kyma-project.io/platform-region"] = operation.ProvisioningParameters.PlatformRegion
 	}
+	l["kyma-project.io/provider"] = string(operation.InputCreator.Provider())
 	l["operator.kyma-project.io/kyma-name"] = KymaName(operation)
 	l["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	if isKymaResourceInternal(operation) {

--- a/internal/process/steps/lifecycle_manager_kubeconfig_test.go
+++ b/internal/process/steps/lifecycle_manager_kubeconfig_test.go
@@ -19,6 +19,7 @@ func TestCheckKymaKubeconfigCreated(t *testing.T) {
 	// Given
 	operation := fixture.FixProvisioningOperation("op", "instance")
 	operation.KymaResourceNamespace = "kyma-system"
+	operation.InputCreator = fixture.FixInputCreator("Test")
 
 	k8sClient := fake.NewClientBuilder().Build()
 
@@ -43,6 +44,7 @@ func TestCheckKymaKubeconfigDeleted(t *testing.T) {
 	// Given
 	operation := fixture.FixDeprovisioningOperationAsOperation("op", "instance")
 	operation.KymaResourceNamespace = "kyma-system"
+	operation.InputCreator = fixture.FixInputCreator("Test")
 
 	k8sClient := fake.NewClientBuilder().Build()
 	err := k8sClient.Create(context.Background(), &v1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "kyma-system", Name: "kubeconfig-runtime-instance"}})
@@ -69,6 +71,7 @@ func TestCheckKymaKubeconfigDeleted(t *testing.T) {
 func TestCheckKymaKubeconfigDeleteSkipped(t *testing.T) {
 	// Given
 	operation := fixture.FixDeprovisioningOperationAsOperation("op", "instance")
+	operation.InputCreator = fixture.FixInputCreator("Test")
 
 	k8sClient := fake.NewClientBuilder().Build()
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Extend the labels added to the Kyma CR with `kyma-project.io/provider`, which can have values `Azure`, `AWS`, `GCP` or `SapConvergedCloud`. This change will be used to expose the provider information as metadata in certain metrics, to be able to provide high level statistics per provider.  

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.tools.sap/kyma/backlog/issues/5694
- https://github.tools.sap/kyma/backlog/issues/5672