### PR TITLE
disable VSO rollout restart 

### DIFF
--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -104,10 +104,10 @@ vsoSecrets:
     avs-creds:
       path: avs
       secretName: "{{ .Values.avs.secretName }}"
-      restartTargets:
-        - kind: Deployment
-          name: >-
-            {{- template "kyma-env-broker.fullname" . -}}
+      #restartTargets:
+      #  - kind: Deployment
+      #    name: >-
+      #      {{- template "kyma-env-broker.fullname" . -}}
       labels: >-
         {{ template "kyma-env-broker.labels" . }}
       templating:
@@ -155,10 +155,10 @@ vsoSecrets:
     edp:
       path: edp
       secretName: "{{ .Values.edp.secretName }}"
-      restartTargets:
-        - kind: Deployment
-          name: >-
-            {{- template "kyma-env-broker.fullname" . -}}
+      #restartTargets:
+      #  - kind: Deployment
+      #    name: >-
+      #      {{- template "kyma-env-broker.fullname" . -}}
       labels: >-
         {{ template "kyma-env-broker.labels" . }}
       templating:
@@ -183,9 +183,9 @@ vsoSecrets:
     cis-v2:
       path: cis
       secretName: "{{ .Values.cis.v2.secretName | required \"please specify .Values.cis.v2.secretName\"}}"
-      restartTargets:
-        - kind: Deployment
-          name: "{{- .Values.subaccountSync.name -}}"
+      #restartTargets:
+      #  - kind: Deployment
+      #    name: "{{- .Values.subaccountSync.name -}}"
       labels: >-
         {{ template "kyma-env-broker.labels" . }}
       templating:
@@ -199,9 +199,9 @@ vsoSecrets:
     cis-accounts:
       path: cis
       secretName: "{{ .Values.cis.accounts.secretName | required \"please specify .Values.cis.accounts.secretName\"}}"
-      restartTargets:
-        - kind: Deployment
-          name: "{{- .Values.subaccountSync.name -}}"
+      #restartTargets:
+      #  - kind: Deployment
+      #    name: "{{- .Values.subaccountSync.name -}}"
       labels: >-
         {{ template "kyma-env-broker.labels" . }}
       templating:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Disable VSO rollout restart
Changes proposed in this pull request:

- Currently VaultStatic secret controller has websocket connection problem -> triggered unexpected rollout restart
- Rollout restart disabled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
`Resolves #6094`: https://github.tools.sap/kyma/backlog/issues/6094