### PR TITLE
dont return error if there was context update to expired instance

### DIFF
--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -946,6 +946,7 @@ func fixConfig() *Config {
 				Enabled:       true,
 				BindablePlans: []string{"aws", "azure"},
 			},
+			AllowUpdateExpiredInstanceWithContext: true,
 		},
 		TrialRegionMappingFilePath: "testdata/trial-regions.yaml",
 

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -2443,7 +2443,7 @@ func TestUpdateOnlyErsContextForExpiredInstance(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 }
 
-func TestUpdateParams(t *testing.T) {
+func TestUpdateParamsForExpiredInstance(t *testing.T) {
 	suite := NewBrokerSuiteTest(t, "2.0")
 	defer suite.TearDown()
 	iid := uuid.New().String()
@@ -2484,7 +2484,7 @@ func TestUpdateParams(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, response.StatusCode)
 }
 
-func TestUpdateErsContextAndParams(t *testing.T) {
+func TestUpdateErsContextAndParamsForExpiredInstance(t *testing.T) {
 	suite := NewBrokerSuiteTest(t, "2.0")
 	defer suite.TearDown()
 	iid := uuid.New().String()

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -2402,7 +2402,7 @@ func TestMultipleUpdateNetworkFilterPersisted(t *testing.T) {
 	suite.AssertDisabledNetworkFilterRuntimeState(instance.RuntimeID, updateOperation2ID, &disabled)
 }
 
-func TestUpdateOnlyErsContext(t *testing.T) {
+func TestUpdateOnlyErsContextForExpiredInstance(t *testing.T) {
 	suite := NewBrokerSuiteTest(t, "2.0")
 	defer suite.TearDown()
 	iid := uuid.New().String()

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -48,6 +48,7 @@ type Config struct {
 	SubaccountsIdsToShowTrialExpirationInfo string        `envconfig:"default="`
 	TrialDocsURL                            string        `envconfig:"default="`
 	EnableShootAndSeedSameRegion            bool          `envconfig:"default=false"`
+	AllowUpdateExpiredInstanceWithContext   bool          `envconfig:"default=false"`
 
 	Binding                BindingConfig
 	KimConfig              kim.Config

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -407,6 +407,8 @@ spec:
               value: "{{ .Values.kim.plans }}"
             - name: APP_BROKER_KIM_CONFIG_KIM_ONLY_PLANS
               value: "{{ .Values.kim.kimOnlyPlans }}"
+            - name: APP_BROKER_ALLOW_UPDATE_EXPIRED_INSTANCE_WITH_CONTEXT
+              value: "{{ .Values.allowUpdateExpiredInstanceWithContext }}"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -121,6 +121,7 @@ broker:
   events:
     enabled: false
   enableShootAndSeedSameRegion: "false"
+  allowUpdateExpiredInstanceWithContext: "false"
 
 binding:
   enabled: false


### PR DESCRIPTION
Description

Changes proposed in this pull request:
- dont return error http code if there was context update to expired instance, which in practive mean that if only ers context was updated for expired instance we responde with http success code

**Related issue(s)**
See also https://github.com/kyma-project/kyma-environment-broker/issues/935