### PR TITLE
KIM Integration - adjustments to current KIM behavior 

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -167,6 +167,8 @@ func (s *CreateRuntimeResourceStep) createLabelsForRuntime(operation internal.Op
 	}
 	if s.kimConfig.ViewOnly && !s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
 		labels["kyma-project.io/controlled-by-provisioner"] = "true"
+	} else {
+		labels["kyma-project.io/controlled-by-provisioner"] = "false"
 	}
 	return labels
 }
@@ -339,6 +341,8 @@ func (s *CreateRuntimeResourceStep) createNetworkingConfiguration(operation inte
 		Pods:     DefaultIfParamNotSet(networking.DefaultPodsCIDR, networkingParams.PodsCidr),
 		Services: DefaultIfParamNotSet(networking.DefaultServicesCIDR, networkingParams.ServicesCidr),
 		Nodes:    DefaultIfParamZero(networking.DefaultNodesCIDR, networkingParams.NodesCidr),
+		//TODO remove when KIM is ready with setting this value
+		Type: ptr.String("calico"),
 	}
 }
 

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -42,11 +42,15 @@ const (
 )
 
 var runtimeAdministrators = []string{"admin1@test.com", "admin2@test.com"}
+
 var defaultNetworking = imv1.Networking{
 	Nodes:    networking.DefaultNodesCIDR,
 	Pods:     networking.DefaultPodsCIDR,
 	Services: networking.DefaultServicesCIDR,
+	//TODO: remove after KIM is handling this properly
+	Type: ptr.String("calico"),
 }
+
 var defaultOIDSConfig = internal.OIDCConfigDTO{
 	ClientID:       "client-id-default",
 	GroupsClaim:    "gc-default",
@@ -414,6 +418,8 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 		Nodes:    "192.168.48.0/20",
 		Pods:     "10.104.0.0/24",
 		Services: "10.105.0.0/24",
+		//TODO remove after KIM is handling this properly
+		Type: ptr.String("calico"),
 	}, runtime.Spec.Shoot.Networking)
 
 	_, err = memoryStorage.Instances().GetByID(operation.InstanceID)
@@ -728,7 +734,7 @@ func assertLabelsKIMDriven(t *testing.T, preOperation internal.Operation, runtim
 	assertLabels(t, preOperation, runtime)
 
 	provisionerDriven, ok := runtime.Labels["kyma-project.io/controlled-by-provisioner"]
-	assert.True(t, !ok || provisionerDriven == "false")
+	assert.True(t, ok && provisionerDriven == "false")
 }
 
 func assertLabelsProvisionerDriven(t *testing.T, preOperation internal.Operation, runtime imv1.Runtime) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Always set label indicating who is driving the provisioning - just use boolean values, "kyma-project.io/controlled-by-provisioner": "false" means KIM (inframan) is controlling the process
- Set networking.type temporary as "calico" to pass the validation of Runtime CR, and to progress further

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#791 
#905 