### PR TITLE
Extend KCP rt output

### DIFF
--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -112,8 +112,6 @@ func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]pkg.RuntimeDTO
 			}
 			archived = append(archived, dto)
 		}
-		// reverse instances to list them in correct order in KCP CLI
-		slices.Reverse(archived)
 		instancesUnion := unionInstances(instanceDTOs, archived)
 		return instancesUnion, instancesCount + instancesArchivedCount, instancesTotalCount + instancesArchivedTotalCount, nil
 	}

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -100,6 +100,7 @@ func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]pkg.RuntimeDTO
 			}
 			dto.Status = pkg.RuntimeStatus{
 				CreatedAt: i.ProvisioningStartedAt,
+				DeletedAt: &i.LastDeprovisioningFinishedAt,
 				Provisioning: &pkg.Operation{
 					CreatedAt: i.ProvisioningStartedAt,
 					UpdatedAt: i.ProvisioningFinishedAt,
@@ -111,6 +112,8 @@ func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]pkg.RuntimeDTO
 			}
 			archived = append(archived, dto)
 		}
+		// reverse instances to list them in correct order in KCP CLI
+		slices.Reverse(archived)
 		instancesUnion := unionInstances(instanceDTOs, archived)
 		return instancesUnion, instancesCount + instancesArchivedCount, instancesTotalCount + instancesArchivedTotalCount, nil
 	}

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -981,7 +981,7 @@ func (r readSession) ListInstancesArchived(filter dbmodel.InstanceFilter) ([]dbm
 
 	stmt := r.session.Select("*").
 		From(InstancesArchivedTableName).
-		OrderBy("last_deprovisioning_finished_at")
+		OrderDesc("last_deprovisioning_finished_at")
 
 	if filter.Page > 0 && filter.PageSize > 0 {
 		stmt.Paginate(uint64(filter.Page), uint64(filter.PageSize))


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add `deleted at` to runtime status,
- fetch recently deleted runtimes.

**Related issue(s)**
See also #1064
