### PR TITLE
Create Assured Workloads documentation

### DIFF
--- a/docs/contributor/03-25-assured-workloads.md
+++ b/docs/contributor/03-25-assured-workloads.md
@@ -1,0 +1,11 @@
+# Assured Workloads
+
+## Overview
+
+SKRs provisioned in the GCP `cf-sa30` subaccount region requires Assured Workloads Kingdom of Saudi Arabia (KSA) control package.
+
+SAP BTP, Kyma runtime supports the BTP `cf-sa30` GCP subaccount region, which is called KSA BTP subaccount region.
+Kyma Control Plane manages `cf-sa30` Kyma runtimes in a separate GCP hyperscaler account pool.
+
+When the PlatformRegion is an KSA BTP subaccount region, KEB services catalog handler exposes
+`me-central2` (KSA, Dammam) as the only possible value for the **region** parameter for `cf-sa30`.

--- a/docs/contributor/03-25-assured-workloads.md
+++ b/docs/contributor/03-25-assured-workloads.md
@@ -7,5 +7,5 @@ SKRs provisioned in the GCP `cf-sa30` subaccount region require Assured Workload
 SAP BTP, Kyma runtime supports the BTP `cf-sa30` GCP subaccount region, which is called KSA BTP subaccount region.
 Kyma Control Plane manages `cf-sa30` Kyma runtimes in a separate GCP hyperscaler account pool.
 
-When the PlatformRegion is a KSA BTP subaccount region, the KEB services catalog handler exposes
+When the **PlatformRegion** is a KSA BTP subaccount region, the KEB services catalog handler exposes
 `me-central2` (KSA, Dammam) as the only possible value for the **region** parameter.

--- a/docs/contributor/03-25-assured-workloads.md
+++ b/docs/contributor/03-25-assured-workloads.md
@@ -8,4 +8,4 @@ SAP BTP, Kyma runtime supports the BTP `cf-sa30` GCP subaccount region, which is
 Kyma Control Plane manages `cf-sa30` Kyma runtimes in a separate GCP hyperscaler account pool.
 
 When the PlatformRegion is an KSA BTP subaccount region, KEB services catalog handler exposes
-`me-central2` (KSA, Dammam) as the only possible value for the **region** parameter for `cf-sa30`.
+`me-central2` (KSA, Dammam) as the only possible value for the **region** parameter.

--- a/docs/contributor/03-25-assured-workloads.md
+++ b/docs/contributor/03-25-assured-workloads.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-SKRs provisioned in the GCP `cf-sa30` subaccount region requires Assured Workloads Kingdom of Saudi Arabia (KSA) control package.
+SKRs provisioned in the GCP `cf-sa30` subaccount region require Assured Workloads Kingdom of Saudi Arabia (KSA) control package.
 
 SAP BTP, Kyma runtime supports the BTP `cf-sa30` GCP subaccount region, which is called KSA BTP subaccount region.
 Kyma Control Plane manages `cf-sa30` Kyma runtimes in a separate GCP hyperscaler account pool.

--- a/docs/contributor/03-25-assured-workloads.md
+++ b/docs/contributor/03-25-assured-workloads.md
@@ -7,5 +7,5 @@ SKRs provisioned in the GCP `cf-sa30` subaccount region require Assured Workload
 SAP BTP, Kyma runtime supports the BTP `cf-sa30` GCP subaccount region, which is called KSA BTP subaccount region.
 Kyma Control Plane manages `cf-sa30` Kyma runtimes in a separate GCP hyperscaler account pool.
 
-When the PlatformRegion is an KSA BTP subaccount region, KEB services catalog handler exposes
+When the PlatformRegion is a KSA BTP subaccount region, the KEB services catalog handler exposes
 `me-central2` (KSA, Dammam) as the only possible value for the **region** parameter.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- create Assured Workloads documentation with information about supporting only `me-central2` gcp region for `cf-sa30` platform region.

**Related issue(s)**
See also #1055, https://github.tools.sap/kyma/backlog/issues/5895#issuecomment-7077851
