### PR TITLE
KIM Integration - managed by provisioner label not set for KIM only

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
@@ -192,7 +193,7 @@ func (s *CreateRuntimeResourceStep) createShootProvider(operation *internal.Oper
 	max := int32(DefaultIfParamNotSet(values.DefaultAutoScalerMax, operation.ProvisioningParameters.Parameters.AutoScalerMax))
 	min := int32(DefaultIfParamNotSet(values.DefaultAutoScalerMin, operation.ProvisioningParameters.Parameters.AutoScalerMin))
 
-	volumeSize := int32(DefaultIfParamNotSet(values.VolumeSizeGb, operation.ProvisioningParameters.Parameters.VolumeSizeGb))
+	volumeSize := strconv.Itoa(DefaultIfParamNotSet(values.VolumeSizeGb, operation.ProvisioningParameters.Parameters.VolumeSizeGb))
 
 	providerObj := imv1.Provider{
 		Type: values.ProviderType,
@@ -213,7 +214,7 @@ func (s *CreateRuntimeResourceStep) createShootProvider(operation *internal.Oper
 				Zones:          values.Zones,
 				Volume: &gardener.Volume{
 					Type:       ptr.String(values.DiskType),
-					VolumeSize: string(volumeSize),
+					VolumeSize: volumeSize,
 				},
 			},
 		},

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -163,7 +163,7 @@ func (s *CreateRuntimeResourceStep) createLabelsForRuntime(operation internal.Op
 		"kyma-project.io/region":             region,
 		"operator.kyma-project.io/kyma-name": kymaName,
 	}
-	if s.kimConfig.ViewOnly {
+	if s.kimConfig.ViewOnly && !s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
 		labels["kyma-project.io/controlled-by-provisioner"] = "true"
 	}
 	return labels

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -491,7 +491,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
 	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
-	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
+	assertWorkersWithVolume(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"}, "50", "gp2")
 	assertNetworking(t, imv1.Networking{
 		Nodes:    "192.168.48.0/20",
 		Pods:     "10.104.0.0/24",
@@ -717,6 +717,19 @@ func assertWorkers(t *testing.T, workers []gardener.Worker, machine string, maxi
 	assert.Equal(t, workers[0].MaxUnavailable.IntValue(), maxUnavailable)
 	assert.Equal(t, workers[0].Maximum, int32(maximum))
 	assert.Equal(t, workers[0].Minimum, int32(minimum))
+}
+
+func assertWorkersWithVolume(t *testing.T, workers []gardener.Worker, machine string, maximum, minimum, maxSurge, maxUnavailable int, zoneCount int, zones []string, volumeSize, volumeType string) {
+	assert.Len(t, workers, 1)
+	assert.Len(t, workers[0].Zones, zoneCount)
+	assert.Subset(t, zones, workers[0].Zones)
+	assert.Equal(t, workers[0].Machine.Type, machine)
+	assert.Equal(t, workers[0].MaxSurge.IntValue(), maxSurge)
+	assert.Equal(t, workers[0].MaxUnavailable.IntValue(), maxUnavailable)
+	assert.Equal(t, workers[0].Maximum, int32(maximum))
+	assert.Equal(t, workers[0].Minimum, int32(minimum))
+	assert.Equal(t, workers[0].Volume.VolumeSize, volumeSize)
+	assert.Equal(t, *workers[0].Volume.Type, volumeType)
 }
 
 func assertNetworking(t *testing.T, expected imv1.Networking, actual imv1.Networking) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Setting label to false when KIM only driven plan, regardless of viewOnly setting
- volumeSize converted properly

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
 #791
#905 
