### PR TITLE
Add auto enable auto-merge PR

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,20 @@
+name: Enable auto merge
+on:
+  pull_request_target:
+    branches: [main]
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    - synchronize
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for PRs
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.BOT_TOKEN}}
+          GIT_EMAIL: team-gopher+1@sap.com
+        run: gh pr merge -A ${{ env.GIT_EMAIL }} --auto --squash "$PR_URL"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

This is a preparation for tide removal. GitHub's auto-merge feature requires this to be enabled for each PR created. This workflow automatically enables auto-merge on every opened PR, so the user doesn't have to.



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
