### PR TITLE
KIM Integration - instances on `runtimes` endpoint decorated with Runtime CR

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -266,7 +266,9 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	expirationHandler := expiration.NewHandler(db.Instances(), db.Operations(), deprovisioningQueue, logs)
 	expirationHandler.AttachRoutes(ts.router)
 
-	runtimeHandler := kebRuntime.NewHandler(db.Instances(), db.Operations(), db.RuntimeStates(), db.InstancesArchived(), cfg.MaxPaginationPage, cfg.DefaultRequestRegion, provisionerClient, logs)
+	runtimeHandler := kebRuntime.NewHandler(db.Instances(), db.Operations(), db.RuntimeStates(), db.InstancesArchived(), cfg.MaxPaginationPage, cfg.DefaultRequestRegion, provisionerClient, cli, broker.KimConfig{
+		Enabled: false,
+	}, logs)
 	runtimeHandler.AttachRoutes(ts.router)
 
 	ts.httpServer = httptest.NewServer(ts.router)

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -385,7 +385,10 @@ func main() {
 	// create list runtimes endpoint
 	runtimeHandler := runtime.NewHandler(db.Instances(), db.Operations(),
 		db.RuntimeStates(), db.InstancesArchived(), cfg.MaxPaginationPage,
-		cfg.DefaultRequestRegion, provisionerClient, logs)
+		cfg.DefaultRequestRegion, provisionerClient,
+		cli,
+		cfg.Broker.KimConfig,
+		logs)
 	runtimeHandler.AttachRoutes(router)
 
 	// create expiration endpoint

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -53,6 +53,7 @@ type RuntimeDTO struct {
 	AVSInternalEvaluationID     int64                          `json:"avsInternalEvaluationID"`
 	KymaConfig                  *gqlschema.KymaConfigInput     `json:"kymaConfig,omitempty"`
 	ClusterConfig               *gqlschema.GardenerConfigInput `json:"clusterConfig,omitempty"`
+	RuntimeConfig               *map[string]interface{}        `json:"runtimeConfig,omitempty"`
 }
 
 type RuntimeStatus struct {
@@ -119,6 +120,7 @@ const (
 	ClusterConfigParam   = "cluster_config"
 	ExpiredParam         = "expired"
 	GardenerConfigParam  = "gardener_config"
+	RuntimeConfigParam   = "runtime_config"
 )
 
 type OperationDetail string
@@ -139,6 +141,8 @@ type ListParameters struct {
 	KymaConfig bool
 	// ClusterConfig specifies whether Gardener cluster configuration details should be included in the response for each runtime
 	ClusterConfig bool
+	// RuntimeResourceConfig specifies whether current Runtime Custom Resource details should be included in the response for each runtime
+	RuntimeResourceConfig bool
 	// GardenerConfig specifies whether current Gardener cluster configuration details from provisioner should be included in the response for each runtime
 	GardenerConfig bool
 	// GlobalAccountIDs parameter filters runtimes by specified global account IDs

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal"
-	kim "github.com/kyma-project/kyma-environment-broker/internal/kim"
 )
 
 const (
@@ -50,7 +49,7 @@ type Config struct {
 	EnableShootAndSeedSameRegion            bool          `envconfig:"default=false"`
 
 	Binding                BindingConfig
-	KimConfig              kim.Config
+	KimConfig              KimConfig
 	UseSmallerMachineTypes bool `envconfig:"default=false"`
 }
 

--- a/internal/broker/kim_config.go
+++ b/internal/broker/kim_config.go
@@ -1,6 +1,6 @@
-package kim
+package broker
 
-type Config struct {
+type KimConfig struct {
 	Enabled      bool     `envconfig:"default=false"` // if true, KIM will be used
 	DryRun       bool     `envconfig:"default=true"`  // if true, only yamls are generated, no resources are created
 	ViewOnly     bool     `envconfig:"default=true"`  // if true, provisioner will control the process
@@ -8,7 +8,7 @@ type Config struct {
 	KimOnlyPlans []string `envconfig:"default=,"`
 }
 
-func (c *Config) IsEnabledForPlan(planName string) bool {
+func (c *KimConfig) IsEnabledForPlan(planName string) bool {
 	if c.Enabled == false {
 		return false
 	}
@@ -20,7 +20,7 @@ func (c *Config) IsEnabledForPlan(planName string) bool {
 	return false
 }
 
-func (c *Config) IsDrivenByKimOnly(planName string) bool {
+func (c *KimConfig) IsDrivenByKimOnly(planName string) bool {
 	if !c.IsEnabledForPlan(planName) {
 		return false
 	}
@@ -32,6 +32,21 @@ func (c *Config) IsDrivenByKimOnly(planName string) bool {
 	return false
 }
 
-func (c *Config) IsDrivenByKim(planName string) bool {
+func (c *KimConfig) IsPlanIdDrivenByKimOnly(planID string) bool {
+	planName := PlanIDsMapping[planID]
+	return c.IsDrivenByKimOnly(planName)
+}
+
+func (c *KimConfig) IsPlanIdDrivenByKim(planID string) bool {
+	planName := PlanIDsMapping[planID]
+	return c.IsDrivenByKim(planName)
+}
+
+func (c *KimConfig) IsDrivenByKim(planName string) bool {
 	return (c.IsEnabledForPlan(planName) && !c.ViewOnly && !c.DryRun) || c.IsDrivenByKimOnly(planName)
+}
+
+func (c *KimConfig) IsEnabledForPlanID(planID string) bool {
+	planName := PlanIDsMapping[planID]
+	return c.IsEnabledForPlan(planName)
 }

--- a/internal/broker/kim_config_test.go
+++ b/internal/broker/kim_config_test.go
@@ -1,4 +1,4 @@
-package kim
+package broker
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 )
 
 func TestIsEnabled_KimDisabled(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:  false,
 		Plans:    []string{"gcp", "preview"},
 		ViewOnly: false,
@@ -22,7 +22,7 @@ func TestIsEnabled_KimDisabled(t *testing.T) {
 }
 
 func TestIsEnabled_KimEnabledForPreview(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:  true,
 		Plans:    []string{"preview"},
 		ViewOnly: false,
@@ -38,7 +38,7 @@ func TestIsEnabled_KimEnabledForPreview(t *testing.T) {
 }
 
 func TestIsEnabled_KimEnabledForPreview_DryRun(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:  true,
 		Plans:    []string{"preview"},
 		ViewOnly: false,
@@ -54,7 +54,7 @@ func TestIsEnabled_KimEnabledForPreview_DryRun(t *testing.T) {
 }
 
 func TestDrivenByKimOnly_KimDisabled(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:      false,
 		Plans:        []string{"gcp", "preview"},
 		KimOnlyPlans: []string{"preview"},
@@ -67,10 +67,16 @@ func TestDrivenByKimOnly_KimDisabled(t *testing.T) {
 	assert.False(t, config.IsDrivenByKim("preview"))
 	assert.False(t, config.IsDrivenByKimOnly("gcp"))
 	assert.False(t, config.IsDrivenByKimOnly("preview"))
+	assert.False(t, config.IsPlanIdDrivenByKimOnly("ca6e5357-707f-4565-bbbd-b3ab732597c6"))
+	assert.False(t, config.IsPlanIdDrivenByKimOnly("5cb3d976-b85c-42ea-a636-79cadda109a9"))
+	assert.False(t, config.IsPlanIdDrivenByKim("ca6e5357-707f-4565-bbbd-b3ab732597c6"))
+	assert.False(t, config.IsPlanIdDrivenByKim("5cb3d976-b85c-42ea-a636-79cadda109a9"))
+	assert.False(t, config.IsPlanIdDrivenByKimOnly("ca6e5357-707f-4565-bbbd-b3ab732597c6"))
+	assert.False(t, config.IsPlanIdDrivenByKimOnly("5cb3d976-b85c-42ea-a636-79cadda109a9"))
 }
 
 func TestDrivenByKimOnly_PreviewByKimOnly(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:      true,
 		Plans:        []string{"preview"},
 		KimOnlyPlans: []string{"preview"},
@@ -86,7 +92,7 @@ func TestDrivenByKimOnly_PreviewByKimOnly(t *testing.T) {
 }
 
 func TestDrivenByKimOnly_PreviewByKimOnlyButNotEnabled(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:      true,
 		KimOnlyPlans: []string{"preview"},
 		ViewOnly:     false,
@@ -101,7 +107,7 @@ func TestDrivenByKimOnly_PreviewByKimOnlyButNotEnabled(t *testing.T) {
 }
 
 func TestDrivenByKim_ButNotByKimOnly(t *testing.T) {
-	config := &Config{
+	config := &KimConfig{
 		Enabled:      true,
 		KimOnlyPlans: []string{"no-plan"},
 		Plans:        []string{"preview"},

--- a/internal/process/deprovisioning/remove_runtime.go
+++ b/internal/process/deprovisioning/remove_runtime.go
@@ -39,8 +39,8 @@ func (s *RemoveRuntimeStep) Name() string {
 }
 
 func (s *RemoveRuntimeStep) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
-		log.Infof("KIM is driving the process for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
+	if s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+		log.Infof("Only KIM is driving the process for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
 		return operation, 0, nil
 	}
 

--- a/internal/process/deprovisioning/remove_runtime.go
+++ b/internal/process/deprovisioning/remove_runtime.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -23,10 +21,10 @@ type RemoveRuntimeStep struct {
 	instanceStorage    storage.Instances
 	provisionerClient  provisioner.Client
 	provisionerTimeout time.Duration
-	kimConfig          kim.Config
+	kimConfig          broker.KimConfig
 }
 
-func NewRemoveRuntimeStep(os storage.Operations, is storage.Instances, cli provisioner.Client, provisionerTimeout time.Duration, kimConfig kim.Config) *RemoveRuntimeStep {
+func NewRemoveRuntimeStep(os storage.Operations, is storage.Instances, cli provisioner.Client, provisionerTimeout time.Duration, kimConfig broker.KimConfig) *RemoveRuntimeStep {
 	return &RemoveRuntimeStep{
 		operationManager:   process.NewOperationManager(os),
 		instanceStorage:    is,
@@ -41,7 +39,7 @@ func (s *RemoveRuntimeStep) Name() string {
 }
 
 func (s *RemoveRuntimeStep) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	if s.kimConfig.IsDrivenByKimOnly(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
+	if !s.kimConfig.IsDrivenByKim(broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]) {
 		log.Infof("KIM is driving the process for plan %s, skipping", broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID])
 		return operation, 0, nil
 	}

--- a/internal/process/deprovisioning/remove_runtime_test.go
+++ b/internal/process/deprovisioning/remove_runtime_test.go
@@ -1,10 +1,9 @@
 package deprovisioning
 
 import (
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"testing"
 	"time"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	provisionerAutomock "github.com/kyma-project/kyma-environment-broker/internal/provisioner/automock"
@@ -19,7 +18,7 @@ func TestRemoveRuntimeStep_Run(t *testing.T) {
 		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
-		kimConfig := kim.Config{
+		kimConfig := broker.KimConfig{
 			Enabled: false,
 		}
 		operation := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)

--- a/internal/process/deprovisioning/remove_runtime_test.go
+++ b/internal/process/deprovisioning/remove_runtime_test.go
@@ -1,9 +1,10 @@
 package deprovisioning
 
 import (
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"testing"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	provisionerAutomock "github.com/kyma-project/kyma-environment-broker/internal/provisioner/automock"

--- a/internal/process/provisioning/check_runtime_step.go
+++ b/internal/process/provisioning/check_runtime_step.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 
 	"github.com/sirupsen/logrus"
 
@@ -21,13 +20,13 @@ type CheckRuntimeStep struct {
 	provisionerClient   provisioner.Client
 	operationManager    *process.OperationManager
 	provisioningTimeout time.Duration
-	kimConfig           kim.Config
+	kimConfig           broker.KimConfig
 }
 
 func NewCheckRuntimeStep(os storage.Operations,
 	provisionerClient provisioner.Client,
 	provisioningTimeout time.Duration,
-	kimConfig kim.Config) *CheckRuntimeStep {
+	kimConfig broker.KimConfig) *CheckRuntimeStep {
 	return &CheckRuntimeStep{
 		provisionerClient:   provisionerClient,
 		operationManager:    process.NewOperationManager(os),

--- a/internal/process/provisioning/check_runtime_step_test.go
+++ b/internal/process/provisioning/check_runtime_step_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -45,7 +43,7 @@ func TestCheckRuntimeStep_RunProvisioningSucceeded(t *testing.T) {
 				RuntimeID: ptr.String(statusRuntimeID),
 			})
 
-			kimConfig := kim.Config{
+			kimConfig := broker.KimConfig{
 				Enabled: false,
 			}
 
@@ -92,7 +90,7 @@ func TestCheckRuntimeStep_RunProvisioningSucceeded_WithKimOnly(t *testing.T) {
 				RuntimeID: ptr.String(statusRuntimeID),
 			})
 
-			kimConfig := kim.Config{
+			kimConfig := broker.KimConfig{
 				Enabled:      true,
 				Plans:        []string{"gcp"},
 				KimOnlyPlans: []string{"gcp"},

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -26,8 +26,6 @@ import (
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
@@ -39,14 +37,14 @@ type CreateRuntimeResourceStep struct {
 	instanceStorage            storage.Instances
 	runtimeStateStorage        storage.RuntimeStates
 	k8sClient                  client.Client
-	kimConfig                  kim.Config
+	kimConfig                  broker.KimConfig
 	config                     input.Config
 	trialPlatformRegionMapping map[string]string
 	useSmallerMachineTypes     bool
 	oidcDefaultValues          internal.OIDCConfigDTO
 }
 
-func NewCreateRuntimeResourceStep(os storage.Operations, is storage.Instances, k8sClient client.Client, kimConfig kim.Config, cfg input.Config,
+func NewCreateRuntimeResourceStep(os storage.Operations, is storage.Instances, k8sClient client.Client, kimConfig broker.KimConfig, cfg input.Config,
 	trialPlatformRegionMapping map[string]string, useSmallerMachines bool, oidcDefaultValues internal.OIDCConfigDTO) *CreateRuntimeResourceStep {
 	return &CreateRuntimeResourceStep{
 		operationManager:           process.NewOperationManager(os),

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -27,8 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -816,8 +814,8 @@ func getClientForTests(t *testing.T) client.Client {
 	return cli
 }
 
-func fixKimConfig(planName string, dryRun bool) kim.Config {
-	return kim.Config{
+func fixKimConfig(planName string, dryRun bool) broker.KimConfig {
+	return broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{planName},
 		ViewOnly: false,
@@ -825,20 +823,11 @@ func fixKimConfig(planName string, dryRun bool) kim.Config {
 	}
 }
 
-func fixKimConfigWithAllPlans(dryRun bool) kim.Config {
-	return kim.Config{
+func fixKimConfigWithAllPlans(dryRun bool) broker.KimConfig {
+	return broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure", "gcp", "azure_lite", "trial", "aws", "free", "preview", "sap-converged-cloud"},
 		ViewOnly: false,
-		DryRun:   dryRun,
-	}
-}
-
-func fixKimConfigProvisionerDriven(planName string, dryRun bool) kim.Config {
-	return kim.Config{
-		Enabled:  true,
-		Plans:    []string{planName},
-		ViewOnly: true,
 		DryRun:   dryRun,
 	}
 }
@@ -883,23 +872,4 @@ channel: stable
 modules: []
 `
 	return operation
-}
-
-func fixProvisionerParameters(cloudProvider internal.CloudProvider, region string) internal.ProvisioningParametersDTO {
-	return internal.ProvisioningParametersDTO{
-		Name:         "cluster-test",
-		VolumeSizeGb: ptr.Integer(50),
-		MachineType:  ptr.String("Standard_D8_v3"),
-		Region:       ptr.String(region),
-		Purpose:      ptr.String("Purpose"),
-		LicenceType:  ptr.String("LicenceType"),
-		Zones:        []string{"1"},
-		AutoScalerParameters: internal.AutoScalerParameters{
-			AutoScalerMin:  ptr.Integer(3),
-			AutoScalerMax:  ptr.Integer(10),
-			MaxSurge:       ptr.Integer(4),
-			MaxUnavailable: ptr.Integer(1),
-		},
-		Provider: &cloudProvider,
-	}
 }

--- a/internal/process/provisioning/create_runtime_without_kyma_step.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_step.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
@@ -30,10 +28,10 @@ type CreateRuntimeWithoutKymaStep struct {
 	instanceStorage     storage.Instances
 	runtimeStateStorage storage.RuntimeStates
 	provisionerClient   provisioner.Client
-	kimConfig           kim.Config
+	kimConfig           broker.KimConfig
 }
 
-func NewCreateRuntimeWithoutKymaStep(os storage.Operations, runtimeStorage storage.RuntimeStates, is storage.Instances, cli provisioner.Client, kimConfig kim.Config) *CreateRuntimeWithoutKymaStep {
+func NewCreateRuntimeWithoutKymaStep(os storage.Operations, runtimeStorage storage.RuntimeStates, is storage.Instances, cli provisioner.Client, kimConfig broker.KimConfig) *CreateRuntimeWithoutKymaStep {
 	return &CreateRuntimeWithoutKymaStep{
 		operationManager:    process.NewOperationManager(os),
 		instanceStorage:     is,

--- a/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/provider"
@@ -32,7 +30,7 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled: false,
 	}
 
@@ -82,7 +80,7 @@ func TestCreateRuntimeWithoutKyma_SkipForKIM(t *testing.T) {
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:      true,
 		Plans:        []string{"gcp"},
 		KimOnlyPlans: []string{"gcp"},
@@ -130,7 +128,7 @@ func TestCreateRuntimeWithoutKyma_RunWithEuAccess(t *testing.T) {
 	err = memoryStorage.Instances().Insert(fixInstance())
 	assert.NoError(t, err)
 
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled: false,
 	}
 
@@ -242,7 +240,7 @@ func TestCreateRuntimeWithoutKymaStep_RunWithBadRequestError(t *testing.T) {
 	err := memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled: false,
 	}
 

--- a/internal/process/provisioning/get_kubeconfig_step.go
+++ b/internal/process/provisioning/get_kubeconfig_step.go
@@ -3,8 +3,6 @@ package provisioning
 import (
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/sirupsen/logrus"
 
@@ -18,12 +16,12 @@ type GetKubeconfigStep struct {
 	provisionerClient   provisioner.Client
 	operationManager    *process.OperationManager
 	provisioningTimeout time.Duration
-	kimConfig           kim.Config
+	kimConfig           broker.KimConfig
 }
 
 func NewGetKubeconfigStep(os storage.Operations,
 	provisionerClient provisioner.Client,
-	kimConfig kim.Config) *GetKubeconfigStep {
+	kimConfig broker.KimConfig) *GetKubeconfigStep {
 	return &GetKubeconfigStep{
 		provisionerClient: provisionerClient,
 		operationManager:  process.NewOperationManager(os),

--- a/internal/process/provisioning/get_kubeconfig_test.go
+++ b/internal/process/provisioning/get_kubeconfig_test.go
@@ -3,8 +3,6 @@ package provisioning
 import (
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
@@ -24,7 +22,7 @@ const (
 
 func TestGetKubeconfigStep(t *testing.T) {
 
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled: false,
 	}
 

--- a/internal/process/steps/gardener_cluster.go
+++ b/internal/process/steps/gardener_cluster.go
@@ -7,10 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
@@ -23,7 +21,7 @@ import (
 
 const GardenerClusterStateReady = "Ready"
 
-func NewSyncGardenerCluster(os storage.Operations, k8sClient client.Client, kimConfig kim.Config) *syncGardenerCluster {
+func NewSyncGardenerCluster(os storage.Operations, k8sClient client.Client, kimConfig broker.KimConfig) *syncGardenerCluster {
 	return &syncGardenerCluster{
 		k8sClient:        k8sClient,
 		kimConfig:        kimConfig,
@@ -31,7 +29,7 @@ func NewSyncGardenerCluster(os storage.Operations, k8sClient client.Client, kimC
 	}
 }
 
-func NewCheckGardenerCluster(os storage.Operations, k8sClient client.Client, kimConfig kim.Config, gardenerClusterStepTimeout time.Duration) *checkGardenerCluster {
+func NewCheckGardenerCluster(os storage.Operations, k8sClient client.Client, kimConfig broker.KimConfig, gardenerClusterStepTimeout time.Duration) *checkGardenerCluster {
 	return &checkGardenerCluster{
 		k8sClient:                  k8sClient,
 		kimConfig:                  kimConfig,
@@ -43,7 +41,7 @@ func NewCheckGardenerCluster(os storage.Operations, k8sClient client.Client, kim
 type checkGardenerCluster struct {
 	k8sClient                  client.Client
 	operationManager           *process.OperationManager
-	kimConfig                  kim.Config
+	kimConfig                  broker.KimConfig
 	gardenerClusterStepTimeout time.Duration
 }
 
@@ -96,7 +94,7 @@ func (s *checkGardenerCluster) GetGardenerCluster(name string, namespace string)
 
 type syncGardenerCluster struct {
 	k8sClient        client.Client
-	kimConfig        kim.Config
+	kimConfig        broker.KimConfig
 	operationManager *process.OperationManager
 }
 

--- a/internal/process/steps/gardener_cluster_test.go
+++ b/internal/process/steps/gardener_cluster_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 
@@ -53,7 +53,7 @@ spec:
 func TestSyncGardenerCluster_RunWithExistingResource(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: true,
@@ -107,7 +107,7 @@ spec:
 func TestSyncGardenerCluster_Run(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: true,
@@ -149,13 +149,12 @@ spec:
 func TestCheckGardenerCluster_RunWhenReady(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: true,
 		DryRun:   false,
 	}
-
 	existingGC := NewGardenerCluster("runtime-id-000", "kcp-system")
 	err := existingGC.SetState("Ready")
 	assert.NoError(t, err)
@@ -179,7 +178,7 @@ func TestCheckGardenerCluster_RunWhenReady(t *testing.T) {
 func TestCheckGardenerCluster_RunWhenNotReady_OperationFail(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: true,
@@ -212,7 +211,7 @@ func TestCheckGardenerCluster_RunWhenNotReady_OperationFail(t *testing.T) {
 func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimDrives(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: false,
@@ -244,7 +243,7 @@ func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimDrives(t *testing.T) {
 func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimOnlyPlanUsed(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:      true,
 		Plans:        []string{"azure"},
 		KimOnlyPlans: []string{"azure"},
@@ -277,7 +276,7 @@ func TestCheckGardenerCluster_IgnoreWhenNotReadyButKimOnlyPlanUsed(t *testing.T)
 func TestCheckGardenerCluster_RunWhenNotReady_Retry(t *testing.T) {
 	// given
 	os := storage.NewMemoryStorage().Operations()
-	kimConfig := kim.Config{
+	kimConfig := broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: true,

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -56,11 +56,15 @@ func KymaName(operation internal.Operation) string {
 }
 
 func KymaRuntimeResourceName(operation internal.Operation) string {
-	return strings.ToLower(operation.RuntimeID)
+	return KymaRuntimeResourceNameFromID(operation.RuntimeID)
 }
 
 func KymaNameFromInstance(instance *internal.Instance) string {
-	return strings.ToLower(instance.RuntimeID)
+	return KymaRuntimeResourceNameFromID(instance.RuntimeID)
+}
+
+func KymaRuntimeResourceNameFromID(ID string) string {
+	return strings.ToLower(ID)
 }
 
 func CreateKymaNameFromOperation(operation internal.Operation) string {

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
-
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
@@ -19,7 +17,7 @@ import (
 
 const RuntimeResourceStateReady = "Ready"
 
-func NewCheckRuntimeResourceStep(os storage.Operations, k8sClient client.Client, kimConfig kim.Config, runtimeResourceStepTimeout time.Duration) *checkRuntimeResource {
+func NewCheckRuntimeResourceStep(os storage.Operations, k8sClient client.Client, kimConfig broker.KimConfig, runtimeResourceStepTimeout time.Duration) *checkRuntimeResource {
 	return &checkRuntimeResource{
 		k8sClient:                  k8sClient,
 		operationManager:           process.NewOperationManager(os),
@@ -30,7 +28,7 @@ func NewCheckRuntimeResourceStep(os storage.Operations, k8sClient client.Client,
 
 type checkRuntimeResource struct {
 	k8sClient                  client.Client
-	kimConfig                  kim.Config
+	kimConfig                  broker.KimConfig
 	operationManager           *process.OperationManager
 	runtimeResourceStepTimeout time.Duration
 }

--- a/internal/process/steps/runtime_resource_test.go
+++ b/internal/process/steps/runtime_resource_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
+
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
-	"github.com/kyma-project/kyma-environment-broker/internal/kim"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/pivotal-cf/brokerapi/v8/domain"
@@ -103,8 +104,8 @@ func TestCheckRuntimeResource_RunWhenNotReady_Retry(t *testing.T) {
 	assert.NotZero(t, backoff)
 }
 
-func fixKimConfigForAzure() kim.Config {
-	return kim.Config{
+func fixKimConfigForAzure() broker.KimConfig {
+	return broker.KimConfig{
 		Enabled:  true,
 		Plans:    []string{"azure"},
 		ViewOnly: false,

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -3,8 +3,9 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -1,8 +1,16 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sirupsen/logrus"
 
@@ -32,12 +40,16 @@ type Handler struct {
 	converter           Converter
 	defaultMaxPage      int
 	provisionerClient   provisioner.Client
+	k8sClient           client.Client
+	kimConfig           broker.KimConfig
 	logger              logrus.FieldLogger
 }
 
 func NewHandler(instanceDb storage.Instances, operationDb storage.Operations, runtimeStatesDb storage.RuntimeStates,
 	instancesArchived storage.InstancesArchived, defaultMaxPage int, defaultRequestRegion string,
-	provisionerClient provisioner.Client, logger logrus.FieldLogger) *Handler {
+	provisionerClient provisioner.Client,
+	k8sClient client.Client, kimConfig broker.KimConfig,
+	logger logrus.FieldLogger) *Handler {
 	return &Handler{
 		instancesDb:         instanceDb,
 		operationsDb:        operationDb,
@@ -46,6 +58,8 @@ func NewHandler(instanceDb storage.Instances, operationDb storage.Operations, ru
 		defaultMaxPage:      defaultMaxPage,
 		provisionerClient:   provisionerClient,
 		instancesArchivedDb: instancesArchived,
+		kimConfig:           kimConfig,
+		k8sClient:           k8sClient,
 		logger:              logger.WithField("service", "RuntimeHandler"),
 	}
 }
@@ -177,6 +191,7 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 	kymaConfig := getBoolParam(pkg.KymaConfigParam, req)
 	clusterConfig := getBoolParam(pkg.ClusterConfigParam, req)
 	gardenerConfig := getBoolParam(pkg.GardenerConfigParam, req)
+	runtimeResourceConfig := getBoolParam(pkg.RuntimeConfigParam, req)
 
 	instances, count, totalCount, err := h.listInstances(filter)
 	if err != nil {
@@ -205,11 +220,32 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 			httputil.WriteErrorResponse(w, http.StatusInternalServerError, err)
 			return
 		}
-		err = h.setRuntimeOptionalAttributes(&dto, kymaConfig, clusterConfig, gardenerConfig)
+
+		instanceDrivenByKimOnly := h.kimConfig.IsDrivenByKimOnly(dto.ServicePlanName)
+
+		err = h.setRuntimeOptionalAttributes(&dto, kymaConfig, clusterConfig, gardenerConfig, instanceDrivenByKimOnly)
 		if err != nil {
 			h.logger.Warn(fmt.Sprintf("unable to set optional attributes: %s", err.Error()))
 			httputil.WriteErrorResponse(w, http.StatusInternalServerError, err)
 			return
+		}
+
+		if runtimeResourceConfig && dto.RuntimeID != "" {
+			runtimeResourceName, runtimeNamespaceName := h.getRuntimeNamesFromLastOperation(dto)
+
+			runtimeResourceObject := &unstructured.Unstructured{}
+			runtimeResourceObject.SetGroupVersionKind(RuntimeResourceGVK())
+			err = h.k8sClient.Get(context.Background(), client.ObjectKey{
+				Namespace: runtimeNamespaceName,
+				Name:      runtimeResourceName,
+			}, runtimeResourceObject)
+			switch {
+			case errors.IsNotFound(err):
+				h.logger.Info(fmt.Sprintf("Runtime resource %s/%s: is not found: %s", dto.InstanceID, dto.RuntimeID, err.Error()))
+			case err != nil:
+				h.logger.Warn(fmt.Sprintf("unable to get Runtime resource %s/%s: %s", dto.InstanceID, dto.RuntimeID, err.Error()))
+			}
+			dto.RuntimeConfig = &runtimeResourceObject.Object
 		}
 
 		toReturn = append(toReturn, dto)
@@ -221,6 +257,20 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 		TotalCount: totalCount,
 	}
 	httputil.WriteResponse(w, http.StatusOK, runtimePage)
+}
+
+func (h *Handler) getRuntimeNamesFromLastOperation(dto pkg.RuntimeDTO) (string, string) {
+	// TODO get rid of additional DB query - we have this info fetched from DB but it is tedious to pass it through
+	op, err := h.operationsDb.GetLastOperation(dto.InstanceID)
+	runtimeResourceName := steps.KymaRuntimeResourceNameFromID(dto.RuntimeID)
+	runtimeNamespaceName := "kcp-system"
+	if err != nil || op.RuntimeResourceName != "" {
+		runtimeResourceName = op.RuntimeResourceName
+	}
+	if err != nil || op.KymaResourceNamespace != "" {
+		runtimeNamespaceName = op.KymaResourceNamespace
+	}
+	return runtimeResourceName, runtimeNamespaceName
 }
 
 func (h *Handler) takeLastNonDryRunClusterOperations(oprs []internal.UpgradeClusterOperation) ([]internal.UpgradeClusterOperation, int) {
@@ -353,7 +403,8 @@ func (h *Handler) setRuntimeLastOperation(dto *pkg.RuntimeDTO) error {
 	return nil
 }
 
-func (h *Handler) setRuntimeOptionalAttributes(dto *pkg.RuntimeDTO, kymaConfig, clusterConfig, gardenerConfig bool) error {
+func (h *Handler) setRuntimeOptionalAttributes(dto *pkg.RuntimeDTO, kymaConfig, clusterConfig, gardenerConfig, drivenByKimOnly bool) error {
+
 	if kymaConfig || clusterConfig {
 		states, err := h.runtimeStatesDb.ListByRuntimeID(dto.RuntimeID)
 		if err != nil && !dberr.IsNotFound(err) {
@@ -374,12 +425,14 @@ func (h *Handler) setRuntimeOptionalAttributes(dto *pkg.RuntimeDTO, kymaConfig, 
 		}
 	}
 
-	if gardenerConfig {
+	if gardenerConfig && dto.RuntimeID != "" && !drivenByKimOnly {
 		runtimeStatus, err := h.provisionerClient.RuntimeStatus(dto.GlobalAccountID, dto.RuntimeID)
 		if err != nil {
-			return fmt.Errorf("while fetching runtime status from provisioner for instance %s: %w", dto.InstanceID, err)
+			dto.Status.GardenerConfig = nil
+			h.logger.Warnf("unable to fetch runtime status for instance %s: %s", dto.InstanceID, err.Error())
+		} else {
+			dto.Status.GardenerConfig = runtimeStatus.RuntimeConfiguration.ClusterConfig
 		}
-		dto.Status.GardenerConfig = runtimeStatus.RuntimeConfiguration.ClusterConfig
 	}
 
 	return nil
@@ -465,4 +518,12 @@ func getBoolParam(param string, req *http.Request) bool {
 	}
 
 	return requested
+}
+
+func RuntimeResourceGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "infrastructuremanager.kyma-project.io",
+		Version: "v1",
+		Kind:    "Runtime",
+	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

KEB endpoint `runtimes` is used by `kcp` CLI e.g. to get gardener configuration information (using `--gardener-config` switch), and this information is used quite often to assert in SKR tests. Getting gardener configuration requires communication with provisioner, so in case of KIM driven instances is pointless.
We need the way to base assertions on the spec fields of Runtime CR.

Changes proposed in this pull request:

- adding new query parameter `runtime-config`
- handling scenario when with `--gardener-config` flag we process instance not known to provisioner

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#791 
#905 
