### PR TITLE
KIM Integration - Skipping `Remove_Runtime` step conditionally

### DIFF
--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -62,7 +62,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 			step: deprovisioning.NewCheckGardenerClusterDeletedStep(db.Operations(), cli),
 		},
 		{
-			step: deprovisioning.NewRemoveRuntimeStep(db.Operations(), db.Instances(), provisionerClient, cfg.Provisioner.DeprovisioningTimeout),
+			step: deprovisioning.NewRemoveRuntimeStep(db.Operations(), db.Instances(), provisionerClient, cfg.Provisioner.DeprovisioningTimeout, cfg.Broker.KimConfig),
 		},
 		{
 			step: deprovisioning.NewCheckRuntimeRemovalStep(db.Operations(), db.Instances(), provisionerClient, cfg.Provisioner.DeprovisioningTimeout),

--- a/internal/process/deprovisioning/remove_runtime.go
+++ b/internal/process/deprovisioning/remove_runtime.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -21,14 +23,16 @@ type RemoveRuntimeStep struct {
 	instanceStorage    storage.Instances
 	provisionerClient  provisioner.Client
 	provisionerTimeout time.Duration
+	kimConfig          kim.Config
 }
 
-func NewRemoveRuntimeStep(os storage.Operations, is storage.Instances, cli provisioner.Client, provisionerTimeout time.Duration) *RemoveRuntimeStep {
+func NewRemoveRuntimeStep(os storage.Operations, is storage.Instances, cli provisioner.Client, provisionerTimeout time.Duration, kimConfig kim.Config) *RemoveRuntimeStep {
 	return &RemoveRuntimeStep{
 		operationManager:   process.NewOperationManager(os),
 		instanceStorage:    is,
 		provisionerClient:  cli,
 		provisionerTimeout: provisionerTimeout,
+		kimConfig:          kimConfig,
 	}
 }
 
@@ -37,6 +41,11 @@ func (s *RemoveRuntimeStep) Name() string {
 }
 
 func (s *RemoveRuntimeStep) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	if s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+		log.Infof("KIM is driving the process for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
+		return operation, 0, nil
+	}
+
 	if time.Since(operation.UpdatedAt) > s.provisionerTimeout {
 		log.Infof("operation has reached the time limit: updated operation time: %s", operation.UpdatedAt)
 		return s.operationManager.OperationFailed(operation, fmt.Sprintf("operation has reached the time limit: %s", s.provisionerTimeout), nil, log)

--- a/internal/process/deprovisioning/remove_runtime_test.go
+++ b/internal/process/deprovisioning/remove_runtime_test.go
@@ -1,9 +1,10 @@
 package deprovisioning
 
 import (
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"testing"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	provisionerAutomock "github.com/kyma-project/kyma-environment-broker/internal/provisioner/automock"

--- a/internal/process/deprovisioning/remove_runtime_test.go
+++ b/internal/process/deprovisioning/remove_runtime_test.go
@@ -1,6 +1,7 @@
 package deprovisioning
 
 import (
+	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	"testing"
 	"time"
 
@@ -17,6 +18,9 @@ func TestRemoveRuntimeStep_Run(t *testing.T) {
 		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
+		kimConfig := kim.Config{
+			Enabled: false,
+		}
 		operation := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
 		operation.GlobalAccountID = fixGlobalAccountID
 		operation.RuntimeID = fixRuntimeID
@@ -29,7 +33,7 @@ func TestRemoveRuntimeStep_Run(t *testing.T) {
 		provisionerClient := &provisionerAutomock.Client{}
 		provisionerClient.On("DeprovisionRuntime", fixGlobalAccountID, fixRuntimeID).Return(fixProvisionerOperationID, nil)
 
-		step := NewRemoveRuntimeStep(memoryStorage.Operations(), memoryStorage.Instances(), provisionerClient, time.Minute)
+		step := NewRemoveRuntimeStep(memoryStorage.Operations(), memoryStorage.Instances(), provisionerClient, time.Minute, kimConfig)
 
 		// when
 		entry := log.WithFields(logrus.Fields{"step": "TEST"})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- If plan is driven by KIM only, skip calling the step which requires provisioner being aware of the instance/shoot

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#791 
#905 
