### PR TITLE
Enterprise SKRs use 80 GiB worker volumes

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -411,7 +411,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
 	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
-	assertWorkersWithVolume(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"}, "50Gi", "gp2")
+	assertWorkersWithVolume(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"}, "80Gi", "gp3")
 	assertNetworking(t, imv1.Networking{
 		Nodes:    "192.168.48.0/20",
 		Pods:     "10.104.0.0/24",

--- a/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -181,8 +181,8 @@ func fixProvisionerInput(disabled bool, euAccess bool) gqlschema.ProvisionRuntim
 			GardenerConfig: &gqlschema.GardenerConfigInput{
 				Name:                                shootName,
 				KubernetesVersion:                   k8sVersion,
-				DiskType:                            ptr.String("pd-standard"),
-				VolumeSizeGb:                        ptr.Integer(50),
+				DiskType:                            ptr.String("pd-balanced"),
+				VolumeSizeGb:                        ptr.Integer(80),
 				MachineType:                         provider.DefaultGCPMachineType,
 				Region:                              "europe-west3",
 				Provider:                            "gcp",

--- a/internal/provider/aws.go
+++ b/internal/provider/aws.go
@@ -37,8 +37,8 @@ func (p *AWSInputProvider) Provide() Values {
 		DefaultMachineType:   DefaultAWSMachineType,
 		Region:               region,
 		Purpose:              PurposeProduction,
-		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		VolumeSizeGb:         80,
+		DiskType:             "gp3",
 	}
 }
 
@@ -75,7 +75,7 @@ func (p *AWSTrialInputProvider) Provide() Values {
 		Region:               region,
 		Purpose:              PurposeEvaluation,
 		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		DiskType:             "gp3",
 	}
 }
 
@@ -112,7 +112,7 @@ func (p *AWSFreemiumInputProvider) Provide() Values {
 		Region:               region,
 		Purpose:              PurposeEvaluation,
 		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		DiskType:             "gp3",
 	}
 }
 

--- a/internal/provider/aws_provider.go
+++ b/internal/provider/aws_provider.go
@@ -61,8 +61,8 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
-			DiskType:       ptr.String("gp2"),
-			VolumeSizeGb:   ptr.Integer(50),
+			DiskType:       ptr.String("gp3"),
+			VolumeSizeGb:   ptr.Integer(80),
 			MachineType:    DefaultAWSMachineType,
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
@@ -228,7 +228,7 @@ func awsLiteDefaults(region string, useSmallerMachineTypes bool) *gqlschema.Clus
 	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
-			DiskType:       ptr.String("gp2"),
+			DiskType:       ptr.String("gp3"),
 			VolumeSizeGb:   ptr.Integer(50),
 			MachineType:    machineType,
 			Region:         region,

--- a/internal/provider/aws_test.go
+++ b/internal/provider/aws_test.go
@@ -35,8 +35,8 @@ func TestAWSDefaults(t *testing.T) {
 		DefaultMachineType:   "m6i.large",
 		Region:               "eu-central-1",
 		Purpose:              "production",
-		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		VolumeSizeGb:         80,
+		DiskType:             "gp3",
 	}, values)
 }
 
@@ -70,8 +70,8 @@ func TestAWSSpecific(t *testing.T) {
 		DefaultMachineType:   "m6i.large",
 		Region:               "ap-southeast-1",
 		Purpose:              "production",
-		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		VolumeSizeGb:         80,
+		DiskType:             "gp3",
 	}, values)
 }
 
@@ -101,7 +101,7 @@ func TestAWSTrialDefaults(t *testing.T) {
 		Region:               "eu-central-1",
 		Purpose:              "evaluation",
 		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		DiskType:             "gp3",
 	}, values)
 }
 
@@ -135,7 +135,7 @@ func TestAWSTrialSpecific(t *testing.T) {
 		Region:               "ap-southeast-1",
 		Purpose:              "evaluation",
 		VolumeSizeGb:         50,
-		DiskType:             "gp2",
+		DiskType:             "gp3",
 	}, values)
 }
 

--- a/internal/provider/azure.go
+++ b/internal/provider/azure.go
@@ -41,8 +41,8 @@ func (p *AzureInputProvider) Provide() Values {
 		DefaultMachineType:   DefaultAzureMachineType,
 		Region:               region,
 		Purpose:              PurposeProduction,
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}
 }
 

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -64,8 +64,8 @@ func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
-			DiskType:       ptr.String("Standard_LRS"),
-			VolumeSizeGb:   ptr.Integer(50),
+			DiskType:       ptr.String("StandardSSD_LRS"),
+			VolumeSizeGb:   ptr.Integer(80),
 			MachineType:    DefaultAzureMachineType,
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",

--- a/internal/provider/azure_test.go
+++ b/internal/provider/azure_test.go
@@ -34,8 +34,8 @@ func TestAzureDefaults(t *testing.T) {
 		DefaultMachineType:   "Standard_D2s_v5",
 		Region:               "eastus",
 		Purpose:              "production",
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}, values)
 }
 
@@ -128,8 +128,8 @@ func TestAzureSpecific(t *testing.T) {
 		DefaultMachineType:   "Standard_D2s_v5",
 		Region:               "uksouth",
 		Purpose:              "production",
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}, values)
 }
 

--- a/internal/provider/gcp.go
+++ b/internal/provider/gcp.go
@@ -32,8 +32,8 @@ func (p *GCPInputProvider) Provide() Values {
 		DefaultMachineType:   DefaultGCPMachineType,
 		Region:               region,
 		Purpose:              PurposeProduction,
-		VolumeSizeGb:         50,
-		DiskType:             "pd-standard",
+		VolumeSizeGb:         80,
+		DiskType:             "pd-balanced",
 	}
 }
 

--- a/internal/provider/gcp_provider.go
+++ b/internal/provider/gcp_provider.go
@@ -52,8 +52,8 @@ func (p *GcpInput) Defaults() *gqlschema.ClusterConfigInput {
 	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
-			DiskType:       ptr.String("pd-standard"),
-			VolumeSizeGb:   ptr.Integer(50),
+			DiskType:       ptr.String("pd-balanced"),
+			VolumeSizeGb:   ptr.Integer(80),
 			MachineType:    DefaultGCPMachineType,
 			Region:         DefaultGCPRegion,
 			Provider:       "gcp",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Migrate to use 80Gi volumes for aws, azure, gcp and plan Kyma runtimes instead of the current 50 GiB. Use these volume types:

| Provider | Old disk type | New disk type | Old disk (50 Gi) cost / month  |  New disk (80 Gi) cost / month  | 
| -- | -- | -- | -- | -- |
| AWS | gp2 | gp3 | 5 USD | 6.4 USD | 
| Azure | Standard_LRS | StandardSSD_LRS | 3.01 USD | 9.60 USD | 
| GCP | pd-standard | pd-balanced | 2.4 USD | 9.6 USD |

Changes proposed in this pull request:

- Change aws, azure and gcp plan provider codes (both for legacy provisioner and KIM integration) to create 80 GiB worker volumes accourding to the above table
- For AWS trial and free, use gp3 instead of gp2 as it's more cost effective volume type.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.tools.sap/kyma/backlog/issues/6109