### PR TITLE
Adjust workflow skipping

### DIFF
--- a/.github/workflows/build-e2e-provisioning-test-image.yaml
+++ b/.github/workflows/build-e2e-provisioning-test-image.yaml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/build-e2e-provisioning-test-image.yaml"
       - "testing/e2e/provisioning/**"
   pull_request_target:
-    types: [ opened, edited, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - ".github/workflows/build-e2e-provisioning-test-image.yaml"
       - "testing/e2e/provisioning/**"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -22,6 +22,11 @@ jobs:
         run: | 
           echo "Draft PRs are not checked"
           exit 1
+      - name: Check if author is kyma-gopher-bot
+        if: ${{ github.event.pull_request.user.login == 'kyma-gopher-bot' }}
+        run: | 
+          echo "PRs from kyma-gopher-bot are automatically green"
+          exit 0
       - uses: wechuli/allcheckspassed@2e5e8bbc775f5680ed5d02e3a22e2fc7219792ac
         with:
           delay: '1'

--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -3,6 +3,9 @@ name: pull-build-images
 on:
    pull_request_target:
       types: [ opened, edited, synchronize, reopened, ready_for_review ]
+      paths-ignore:
+         - "**.md"
+         - "sec-scanners-config.yaml"
 
 permissions:
    id-token: write

--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -13,7 +13,6 @@ permissions:
 jobs:
    kyma-environment-broker-image:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-    if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
     with: 
       name:  kyma-environment-broker
       dockerfile: Dockerfile.keb
@@ -21,7 +20,6 @@ jobs:
 
    archiver-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-archiver-job
          dockerfile: Dockerfile.job
@@ -30,7 +28,6 @@ jobs:
 
    environments-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environments-cleanup-job
          dockerfile: Dockerfile.job
@@ -39,7 +36,6 @@ jobs:
 
    deprovision-retrigger-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-deprovision-retrigger-job
          dockerfile: Dockerfile.job
@@ -48,7 +44,6 @@ jobs:
 
    expirator-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-expirator-job
          dockerfile: Dockerfile.job
@@ -57,7 +52,6 @@ jobs:
 
    runtime-reconciler-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-runtime-reconciler
          dockerfile: Dockerfile.runtimereconciler
@@ -66,7 +60,6 @@ jobs:
 
    subaccount-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-subaccount-cleanup-job
          dockerfile: Dockerfile.job
@@ -75,7 +68,6 @@ jobs:
 
    subaccount-sync-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-subaccount-sync
          dockerfile: Dockerfile.subaccountsync

--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -2,7 +2,7 @@ name: pull-build-images
 
 on:
    pull_request_target:
-      types: [ opened, edited, synchronize, reopened, ready_for_review ]
+      types: [ opened, synchronize, reopened, ready_for_review ]
       paths-ignore:
          - "**.md"
          - "sec-scanners-config.yaml"

--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
    kyma-environment-broker-image:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
     with: 
       name:  kyma-environment-broker
       dockerfile: Dockerfile.keb
@@ -20,6 +21,7 @@ jobs:
 
    archiver-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-archiver-job
          dockerfile: Dockerfile.job
@@ -28,6 +30,7 @@ jobs:
 
    environments-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environments-cleanup-job
          dockerfile: Dockerfile.job
@@ -36,6 +39,7 @@ jobs:
 
    deprovision-retrigger-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-deprovision-retrigger-job
          dockerfile: Dockerfile.job
@@ -44,6 +48,7 @@ jobs:
 
    expirator-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-expirator-job
          dockerfile: Dockerfile.job
@@ -52,6 +57,7 @@ jobs:
 
    runtime-reconciler-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-runtime-reconciler
          dockerfile: Dockerfile.runtimereconciler
@@ -60,6 +66,7 @@ jobs:
 
    subaccount-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-subaccount-cleanup-job
          dockerfile: Dockerfile.job
@@ -68,6 +75,7 @@ jobs:
 
    subaccount-sync-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
       with: 
          name: kyma-environment-subaccount-sync
          dockerfile: Dockerfile.subaccountsync

--- a/.github/workflows/run-govulncheck.yaml
+++ b/.github/workflows/run-govulncheck.yaml
@@ -3,6 +3,9 @@ name: Run govulncheck
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
+      - "sec-scanners-config.yaml"
 
 jobs:
   run-govulncheck:

--- a/.github/workflows/run-keb-chart-install-tests.yaml
+++ b/.github/workflows/run-keb-chart-install-tests.yaml
@@ -3,11 +3,14 @@ name: Run KEB chart install tests
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - "**.md"
+      - "sec-scanners-config.yaml"
 
 jobs:
   run-install-keb-chart-tests:
     uses: "./.github/workflows/run-keb-chart-install-tests-reusable.yaml"
-    if: ${{ !github.event.pull_request.draft }}
     with:
       last-k3s-versions: 3
       release: "false"

--- a/.github/workflows/run-keb-chart-install-tests.yaml
+++ b/.github/workflows/run-keb-chart-install-tests.yaml
@@ -11,7 +11,6 @@ on:
 jobs:
   run-install-keb-chart-tests:
     uses: "./.github/workflows/run-keb-chart-install-tests-reusable.yaml"
-    if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
     with:
       last-k3s-versions: 3
       release: "false"

--- a/.github/workflows/run-keb-chart-install-tests.yaml
+++ b/.github/workflows/run-keb-chart-install-tests.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   run-install-keb-chart-tests:
     uses: "./.github/workflows/run-keb-chart-install-tests-reusable.yaml"
+    if: ${{ !github.event.pull_request.user.login == 'kyma-gopher-bot' }}
     with:
       last-k3s-versions: 3
       release: "false"

--- a/.github/workflows/run-verify.yaml
+++ b/.github/workflows/run-verify.yaml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths-ignore:
+      - "**.md"
+      - "sec-scanners-config.yaml"
   
 permissions:
   contents: read

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -49,7 +49,7 @@ This [workflow](/.github/workflows/auto-merge.yaml) enables the auto-merge funct
 
 ## All Cheks Passed Workflow
 
-This [workflow](/.github/workflows/pr-checks.yaml) checks if all jobs, except those excluded in the workflow configuration, have passed.
+This [workflow](/.github/workflows/pr-checks.yaml) checks if all jobs, except those excluded in the workflow configuration, have passed. If the workflow is triggered by a PR where the author is the `kyma-gopher-bot`, the workflow will end immediately with success.
 
 ## Reusable Workflows
 

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -49,7 +49,7 @@ This [workflow](/.github/workflows/auto-merge.yaml) enables the auto-merge funct
 
 ## All Cheks Passed Workflow
 
-This [workflow](/.github/workflows/pr-checks.yaml) checks if all jobs, except those excluded in the workflow configuration, have passed. If the workflow is triggered by a PR where the author is the `kyma-gopher-bot`, the workflow will end immediately with success.
+This [workflow](/.github/workflows/pr-checks.yaml) checks if all jobs, except those excluded in the workflow configuration, have passed. If the workflow is triggered by a PR where the author is the `kyma-gopher-bot`, the workflow ends immediately with success.
 
 ## Reusable Workflows
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

During release the kyma-gopher-bot creates a PR with bumps. For example, it changes the values.yaml of the KEB chart. We shouldn't run tests on exactly this PR and waste time, because we do tests in the release workflow. But we can't skip those jobs with path filtering either, because human developers also change those files during their daily work and then the tests need to be run.

A workaround is to add a check to workflows when they are triggered by kyma-gopher-bot and skip them. The `All checks passed` workflow only needs to be green to merge a PR, so in the case of kyma-gopher-bot we can just return a success status immediately without waiting for other jobs. 

Note that if kyma-gopher-bot does more _development_ PR's in the future, this behavior will need to be changed so that all workflow states are checked as in the case of a human developer PR.

Changes proposed in this pull request:

- Add more path filtering
- Immediately return success in `All check passed` when triggered by kyma-gopher-bot

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
