### PR TITLE
Use Gardener in SKR binding test

### DIFF
--- a/docs/contributor/05-10-e2e_tests.md
+++ b/docs/contributor/05-10-e2e_tests.md
@@ -134,7 +134,7 @@ The test executes the following steps:
 1. Provisions a Kyma runtime cluster.
 2. Creates a binding using Kubernetes TokenRequest and saves the returned kubeconfig.
 3. Initializes a Kubernetes client with the returned kubeconfig.
-4. Tries to fetch a secret using binding from Kubernetes TokenRequest.
+4. Tries to fetch a Secret using the binding from Kubernetes TokenRequest.
 5. Creates a binding using Gardener and saves the returned kubeconfig.
 6. Initializes a Kubernetes client with the returned kubeconfig.
 7. Tries to fetch a secret using binding from Gardener.

--- a/docs/contributor/05-10-e2e_tests.md
+++ b/docs/contributor/05-10-e2e_tests.md
@@ -137,7 +137,7 @@ The test executes the following steps:
 4. Tries to fetch a Secret using the binding from Kubernetes TokenRequest.
 5. Creates a binding using Gardener and saves the returned kubeconfig.
 6. Initializes a Kubernetes client with the returned kubeconfig.
-7. Tries to fetch a secret using binding from Gardener.
+7. Tries to fetch a Secret using the binding from Gardener.
 8. Deprovisions the Kyma runtime instance and cleans up the resources.
 
 ### Test Execution

--- a/docs/contributor/05-10-e2e_tests.md
+++ b/docs/contributor/05-10-e2e_tests.md
@@ -132,10 +132,13 @@ The test executes the following steps:
 
 The test executes the following steps:
 1. Provisions a Kyma runtime cluster.
-2. Creates a binding and saves the returned kubeconfig.
+2. Creates a binding using Kubernetes TokenRequest and saves the returned kubeconfig.
 3. Initializes a Kubernetes client with the returned kubeconfig.
-4. Tries to fetch a secret.
-5. Deprovisions the Kyma runtime instance and cleans up the resources.
+4. Tries to fetch a secret using binding from Kubernetes TokenRequest.
+5. Creates a binding using Gardener and saves the returned kubeconfig.
+6. Initializes a Kubernetes client with the returned kubeconfig.
+7. Tries to fetch a secret using binding from Gardener.
+8. Deprovisions the Kyma runtime instance and cleans up the resources.
 
 ### Test Execution
 

--- a/testing/e2e/skr/kyma-environment-broker/client.js
+++ b/testing/e2e/skr/kyma-environment-broker/client.js
@@ -272,12 +272,12 @@ class KEBClient {
     });
   }
 
-  async createBinding(instanceID) {
+  async createBinding(instanceID, tokenRequest) {
     const payload = {
       service_id: KYMA_SERVICE_ID,
       plan_id: this.planID,
       parameters: {
-        token_request: true,
+        token_request: tokenRequest,
       },
     };
     const bindingID = Math.random().toString(36).substring(2, 18);

--- a/testing/e2e/skr/skr-binding-test/index.js
+++ b/testing/e2e/skr/skr-binding-test/index.js
@@ -27,9 +27,9 @@ describe('SKR Binding test', function() {
     await provisionSKRInstance(options, provisioningTimeout);
   });
 
-  it('Create SKR binding', async function() {
+  it('Create SKR binding using Kubernetes TokenRequest', async function() {
     try {
-      kubeconfigFromBinding = await keb.createBinding(options.instanceID);
+      kubeconfigFromBinding = await keb.createBinding(options.instanceID, true);
     } catch (err) {
       console.log(err);
     }
@@ -39,7 +39,23 @@ describe('SKR Binding test', function() {
     await initializeK8sClient({kubeconfig: kubeconfigFromBinding.credentials});
   });
 
-  it('Fetch sap-btp-manager secret', async function() {
+  it('Fetch sap-btp-manager secret using binding from Kubernetes TokenRequest', async function() {
+    await getSecret(secretName, ns);
+  });
+
+  it('Create SKR binding using Gardener', async function() {
+    try {
+      kubeconfigFromBinding = await keb.createBinding(options.instanceID, false);
+    } catch (err) {
+      console.log(err);
+    }
+  });
+
+  it('Initiate K8s client with kubeconfig from binding', async function() {
+    await initializeK8sClient({kubeconfig: kubeconfigFromBinding.credentials});
+  });
+
+  it('Fetch sap-btp-manager secret using binding from Gardener', async function() {
     await getSecret(secretName, ns);
   });
 

--- a/testing/e2e/skr/utils/index.js
+++ b/testing/e2e/skr/utils/index.js
@@ -11,6 +11,13 @@ let watch;
 
 function initializeK8sClient(opts) {
   opts = opts || {};
+
+  k8sDynamicApi = null;
+  k8sAppsApi = null;
+  k8sCoreV1Api = null;
+  k8sRbacAuthorizationV1Api = null;
+  watch = null;
+
   try {
     console.log('Trying to initialize a K8S client');
     if (opts.kubeconfigPath) {

--- a/testing/e2e/skr/utils/index.js
+++ b/testing/e2e/skr/utils/index.js
@@ -17,6 +17,8 @@ function initializeK8sClient(opts) {
   k8sCoreV1Api = null;
   k8sRbacAuthorizationV1Api = null;
   watch = null;
+  k8sLog = null;
+  k8sServerUrl = null;
 
   try {
     console.log('Trying to initialize a K8S client');


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Create a binding and try to fetch a secret using Gardener `shootsadminkubeconfig-subresource`.

**Related issue(s)**
See also #284
