### PR TITLE
KIM Integration - correctly skipped steps for KIM only driven plans

### DIFF
--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -87,7 +87,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		{
 			condition: provisioning.SkipForOwnClusterPlan,
 			stage:     createRuntimeStageName,
-			step:      provisioning.NewCreateRuntimeWithoutKymaStep(db.Operations(), db.RuntimeStates(), db.Instances(), provisionerClient),
+			step:      provisioning.NewCreateRuntimeWithoutKymaStep(db.Operations(), db.RuntimeStates(), db.Instances(), provisionerClient, cfg.Broker.KimConfig),
 		},
 		{
 			stage: createRuntimeStageName,

--- a/internal/process/provisioning/create_runtime_without_kyma_step.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_step.go
@@ -2,9 +2,10 @@ package provisioning
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-	"time"
 
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal"

--- a/internal/process/provisioning/create_runtime_without_kyma_step.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_step.go
@@ -47,7 +47,7 @@ func (s *CreateRuntimeWithoutKymaStep) Name() string {
 }
 
 func (s *CreateRuntimeWithoutKymaStep) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	if s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+	if s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
 		log.Infof("KIM is driving the process for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
 		return operation, 0, nil
 	}

--- a/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -2,9 +2,10 @@ package provisioning
 
 import (
 	"fmt"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"reflect"
 	"testing"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"

--- a/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"fmt"
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"reflect"
 	"testing"
 
@@ -30,6 +31,10 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
+	kimConfig := kim.Config{
+		Enabled: false,
+	}
+
 	disabled := false
 	provisionerInput := fixProvisionerInput(disabled, false)
 
@@ -47,7 +52,7 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 		RuntimeID: ptr.String(runtimeID),
 	}, nil)
 
-	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient)
+	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient, kimConfig)
 
 	// when
 	entry := log.WithFields(logrus.Fields{"step": "TEST"})
@@ -76,6 +81,10 @@ func TestCreateRuntimeWithoutKyma_RunWithEuAccess(t *testing.T) {
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
+	kimConfig := kim.Config{
+		Enabled: false,
+	}
+
 	disabled := false
 	provisionerInput := fixProvisionerInput(disabled, true)
 
@@ -93,7 +102,7 @@ func TestCreateRuntimeWithoutKyma_RunWithEuAccess(t *testing.T) {
 		RuntimeID: ptr.String(runtimeID),
 	}, nil)
 
-	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient)
+	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient, kimConfig)
 
 	// when
 	entry := log.WithFields(logrus.Fields{"step": "TEST"})
@@ -184,13 +193,17 @@ func TestCreateRuntimeWithoutKymaStep_RunWithBadRequestError(t *testing.T) {
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
+	kimConfig := kim.Config{
+		Enabled: false,
+	}
+
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
 	provisionerClient := &provisionerAutomock.Client{}
 	provisionerClient.On("ProvisionRuntime", globalAccountID, subAccountID, mock.Anything).Return(gqlschema.OperationStatus{}, fmt.Errorf("some permanent error"))
 
-	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient)
+	step := NewCreateRuntimeWithoutKymaStep(memoryStorage.Operations(), memoryStorage.RuntimeStates(), memoryStorage.Instances(), provisionerClient, kimConfig)
 
 	// when
 	entry := log.WithFields(logrus.Fields{"step": "TEST"})

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -42,6 +42,7 @@ func (_ *checkRuntimeResource) Name() string {
 func (s *checkRuntimeResource) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
 		log.Infof("Only provisioner is controlling provisioning process, skipping")
+		return operation, 0, nil
 	}
 
 	runtime, err := s.GetRuntimeResource(operation.RuntimeID, operation.KymaResourceNamespace)

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -48,18 +48,10 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log logrus.Fiel
 		log.Infof("KIM is not enabled for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
 		return operation, 0, nil
 	}
-	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
-		if s.kimConfig.ViewOnly {
-			log.Infof("Provisioner is controlling provisioning process, skipping")
-			return operation, 0, nil
-		}
-
-		if s.kimConfig.DryRun {
-			log.Infof("KIM integration in dry-run mode, skipping")
-			return operation, 0, nil
-		}
+	if !s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+		log.Infof("Provisioner is controlling provisioning process, skipping")
+		return operation, 0, nil
 	}
-	// post: KIM is enabled for the given plan
 
 	runtime, err := s.GetRuntimeResource(operation.RuntimeID, operation.KymaResourceNamespace)
 	if err != nil {

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -48,16 +48,18 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log logrus.Fiel
 		log.Infof("KIM is not enabled for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
 		return operation, 0, nil
 	}
+	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+		if s.kimConfig.ViewOnly {
+			log.Infof("Provisioner is controlling provisioning process, skipping")
+			return operation, 0, nil
+		}
 
-	if s.kimConfig.ViewOnly {
-		log.Infof("Provisioner is controlling provisioning process, skipping")
-		return operation, 0, nil
+		if s.kimConfig.DryRun {
+			log.Infof("KIM integration in dry-run mode, skipping")
+			return operation, 0, nil
+		}
 	}
-
-	if s.kimConfig.DryRun {
-		log.Infof("KIM integration in dry-run mode, skipping")
-		return operation, 0, nil
-	}
+	// post: KIM is enabled for the given plan
 
 	runtime, err := s.GetRuntimeResource(operation.RuntimeID, operation.KymaResourceNamespace)
 	if err != nil {

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -40,17 +40,8 @@ func (_ *checkRuntimeResource) Name() string {
 }
 
 func (s *checkRuntimeResource) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	if !s.kimConfig.IsEnabledForPlan(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
-		if !s.kimConfig.Enabled {
-			log.Infof("KIM is not enabled, skipping")
-			return operation, 0, nil
-		}
-		log.Infof("KIM is not enabled for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
-		return operation, 0, nil
-	}
-	if !s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
-		log.Infof("Provisioner is controlling provisioning process, skipping")
-		return operation, 0, nil
+	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+		log.Infof("Only provisioner is controlling provisioning process, skipping")
 	}
 
 	runtime, err := s.GetRuntimeResource(operation.RuntimeID, operation.KymaResourceNamespace)

--- a/internal/process/steps/runtime_resource_test.go
+++ b/internal/process/steps/runtime_resource_test.go
@@ -104,12 +104,11 @@ func TestCheckRuntimeResource_RunWhenNotReady_Retry(t *testing.T) {
 }
 
 func fixKimConfigForAzure() kim.Config {
-	kimConfig := kim.Config{
+	return kim.Config{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: false,
 	}
-	return kimConfig
 }
 
 func createRuntime(state imv1.State) imv1.Runtime {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- CreateRuntimeWithoutKyma step skipped for KIM only driven plans
- CheckRuntimeResource called for KIM driven plans

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#791 
#905 