### PR TITLE
Fix typo

### DIFF
--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -114,7 +114,7 @@ func AzureRegionsDisplay(euRestrictedAccess bool) map[string]string {
 		"japaneast":     "japaneast (Japan, Tokyo)",
 		"southeastasia": "southeastasia (Asia Pacific, Singapore)",
 		"australiaeast": "australiaeast (Australia, Sydney)",
-		"brazilsouth":   "brazilsouth (Brasil, São Paulo)",
+		"brazilsouth":   "brazilsouth (Brazil, São Paulo)",
 	}
 }
 
@@ -149,7 +149,7 @@ func GcpRegionsDisplay(assuredWorkloads bool) map[string]string {
 		"me-central2":          "me-central2 (KSA, Dammam)",
 		"asia-northeast2":      "asia-northeast2 (Japan, Osaka)",
 		"me-west1":             "me-west1 (Israel, Tel Aviv)",
-		"southamerica-east1":   "southamerica-east1 (Brasil, São Paulo)",
+		"southamerica-east1":   "southamerica-east1 (Brazil, São Paulo)",
 		"australia-southeast1": "australia-southeast1 (Australia, Sydney)",
 	}
 }

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -215,7 +215,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -218,7 +218,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -168,7 +168,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -170,7 +170,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -238,7 +238,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -190,7 +190,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/free-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/free-azure-schema-additional-params.json
@@ -188,7 +188,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/azure/free-azure-schema.json
+++ b/internal/broker/testdata/azure/free-azure-schema.json
@@ -141,7 +141,7 @@
         "japaneast": "japaneast (Japan, Tokyo)",
         "southeastasia": "southeastasia (Asia Pacific, Singapore)",
         "australiaeast": "australiaeast (Australia, Sydney)",
-        "brazilsouth": "brazilsouth (Brasil, São Paulo)"
+        "brazilsouth": "brazilsouth (Brazil, São Paulo)"
       },
       "enum": [
         "eastus",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -221,7 +221,7 @@
         "me-central2": "me-central2 (KSA, Dammam)",
         "asia-northeast2": "asia-northeast2 (Japan, Osaka)",
         "me-west1": "me-west1 (Israel, Tel Aviv)",
-        "southamerica-east1": "southamerica-east1 (Brasil, São Paulo)",
+        "southamerica-east1": "southamerica-east1 (Brazil, São Paulo)",
         "australia-southeast1": "australia-southeast1 (Australia, Sydney)"
       },
       "enum": [

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -173,7 +173,7 @@
         "me-central2": "me-central2 (KSA, Dammam)",
         "asia-northeast2": "asia-northeast2 (Japan, Osaka)",
         "me-west1": "me-west1 (Israel, Tel Aviv)",
-        "southamerica-east1": "southamerica-east1 (Brasil, São Paulo)",
+        "southamerica-east1": "southamerica-east1 (Brazil, São Paulo)",
         "australia-southeast1": "australia-southeast1 (Australia, Sydney)"
       },
       "enum": [


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Brazil is written with an `s` in Spanish and Portuguese, and in English it is written with a `z`.

**Related issue(s)**
See also #1139
