### PR TITLE
KIM Integration - set `Purpose` as development for all plans

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -250,7 +250,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_EnforceSeed_ActualCre
 	assert.True(t, *runtime.Spec.Shoot.EnforceSeedLocation)
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assert.Equal(t, SecretBindingName, runtime.Spec.Shoot.SecretBindingName)
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 	assert.Equal(t, "zone", string(runtime.Spec.Shoot.ControlPlane.HighAvailability.FailureTolerance.Type))
@@ -300,7 +300,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DisableEnterpriseFilt
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assert.Equal(t, SecretBindingName, runtime.Spec.Shoot.SecretBindingName)
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 	assert.Equal(t, "zone", string(runtime.Spec.Shoot.ControlPlane.HighAvailability.FailureTolerance.Type))
@@ -349,7 +349,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DefaultAdmin_ActualCr
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assert.Equal(t, SecretBindingName, runtime.Spec.Shoot.SecretBindingName)
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 	assert.Equal(t, "zone", string(runtime.Spec.Shoot.ControlPlane.HighAvailability.FailureTolerance.Type))
@@ -398,7 +398,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DryRun_ActualCreation
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assert.Equal(t, SecretBindingName, runtime.Spec.Shoot.SecretBindingName)
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 	assert.Equal(t, "zone", string(runtime.Spec.Shoot.ControlPlane.HighAvailability.FailureTolerance.Type))
@@ -452,7 +452,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assertWorkersWithVolume(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"}, "80Gi", "gp3")
 	assertNetworking(t, imv1.Networking{
 		Nodes:    "192.168.48.0/20",
@@ -504,7 +504,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZone_ActualCreation(t *test
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 3, 0, 3, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 
 	_, err = memoryStorage.Instances().GetByID(operation.InstanceID)
@@ -549,7 +549,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation(t 
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 
 	_, err = memoryStorage.Instances().GetByID(operation.InstanceID)
@@ -595,7 +595,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation_Wi
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 
 	// then retry
@@ -615,7 +615,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation_Wi
 
 	assert.Equal(t, "aws", runtime.Spec.Shoot.Provider.Type)
 	assert.Equal(t, "eu-west-2", runtime.Spec.Shoot.Region)
-	assert.Equal(t, "production", string(runtime.Spec.Shoot.Purpose))
+	assert.Equal(t, "development", string(runtime.Spec.Shoot.Purpose))
 	assertWorkers(t, runtime.Spec.Shoot.Provider.Workers, "m6i.large", 20, 3, 1, 0, 1, []string{"eu-west-2a", "eu-west-2b", "eu-west-2c"})
 
 	_, err = memoryStorage.Instances().GetByID(operation.InstanceID)

--- a/internal/provider/aws.go
+++ b/internal/provider/aws.go
@@ -36,7 +36,7 @@ func (p *AWSInputProvider) Provide() Values {
 		ProviderType:         "aws",
 		DefaultMachineType:   DefaultAWSMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              PurposeDevelopment,
 		VolumeSizeGb:         80,
 		DiskType:             "gp3",
 	}
@@ -73,7 +73,7 @@ func (p *AWSTrialInputProvider) Provide() Values {
 		ProviderType:         "aws",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		VolumeSizeGb:         50,
 		DiskType:             "gp3",
 	}
@@ -110,7 +110,7 @@ func (p *AWSFreemiumInputProvider) Provide() Values {
 		ProviderType:         "aws",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		VolumeSizeGb:         50,
 		DiskType:             "gp3",
 	}

--- a/internal/provider/aws_test.go
+++ b/internal/provider/aws_test.go
@@ -34,7 +34,7 @@ func TestAWSDefaults(t *testing.T) {
 		ProviderType:         "aws",
 		DefaultMachineType:   "m6i.large",
 		Region:               "eu-central-1",
-		Purpose:              "production",
+		Purpose:              "development",
 		VolumeSizeGb:         80,
 		DiskType:             "gp3",
 	}, values)
@@ -69,7 +69,7 @@ func TestAWSSpecific(t *testing.T) {
 		ProviderType:         "aws",
 		DefaultMachineType:   "m6i.large",
 		Region:               "ap-southeast-1",
-		Purpose:              "production",
+		Purpose:              "development",
 		VolumeSizeGb:         80,
 		DiskType:             "gp3",
 	}, values)
@@ -99,7 +99,7 @@ func TestAWSTrialDefaults(t *testing.T) {
 		ProviderType:         "aws",
 		DefaultMachineType:   "m5.xlarge",
 		Region:               "eu-central-1",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		VolumeSizeGb:         50,
 		DiskType:             "gp3",
 	}, values)
@@ -133,7 +133,7 @@ func TestAWSTrialSpecific(t *testing.T) {
 		ProviderType:         "aws",
 		DefaultMachineType:   "m5.xlarge",
 		Region:               "ap-southeast-1",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		VolumeSizeGb:         50,
 		DiskType:             "gp3",
 	}, values)

--- a/internal/provider/azure.go
+++ b/internal/provider/azure.go
@@ -40,7 +40,7 @@ func (p *AzureInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   DefaultAzureMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              PurposeDevelopment,
 		DiskType:             "StandardSSD_LRS",
 		VolumeSizeGb:         80,
 	}
@@ -79,7 +79,7 @@ func (p *AzureTrialInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}
@@ -123,7 +123,7 @@ func (p *AzureLiteInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}
@@ -158,7 +158,7 @@ func (p *AzureFreemiumInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}

--- a/internal/provider/azure_test.go
+++ b/internal/provider/azure_test.go
@@ -33,7 +33,7 @@ func TestAzureDefaults(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D2s_v5",
 		Region:               "eastus",
-		Purpose:              "production",
+		Purpose:              "development",
 		DiskType:             "StandardSSD_LRS",
 		VolumeSizeGb:         80,
 	}, values)
@@ -63,7 +63,7 @@ func TestAzureTrialDefaults(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "switzerlandnorth",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}, values)
@@ -92,7 +92,7 @@ func TestAzureLiteDefaults(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "eastus",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}, values)
@@ -127,7 +127,7 @@ func TestAzureSpecific(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D2s_v5",
 		Region:               "uksouth",
-		Purpose:              "production",
+		Purpose:              "development",
 		DiskType:             "StandardSSD_LRS",
 		VolumeSizeGb:         80,
 	}, values)
@@ -163,7 +163,7 @@ func TestAzureTrialSpecific(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "southeastasia",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}, values)
@@ -197,7 +197,7 @@ func TestAzureLiteSpecific(t *testing.T) {
 		ProviderType:         "azure",
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "uksouth",
-		Purpose:              "evaluation",
+		Purpose:              "development",
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}, values)

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -1,8 +1,9 @@
 package provider
 
 const (
-	PurposeEvaluation = "evaluation"
-	PurposeProduction = "production"
+	PurposeEvaluation  = "evaluation"
+	PurposeProduction  = "production"
+	PurposeDevelopment = "development"
 )
 
 func updateString(toUpdate *string, value *string) {

--- a/internal/provider/gcp.go
+++ b/internal/provider/gcp.go
@@ -32,7 +32,7 @@ func (p *GCPInputProvider) Provide() Values {
 		ProviderType:         "gcp",
 		DefaultMachineType:   DefaultGCPMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              PurposeDevelopment,
 		VolumeSizeGb:         80,
 		DiskType:             "pd-balanced",
 	}
@@ -65,7 +65,7 @@ func (p *GCPTrialInputProvider) Provide() Values {
 		ProviderType:         "gcp",
 		DefaultMachineType:   DefaultGCPTrialMachineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              PurposeDevelopment,
 		VolumeSizeGb:         30,
 		DiskType:             "pd-standard",
 	}

--- a/internal/provider/sap-converged-cloud.go
+++ b/internal/provider/sap-converged-cloud.go
@@ -32,7 +32,7 @@ func (p *SapConvergedCloudInputProvider) Provide() Values {
 		ProviderType:         "openstack",
 		DefaultMachineType:   DefaultSapConvergedCloudMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              PurposeDevelopment,
 		DiskType:             "",
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Regardless of plan, `Purpose` set as development - consistently with provisioner 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#905 