### PR TITLE
Default region for KSA

### DIFF
--- a/internal/provider/gcp.go
+++ b/internal/provider/gcp.go
@@ -20,10 +20,7 @@ type (
 func (p *GCPInputProvider) Provide() Values {
 	zonesCount := p.zonesCount()
 	zones := p.zones()
-	region := DefaultGCPRegion
-	if p.ProvisioningParameters.Parameters.Region != nil {
-		region = *p.ProvisioningParameters.Parameters.Region
-	}
+	region := p.region()
 	return Values{
 		DefaultAutoScalerMax: 20,
 		DefaultAutoScalerMin: 3,
@@ -52,6 +49,18 @@ func (p *GCPInputProvider) zones() []string {
 		region = *p.ProvisioningParameters.Parameters.Region
 	}
 	return ZonesForGCPRegion(region, p.zonesCount())
+}
+
+func (p *GCPInputProvider) region() string {
+	if assuredworkloads.IsKSA(p.ProvisioningParameters.PlatformRegion) {
+		return DefaultGCPAssuredWorkloadsRegion
+	}
+
+	if p.ProvisioningParameters.Parameters.Region != nil && *p.ProvisioningParameters.Parameters.Region != "" {
+		return *p.ProvisioningParameters.Parameters.Region
+	}
+
+	return DefaultGCPRegion
 }
 
 func (p *GCPTrialInputProvider) Provide() Values {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `me-central2` region as a default KSA platform region.

**Related issue(s)**
See also #791
