### PR TITLE
Support only me-central2 region for cf-sa30

### DIFF
--- a/common/hyperscaler/hyperscaler_type.go
+++ b/common/hyperscaler/hyperscaler_type.go
@@ -1,8 +1,6 @@
 package hyperscaler
 
-const (
-	BTPRegionDammamGCP = "cf-sa30"
-)
+import "github.com/kyma-project/kyma-environment-broker/internal/assuredworkloads"
 
 type Type struct {
 	hyperscalerName   string
@@ -49,8 +47,8 @@ func (t Type) GetKey() string {
 	if t.hyperscalerName == "openstack" && t.hyperscalerRegion != "" {
 		return t.hyperscalerName + "_" + t.hyperscalerRegion
 	}
-	if t.hyperscalerName == "gcp" && t.platformRegion == BTPRegionDammamGCP {
-		return t.hyperscalerName + "_" + BTPRegionDammamGCP
+	if t.hyperscalerName == "gcp" && assuredworkloads.IsKSA(t.platformRegion) {
+		return t.hyperscalerName + "_" + assuredworkloads.BTPRegionDammamGCP
 	}
 	return t.hyperscalerName
 }

--- a/internal/assuredworkloads/assured_workloads.go
+++ b/internal/assuredworkloads/assured_workloads.go
@@ -1,0 +1,12 @@
+package assuredworkloads
+
+const (
+	BTPRegionDammamGCP = "cf-sa30"
+)
+
+func IsKSA(platformRegion string) bool {
+	if platformRegion == BTPRegionDammamGCP {
+		return true
+	}
+	return false
+}

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -10,6 +10,8 @@ import (
 	"net/netip"
 	"strings"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/assuredworkloads"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/kubeconfig"
 	"github.com/kyma-project/kyma-environment-broker/internal/whitelist"
 
@@ -466,7 +468,7 @@ func (b *ProvisionEndpoint) determineLicenceType(planId string) *string {
 
 func (b *ProvisionEndpoint) validator(details *domain.ProvisionDetails, provider internal.CloudProvider, ctx context.Context) (JSONSchemaValidator, error) {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, b.config.EnableShootAndSeedSameRegion, b.convergedCloudRegionsProvider.GetRegions(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, b.config.EnableShootAndSeedSameRegion, b.convergedCloudRegionsProvider.GetRegions(platformRegion), assuredworkloads.IsKSA(platformRegion))
 	plan := plans[details.PlanID]
 	schema := string(Marshal(plan.Schemas.Instance.Create.Parameters))
 

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/assuredworkloads"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/jsonschema"
 	"github.com/kyma-project/kyma-environment-broker/internal/euaccess"
 	"github.com/kyma-project/kyma-environment-broker/internal/kubeconfig"
@@ -386,7 +388,7 @@ func (b *UpdateEndpoint) extractActiveValue(id string, provisioning internal.Pro
 func (b *UpdateEndpoint) getJsonSchemaValidator(provider internal.CloudProvider, planID string, platformRegion string) (JSONSchemaValidator, error) {
 	// shootAndSeedSameRegion is never enabled for update
 	b.log.Printf("region is: %s", platformRegion)
-	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, false, b.convergedCloudRegionsProvider.GetRegions(platformRegion))
+	plans := Plans(b.plansConfig, provider, b.config.IncludeAdditionalParamsInSchema, euaccess.IsEURestrictedAccess(platformRegion), b.config.UseSmallerMachineTypes, false, b.convergedCloudRegionsProvider.GetRegions(platformRegion), assuredworkloads.IsKSA(platformRegion))
 	plan := plans[planID]
 	schema := string(Marshal(plan.Schemas.Instance.Update.Parameters))
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -116,7 +116,12 @@ func AzureRegionsDisplay(euRestrictedAccess bool) map[string]string {
 	}
 }
 
-func GcpRegions() []string {
+func GcpRegions(assuredWorkloads bool) []string {
+	if assuredWorkloads {
+		return []string{
+			"me-central2",
+		}
+	}
 	return []string{
 		"europe-west3",
 		"asia-south1",
@@ -127,7 +132,12 @@ func GcpRegions() []string {
 	}
 }
 
-func GcpRegionsDisplay() map[string]string {
+func GcpRegionsDisplay(assuredWorkloads bool) map[string]string {
+	if assuredWorkloads {
+		return map[string]string{
+			"me-central2": "me-central2 (KSA, Dammam)",
+		}
+	}
 	return map[string]string{
 		"europe-west3":    "europe-west3 (Europe, Frankfurt)",
 		"asia-south1":     "asia-south1 (India, Mumbai)",
@@ -326,8 +336,8 @@ func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machin
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false)
 }
 
-func GCPSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, shootAndSeedFeatureFlag bool) *map[string]interface{} {
-	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, GcpRegions(), update)
+func GCPSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, shootAndSeedFeatureFlag bool, assuredWorkloads bool) *map[string]interface{} {
+	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, GcpRegions(assuredWorkloads), update)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), true, shootAndSeedFeatureFlag)
 }
 
@@ -464,7 +474,7 @@ func unmarshalSchema(schema *RootSchema) *map[string]interface{} {
 
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
-func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, useSmallerMachineTypes bool, shootAndSeedFeatureFlag bool, sapConvergedCloudRegions []string) map[string]domain.ServicePlan {
+func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool, euAccessRestricted bool, useSmallerMachineTypes bool, shootAndSeedFeatureFlag bool, sapConvergedCloudRegions []string, assuredWorkloads bool) map[string]domain.ServicePlan {
 	awsMachineNames := AwsMachinesNames()
 	awsMachinesDisplay := AwsMachinesDisplay()
 	awsRegionsDisplay := AWSRegionsDisplay()
@@ -475,7 +485,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	azureLiteMachinesDisplay := AzureLiteMachinesDisplay()
 	gcpMachinesNames := GcpMachinesNames()
 	gcpMachinesDisplay := GcpMachinesDisplay()
-	gcpRegionsDisplay := GcpRegionsDisplay()
+	gcpRegionsDisplay := GcpRegionsDisplay(assuredWorkloads)
 
 	if !useSmallerMachineTypes {
 		azureLiteMachinesNames = removeMachinesNamesFromList(azureLiteMachinesNames, "Standard_D2s_v5")
@@ -487,7 +497,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	azureSchema := AzureSchema(azureMachinesDisplay, azureRegionsDisplay, azureMachinesNames, includeAdditionalParamsInSchema, false, euAccessRestricted, shootAndSeedFeatureFlag)
 	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureRegionsDisplay, azureLiteMachinesNames, includeAdditionalParamsInSchema, false, euAccessRestricted, shootAndSeedFeatureFlag)
 	freemiumSchema := FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, false, euAccessRestricted)
-	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag)
+	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, false, shootAndSeedFeatureFlag, assuredWorkloads)
 	ownClusterSchema := OwnClusterSchema(false)
 	previewCatalogSchema := PreviewSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, false, euAccessRestricted)
 
@@ -495,7 +505,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 
 	outputPlans := map[string]domain.ServicePlan{
 		AWSPlanID:        defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
-		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag)),
+		GCPPlanID:        defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpRegionsDisplay, gcpMachinesNames, includeAdditionalParamsInSchema, true, shootAndSeedFeatureFlag, assuredWorkloads)),
 		AzurePlanID:      defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureRegionsDisplay, azureMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
 		AzureLitePlanID:  defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureRegionsDisplay, azureLiteMachinesNames, includeAdditionalParamsInSchema, true, euAccessRestricted, shootAndSeedFeatureFlag)),
 		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, true, euAccessRestricted)),

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -195,15 +195,29 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name: "GCP schema is correct",
 			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
-				return GCPSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, additionalParams)
+				return GCPSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, additionalParams, false)
 			},
 			machineTypes:        GcpMachinesNames(),
 			machineTypesDisplay: GcpMachinesDisplay(),
-			regionDisplay:       GcpRegionsDisplay(),
+			regionDisplay:       GcpRegionsDisplay(false),
 			path:                "gcp",
 			file:                "gcp-schema.json",
 			updateFile:          "update-gcp-schema.json",
 			fileOIDC:            "gcp-schema-additional-params.json",
+			updateFileOIDC:      "update-gcp-schema-additional-params.json",
+		},
+		{
+			name: "GCP schema with assured workloads is correct",
+			generator: func(machinesDisplay, regionsDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
+				return GCPSchema(machinesDisplay, regionsDisplay, machines, additionalParams, update, additionalParams, true)
+			},
+			machineTypes:        GcpMachinesNames(),
+			machineTypesDisplay: GcpMachinesDisplay(),
+			regionDisplay:       GcpRegionsDisplay(true),
+			path:                "gcp",
+			file:                "gcp-schema-assured-workloads.json",
+			updateFile:          "update-gcp-schema.json",
+			fileOIDC:            "gcp-schema-additional-params-assured-workloads.json",
 			updateFileOIDC:      "update-gcp-schema-additional-params.json",
 		},
 		{
@@ -269,7 +283,7 @@ func TestSapConvergedSchema(t *testing.T) {
 		regions := []string{"region1", "region2"}
 
 		// when
-		schema := Plans(nil, "", false, false, false, false, regions)
+		schema := Plans(nil, "", false, false, false, false, regions, false)
 		convergedSchema, found := schema[SapConvergedCloudPlanID]
 		schemaRegionsCreate := convergedSchema.Schemas.Instance.Create.Parameters["properties"].(map[string]interface{})["region"].(map[string]interface{})["enum"]
 
@@ -284,7 +298,7 @@ func TestSapConvergedSchema(t *testing.T) {
 		regions := []string{}
 
 		// when
-		schema := Plans(nil, "", false, false, false, false, regions)
+		schema := Plans(nil, "", false, false, false, false, regions, false)
 		_, found := schema[SapConvergedCloudPlanID]
 
 		// then
@@ -292,7 +306,7 @@ func TestSapConvergedSchema(t *testing.T) {
 		assert.False(t, found)
 
 		// when
-		schema = Plans(nil, "", false, false, false, false, nil)
+		schema = Plans(nil, "", false, false, false, false, nil, false)
 		_, found = schema[SapConvergedCloudPlanID]
 
 		// then

--- a/internal/broker/services.go
+++ b/internal/broker/services.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/assuredworkloads"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/euaccess"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/middleware"
@@ -63,6 +65,7 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 		b.cfg.UseSmallerMachineTypes,
 		b.cfg.EnableShootAndSeedSameRegion,
 		b.convergedCloudRegionsProvider.GetRegions(platformRegion),
+		assuredworkloads.IsKSA(platformRegion),
 	) {
 
 		// filter out not enabled plans

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "_controlsOrder": [
+    "name",
+    "region",
+    "shootAndSeedSameRegion",
+    "machineType",
+    "autoScalerMin",
+    "autoScalerMax",
+    "modules",
+    "networking",
+    "oidc",
+    "administrators"
+  ],
+  "_show_form_view": true,
+  "properties": {
+    "administrators": {
+      "description": "Specifies the list of runtime administrators",
+      "items": {
+        "type": "string"
+      },
+      "title": "Administrators",
+      "type": "array"
+    },
+    "autoScalerMax": {
+      "default": 20,
+      "description": "Specifies the maximum number of virtual machines to create",
+      "maximum": 300,
+      "minimum": 3,
+      "type": "integer"
+    },
+    "autoScalerMin": {
+      "default": 3,
+      "description": "Specifies the minimum number of virtual machines to create",
+      "minimum": 3,
+      "type": "integer"
+    },
+    "machineType": {
+      "_enumDisplayName": {
+        "n2-standard-2":  "n2-standard-2 (2vCPU, 8GB RAM)",
+        "n2-standard-4":  "n2-standard-4 (4vCPU, 16GB RAM)",
+        "n2-standard-8":  "n2-standard-8 (8vCPU, 32GB RAM)",
+        "n2-standard-16": "n2-standard-16 (16vCPU, 64GB RAM)",
+        "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
+        "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
+      },
+      "enum": [
+        "n2-standard-2",
+        "n2-standard-4",
+        "n2-standard-8",
+        "n2-standard-16",
+        "n2-standard-32",
+        "n2-standard-48"
+      ],
+      "type": "string"
+    },
+    "modules": {
+      "_controlsOrder": [
+        "default",
+        "list"
+      ],
+      "description": "Use default modules or provide your custom list of modules. Provide an empty custom list of modules if you don’t want any modules enabled.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "description": "Default modules",
+          "properties": {
+            "default": {
+              "default": true,
+              "description": "Check the default modules in the <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>default modules table</a>.",
+              "readOnly": true,
+              "title": "Use Default",
+              "type": "boolean"
+            }
+          },
+          "title": "Default",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Define custom module list",
+          "properties": {
+            "list": {
+              "description": "Check a module technical name on this <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>website</a>. You can only use a module technical name once. Provide an empty custom list of modules if you don’t want any modules enabled.",
+              "items": {
+                "_controlsOrder": [
+                  "name",
+                  "channel",
+                  "customResourcePolicy"
+                ],
+                "properties": {
+                  "channel": {
+                    "_enumDisplayName": {
+                      "": "",
+                      "fast": "Fast - latest version",
+                      "regular": "Regular - default version"
+                    },
+                    "default": "",
+                    "description": "Select your preferred release channel or leave this field empty.",
+                    "enum": [
+                      "",
+                      "regular",
+                      "fast"
+                    ],
+                    "type": "string"
+                  },
+                  "customResourcePolicy": {
+                    "_enumDisplayName": {
+                      "": "",
+                      "CreateAndDelete": "CreateAndDelete - default module resource is created or deleted.",
+                      "Ignore": "Ignore - module resource is not created."
+                    },
+                    "default": "",
+                    "description": "Select your preferred CustomResourcePolicy setting or leave this field empty.",
+                    "enum": [
+                      "",
+                      "CreateAndDelete",
+                      "Ignore"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Check a module technical name on this <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>website</a>. You can only use a module technical name once.",
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "title": "Custom",
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "name": {
+      "_BTPdefaultTemplate": {
+        "elements": [
+          "saSubdomain"
+        ]
+      },
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9-]*$",
+      "title": "Cluster Name",
+      "type": "string"
+    },
+    "networking": {
+      "description": "Networking configuration. These values are immutable and cannot be updated later. All provided CIDR ranges must not overlap one another.",
+      "properties": {
+        "nodes": {
+          "default": "10.250.0.0/22",
+          "description": "CIDR range for Nodes, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Nodes",
+          "type": "string"
+        },
+        "pods": {
+          "default": "10.96.0.0/13",
+          "description": "CIDR range for Pods, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Pods",
+          "type": "string"
+        },
+        "services": {
+          "default": "10.104.0.0/13",
+          "description": "CIDR range for Services, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Services",
+          "type": "string"
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "type": "object"
+    },
+    "oidc": {
+      "description": "OIDC configuration",
+      "properties": {
+        "clientID": {
+          "description": "The client ID for the OpenID Connect client.",
+          "type": "string"
+        },
+        "groupsClaim": {
+          "description": "If provided, the name of a custom OpenID Connect claim for specifying user groups.",
+          "type": "string"
+        },
+        "issuerURL": {
+          "description": "The URL of the OpenID issuer, only HTTPS scheme will be accepted.",
+          "type": "string"
+        },
+        "signingAlgs": {
+          "description": "Comma separated list of allowed JOSE asymmetric signing algorithms, for example, RS256, ES256",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "usernameClaim": {
+          "description": "The OpenID claim to use as the user name.",
+          "type": "string"
+        },
+        "usernamePrefix": {
+          "description": "If provided, all usernames will be prefixed with this value. If not provided, username claims other than 'email' are prefixed by the issuer URL to avoid clashes. To skip any prefixing, provide the value '-' (dash character without additional characters).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "clientID",
+        "issuerURL"
+      ],
+      "type": "object"
+    },
+    "region": {
+      "_enumDisplayName": {
+        "me-central2": "me-central2 (KSA, Dammam)"
+      },
+      "enum": [
+        "me-central2"
+      ],
+      "minLength": 1,
+      "type": "string"
+    },
+    "shootAndSeedSameRegion": {
+      "default": false,
+      "description": "If set to true a Gardener seed will be placed in the same region as the selected region from the Region field. Provisioning process will fail if no seed is availabie in the region.",
+      "type": "boolean",
+      "title": "Enforce Same Location for Seed and Shoot"
+    }
+  },
+  "required": [
+    "name",
+    "region"
+  ],
+  "type": "object"
+}

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "_controlsOrder": [
+    "name",
+    "region",
+    "machineType",
+    "autoScalerMin",
+    "autoScalerMax",
+    "modules",
+    "networking"
+  ],
+  "_show_form_view": true,
+  "properties": {
+    "autoScalerMax": {
+      "default": 20,
+      "description": "Specifies the maximum number of virtual machines to create",
+      "maximum": 300,
+      "minimum": 3,
+      "type": "integer"
+    },
+    "autoScalerMin": {
+      "default": 3,
+      "description": "Specifies the minimum number of virtual machines to create",
+      "minimum": 3,
+      "type": "integer"
+    },
+    "machineType": {
+      "_enumDisplayName": {
+        "n2-standard-2":  "n2-standard-2 (2vCPU, 8GB RAM)",
+        "n2-standard-4":  "n2-standard-4 (4vCPU, 16GB RAM)",
+        "n2-standard-8":  "n2-standard-8 (8vCPU, 32GB RAM)",
+        "n2-standard-16": "n2-standard-16 (16vCPU, 64GB RAM)",
+        "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
+        "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
+      },
+      "enum": [
+        "n2-standard-2",
+        "n2-standard-4",
+        "n2-standard-8",
+        "n2-standard-16",
+        "n2-standard-32",
+        "n2-standard-48"
+      ],
+      "type": "string"
+    },
+    "modules": {
+      "_controlsOrder": [
+        "default",
+        "list"
+      ],
+      "description": "Use default modules or provide your custom list of modules. Provide an empty custom list of modules if you don’t want any modules enabled.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "description": "Default modules",
+          "properties": {
+            "default": {
+              "default": true,
+              "description": "Check the default modules in the <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>default modules table</a>.",
+              "readOnly": true,
+              "title": "Use Default",
+              "type": "boolean"
+            }
+          },
+          "title": "Default",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Define custom module list",
+          "properties": {
+            "list": {
+              "description": "Check a module technical name on this <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>website</a>. You can only use a module technical name once. Provide an empty custom list of modules if you don’t want any modules enabled.",
+              "items": {
+                "_controlsOrder": [
+                  "name",
+                  "channel",
+                  "customResourcePolicy"
+                ],
+                "properties": {
+                  "channel": {
+                    "_enumDisplayName": {
+                      "": "",
+                      "fast": "Fast - latest version",
+                      "regular": "Regular - default version"
+                    },
+                    "default": "",
+                    "description": "Select your preferred release channel or leave this field empty.",
+                    "enum": [
+                      "",
+                      "regular",
+                      "fast"
+                    ],
+                    "type": "string"
+                  },
+                  "customResourcePolicy": {
+                    "_enumDisplayName": {
+                      "": "",
+                      "CreateAndDelete": "CreateAndDelete - default module resource is created or deleted.",
+                      "Ignore": "Ignore - module resource is not created."
+                    },
+                    "default": "",
+                    "description": "Select your preferred CustomResourcePolicy setting or leave this field empty.",
+                    "enum": [
+                      "",
+                      "CreateAndDelete",
+                      "Ignore"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Check a module technical name on this <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-modules?version=Cloud>website</a>. You can only use a module technical name once.",
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "title": "Custom",
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "name": {
+      "_BTPdefaultTemplate": {
+        "elements": [
+          "saSubdomain"
+        ]
+      },
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9-]*$",
+      "title": "Cluster Name",
+      "type": "string"
+    },
+    "networking": {
+      "description": "Networking configuration. These values are immutable and cannot be updated later. All provided CIDR ranges must not overlap one another.",
+      "properties": {
+        "nodes": {
+          "default": "10.250.0.0/22",
+          "description": "CIDR range for Nodes, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Nodes",
+          "type": "string"
+        },
+        "pods": {
+          "default": "10.96.0.0/13",
+          "description": "CIDR range for Pods, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Pods",
+          "type": "string"
+        },
+        "services": {
+          "default": "10.104.0.0/13",
+          "description": "CIDR range for Services, must not overlap with the following CIDRs: 10.243.128.0/17, 10.242.0.0/16, 10.243.0.0/17, 10.64.0.0/11, 10.254.0.0/16, 10.243.0.0/16",
+          "title": "CIDR range for Services",
+          "type": "string"
+        }
+      },
+      "required": [
+        "nodes"
+      ],
+      "type": "object"
+    },
+    "region": {
+      "_enumDisplayName": {
+        "me-central2": "me-central2 (KSA, Dammam)"
+      },
+      "enum": [
+        "me-central2"
+      ],
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "region"
+  ],
+  "type": "object"
+}

--- a/internal/provider/gcp.go
+++ b/internal/provider/gcp.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/assuredworkloads"
 )
 
 type (
@@ -79,6 +80,9 @@ func (p *GCPTrialInputProvider) zones() []string {
 }
 
 func (p *GCPTrialInputProvider) region() string {
+	if assuredworkloads.IsKSA(p.ProvisioningParameters.PlatformRegion) {
+		return DefaultGCPAssuredWorkloadsRegion
+	}
 	if p.ProvisioningParameters.PlatformRegion != "" {
 		abstractRegion, found := p.PlatformRegionMapping[p.ProvisioningParameters.PlatformRegion]
 		if found {

--- a/internal/provider/gcp_provider_test.go
+++ b/internal/provider/gcp_provider_test.go
@@ -73,6 +73,20 @@ func TestGcpTrialInput_ApplyParametersWithRegion(t *testing.T) {
 		//then
 		assert.Equal(t, "europe-west3", input.GardenerConfig.Region)
 	})
+
+	// when
+	t.Run("use default region for not defined mapping", func(t *testing.T) {
+		// given
+		input := svc.Defaults()
+
+		// when
+		svc.ApplyParameters(input, internal.ProvisioningParameters{
+			PlatformRegion: "cf-sa30",
+		})
+
+		//then
+		assert.Equal(t, DefaultGCPAssuredWorkloadsRegion, input.GardenerConfig.Region)
+	})
 }
 
 func TestGcpInput_SingleZone_ApplyParameters(t *testing.T) {
@@ -110,6 +124,26 @@ func TestGcpInput_SingleZone_ApplyParameters(t *testing.T) {
 		// then
 		assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones, 1)
 		assert.Subset(t, []string{"us-central1-a", "us-central1-b", "us-central1-c"}, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones)
+	})
+
+	// when
+	t.Run("use default region and default zones count for Assured Workloads", func(t *testing.T) {
+		// given
+		input := svc.Defaults()
+
+		// when
+		svc.ApplyParameters(input, internal.ProvisioningParameters{
+			PlatformRegion: "cf-sa30",
+		})
+
+		// then
+		assert.Equal(t, DefaultGCPAssuredWorkloadsRegion, input.GardenerConfig.Region)
+		assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones, 1)
+
+		for _, zone := range input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones {
+			regionFromZone := zone[:len(zone)-2]
+			assert.Equal(t, DefaultGCPAssuredWorkloadsRegion, regionFromZone)
+		}
 	})
 }
 
@@ -152,6 +186,22 @@ func TestGcpInput_MultiZone_ApplyParameters(t *testing.T) {
 		// then
 		assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones, 3)
 		assert.Subset(t, []string{"us-central1-a", "us-central1-b", "us-central1-c"}, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones)
+		assert.Equal(t, "zone", *input.GardenerConfig.ControlPlaneFailureTolerance)
+	})
+
+	// when
+	t.Run("use default region and default zones count for Assured Workloads", func(t *testing.T) {
+		// given
+		input := svc.Defaults()
+
+		// when
+		svc.ApplyParameters(input, internal.ProvisioningParameters{
+			PlatformRegion: "cf-sa30",
+		})
+
+		// then
+		assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones, 3)
+		assert.Subset(t, []string{"me-central2-a", "me-central2-b", "me-central2-c"}, input.GardenerConfig.ProviderSpecificConfig.GcpConfig.Zones)
 		assert.Equal(t, "zone", *input.GardenerConfig.ControlPlaneFailureTolerance)
 	})
 }

--- a/internal/provider/gcp_provider_test.go
+++ b/internal/provider/gcp_provider_test.go
@@ -75,7 +75,7 @@ func TestGcpTrialInput_ApplyParametersWithRegion(t *testing.T) {
 	})
 
 	// when
-	t.Run("use default region for not defined mapping", func(t *testing.T) {
+	t.Run("use default region for Assured Workloads", func(t *testing.T) {
 		// given
 		input := svc.Defaults()
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- for `cf-sa30` platform region we have to support only `me-central2` gcp region. 

**Related issue(s)**
See also #1055, https://github.tools.sap/kyma/backlog/issues/5895#issuecomment-7077851
