### PR TITLE
Use runtime ID from Infrastructure Manager

### DIFF
--- a/internal/environmentscleanup/service.go
+++ b/internal/environmentscleanup/service.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	shootAnnotationRuntimeId = "kcp.provisioner.kyma-project.io/runtime-id"
-	shootLabelAccountId      = "account"
+	shootAnnotationRuntimeId                      = "kcp.provisioner.kyma-project.io/runtime-id"
+	shootAnnotationInfrastructureManagerRuntimeId = "infrastructuremanager.kyma-project.io/runtime-id"
+	shootLabelAccountId                           = "account"
 )
 
 //go:generate mockery --name=GardenerClient --output=automock
@@ -154,7 +155,10 @@ func (s *Service) shootToRuntime(st unstructured.Unstructured) (*runtime, error)
 	shoot := gardener.Shoot{Unstructured: st}
 	runtimeID, ok := shoot.GetAnnotations()[shootAnnotationRuntimeId]
 	if !ok {
-		return nil, fmt.Errorf("shoot %q has no runtime-id annotation", shoot.GetName())
+		runtimeID, ok = shoot.GetAnnotations()[shootAnnotationInfrastructureManagerRuntimeId]
+		if !ok {
+			return nil, fmt.Errorf("shoot %q has no runtime-id annotation", shoot.GetName())
+		}
 	}
 
 	accountID, ok := shoot.GetLabels()[shootLabelAccountId]

--- a/internal/environmentscleanup/service_test.go
+++ b/internal/environmentscleanup/service_test.go
@@ -200,6 +200,22 @@ func TestService_PerformCleanup(t *testing.T) {
 						},
 					},
 				},
+				{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "az-1234",
+							"creationTimestamp": creationTime,
+							"annotations": map[string]interface{}{
+								shootAnnotationInfrastructureManagerRuntimeId: fixRuntimeID2,
+								shootLabelAccountId:                           fixAccountID,
+							},
+							"clusterName": "cluster-one",
+						},
+						"spec": map[string]interface{}{
+							"cloudProfileName": "az",
+						},
+					},
+				},
 			},
 		}
 		gcMock.On("List", mock.Anything, mock.AnythingOfType("v1.ListOptions")).Return(&unl, nil)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- if shoot don't have Provisioner runtime ID, we should try to use Infrastructure Manager runtime ID.

**Related issue(s)**
See also #1116
