### PR TITLE
Do not retry deprovisioning if Kyma resource was not deleted

### DIFF
--- a/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
+++ b/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
@@ -62,7 +62,7 @@ func (step *CheckKymaResourceDeletedStep) Run(operation internal.Operation, logg
 		Name:      kymaResourceName,
 	}, kymaUnstructured)
 
-	if !errors.IsNotFound(err) && err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		logger.Errorf("unable to check Kyma resource existence: %s", err)
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger, err)
 	}

--- a/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
+++ b/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
@@ -62,14 +62,13 @@ func (step *CheckKymaResourceDeletedStep) Run(operation internal.Operation, logg
 		Name:      kymaResourceName,
 	}, kymaUnstructured)
 
-	if err == nil {
-		logger.Infof("Kyma resource still exists")
-		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "Kyma resource still exists", 5*time.Second, step.kymaResourceDeletionTimeout, logger, nil)
-	}
-
-	if !errors.IsNotFound(err) {
+	if !errors.IsNotFound(err) && err != nil {
 		logger.Errorf("unable to check Kyma resource existence: %s", err)
 		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger, err)
+	}
+
+	if err == nil {
+		logger.Infof("Kyma resource still exists")
 	}
 
 	return step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {

--- a/internal/process/deprovisioning/check_kyma_resource_deleted_step_test.go
+++ b/internal/process/deprovisioning/check_kyma_resource_deleted_step_test.go
@@ -94,7 +94,7 @@ func TestCheckKymaResourceDeleted_RetryWhenStillExists(t *testing.T) {
 
 	// Then
 	require.NoError(t, err)
-	assert.NotZero(t, backoff)
+	assert.Zero(t, backoff)
 }
 
 func assertNoKymaResourceWithGivenRuntimeID(t *testing.T, kcpClient client.Client, kymaResourceNamespace string, resourceName string) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

if Kyma resource was not deleted don't add the `Check_Kyma_Resource_Deleted` step as deprovision incomplete to avoid retrying the deprovision.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #992