### PR TITLE
Increase retry timeout in Inject BTP Operator Credentials step

### DIFF
--- a/internal/process/provisioning/inject_btp_operator_credentials_step.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	updateSecretBackoff = 10 * time.Second
+	retryInterval       = 5 * time.Second
+	retryTimeout        = 2 * time.Minute
 )
 
 type K8sClientProvider interface {
@@ -47,8 +49,8 @@ func (s *InjectBTPOperatorCredentialsStep) Run(operation internal.Operation, log
 	k8sClient, err := s.k8sClientProvider.K8sClientForRuntimeID(operation.RuntimeID)
 
 	if err != nil {
-		log.Error("kubernetes client not set: %w", err)
-		return s.operationManager.RetryOperation(operation, "unable to get K8S client", err, 5*time.Second, 30*time.Second, log)
+		log.Errorf("kubernetes client not set: %w", err)
+		return s.operationManager.RetryOperation(operation, "unable to get K8S client", err, retryInterval, retryTimeout, log)
 	}
 
 	clusterID := operation.InstanceDetails.ServiceManagerClusterID


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

increase the retry timeout in step to avoid provisioning failure when there is a temporary network connectivity issue.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
