### PR TITLE
KIM Integration - `Purpose` default configurable per landscape

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -129,7 +129,7 @@ func (s *CreateRuntimeResourceStep) Run(operation internal.Operation, log logrus
 func (s *CreateRuntimeResourceStep) updateRuntimeResourceObject(runtime *imv1.Runtime, operation internal.Operation, runtimeName, kymaName, kymaNamespace string) error {
 
 	// get plan specific values (like zones, default machine type etc.
-	values, err := provider.GenerateValues(&operation, s.config.MultiZoneCluster, s.config.DefaultTrialProvider, s.useSmallerMachineTypes, s.trialPlatformRegionMapping)
+	values, err := provider.GenerateValues(&operation, s.config.MultiZoneCluster, s.config.DefaultTrialProvider, s.useSmallerMachineTypes, s.trialPlatformRegionMapping, s.config.DefaultGardenerShootPurpose)
 	if err != nil {
 		return err
 	}

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/provider"
+
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/networking"
@@ -222,7 +224,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_EnforceSeed_ActualCre
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	kimConfig := fixKimConfig("aws", false)
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone"}
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
@@ -272,7 +274,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DisableEnterpriseFilt
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	kimConfig := fixKimConfig("aws", false)
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone"}
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
@@ -322,7 +324,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DefaultAdmin_ActualCr
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	kimConfig := fixKimConfig("aws", false)
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone"}
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
@@ -371,7 +373,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DryRun_ActualCreation
 
 	kimConfig := fixKimConfig("aws", false)
 	kimConfig.ViewOnly = true
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone"}
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
@@ -427,7 +429,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 	kimConfig := fixKimConfig("aws", false)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: true}
+	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction}
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
 
 	// when
@@ -479,7 +481,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZone_ActualCreation(t *test
 	kimConfig := fixKimConfig("aws", false)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: true}
+	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction}
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
 
 	// when
@@ -524,7 +526,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation(t 
 	kimConfig := fixKimConfig("preview", false)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: false}
+	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction}
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
 
 	// when
@@ -570,7 +572,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation_Wi
 	kimConfig := fixKimConfig("preview", false)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: false}
+	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction}
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, kimConfig, inputConfig, nil, false, defaultOIDSConfig)
 
 	// when

--- a/internal/provider/aws.go
+++ b/internal/provider/aws.go
@@ -7,6 +7,7 @@ import (
 
 type (
 	AWSInputProvider struct {
+		Purpose                string
 		MultiZone              bool
 		ProvisioningParameters internal.ProvisioningParameters
 	}
@@ -36,7 +37,7 @@ func (p *AWSInputProvider) Provide() Values {
 		ProviderType:         "aws",
 		DefaultMachineType:   DefaultAWSMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              p.Purpose,
 		VolumeSizeGb:         80,
 		DiskType:             "gp3",
 	}

--- a/internal/provider/aws_test.go
+++ b/internal/provider/aws_test.go
@@ -14,6 +14,7 @@ func TestAWSDefaults(t *testing.T) {
 
 	// given
 	provider := AWSInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: nil},
@@ -44,6 +45,7 @@ func TestAWSSpecific(t *testing.T) {
 
 	// given
 	provider := AWSInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters: internal.ProvisioningParametersDTO{

--- a/internal/provider/azure.go
+++ b/internal/provider/azure.go
@@ -7,6 +7,7 @@ import (
 
 type (
 	AzureInputProvider struct {
+		Purpose                string
 		MultiZone              bool
 		ProvisioningParameters internal.ProvisioningParameters
 	}
@@ -16,6 +17,7 @@ type (
 		ProvisioningParameters internal.ProvisioningParameters
 	}
 	AzureLiteInputProvider struct {
+		Purpose                string
 		UseSmallerMachineTypes bool
 		ProvisioningParameters internal.ProvisioningParameters
 	}
@@ -40,7 +42,7 @@ func (p *AzureInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   DefaultAzureMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              p.Purpose,
 		DiskType:             "StandardSSD_LRS",
 		VolumeSizeGb:         80,
 	}
@@ -123,7 +125,7 @@ func (p *AzureLiteInputProvider) Provide() Values {
 		ProviderType:         "azure",
 		DefaultMachineType:   machineType,
 		Region:               region,
-		Purpose:              PurposeEvaluation,
+		Purpose:              p.Purpose,
 		DiskType:             "Standard_LRS",
 		VolumeSizeGb:         50,
 	}

--- a/internal/provider/azure_test.go
+++ b/internal/provider/azure_test.go
@@ -13,6 +13,7 @@ func TestAzureDefaults(t *testing.T) {
 
 	// given
 	azure := AzureInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: ptr.String("eastus")},
@@ -73,6 +74,7 @@ func TestAzureLiteDefaults(t *testing.T) {
 
 	// given
 	azure := AzureLiteInputProvider{
+		Purpose: PurposeEvaluation,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: ptr.String("eastus")},
 			PlatformRegion: "cf-eu11",
@@ -102,6 +104,7 @@ func TestAzureSpecific(t *testing.T) {
 
 	// given
 	azure := AzureInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters: internal.ProvisioningParametersDTO{
@@ -173,6 +176,7 @@ func TestAzureLiteSpecific(t *testing.T) {
 
 	// given
 	azure := AzureLiteInputProvider{
+		Purpose: PurposeEvaluation,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters: internal.ProvisioningParametersDTO{
 				MachineType: ptr.String("Standard_D48_v3"),

--- a/internal/provider/gcp.go
+++ b/internal/provider/gcp.go
@@ -7,11 +7,13 @@ import (
 
 type (
 	GCPInputProvider struct {
+		Purpose                string
 		MultiZone              bool
 		ProvisioningParameters internal.ProvisioningParameters
 	}
 
 	GCPTrialInputProvider struct {
+		Purpose                string
 		PlatformRegionMapping  map[string]string
 		ProvisioningParameters internal.ProvisioningParameters
 	}
@@ -29,7 +31,7 @@ func (p *GCPInputProvider) Provide() Values {
 		ProviderType:         "gcp",
 		DefaultMachineType:   DefaultGCPMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              p.Purpose,
 		VolumeSizeGb:         80,
 		DiskType:             "pd-balanced",
 	}

--- a/internal/provider/gcp_test.go
+++ b/internal/provider/gcp_test.go
@@ -11,6 +11,7 @@ func TestGCPDefaults(t *testing.T) {
 
 	// given
 	provider := GCPInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: nil},
@@ -41,6 +42,7 @@ func TestGCPSpecific(t *testing.T) {
 
 	// given
 	provider := GCPInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters: internal.ProvisioningParametersDTO{

--- a/internal/provider/model.go
+++ b/internal/provider/model.go
@@ -9,8 +9,7 @@ type Values struct {
 	ProviderType         string
 	DefaultMachineType   string
 	Region               string
-	Purpose              string //TODO default per landscape in configuration
+	Purpose              string
 	VolumeSizeGb         int
 	DiskType             string
-	// todo: add other plan specific values
 }

--- a/internal/provider/provider_values.go
+++ b/internal/provider/provider_values.go
@@ -17,31 +17,37 @@ func GenerateValues(
 	defaultTrialProvider internal.CloudProvider,
 	useSmallerMachineTypes bool,
 	trialPlatformRegionMapping map[string]string,
+	defaultPurpose string,
 ) (Values, error) {
 	var p Provider
 	switch operation.ProvisioningParameters.PlanID {
 	case broker.AWSPlanID:
 		p = &AWSInputProvider{
+			Purpose:                defaultPurpose,
 			MultiZone:              multiZoneCluster,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}
 	case broker.PreviewPlanID:
 		p = &AWSInputProvider{
+			Purpose:                defaultPurpose,
 			MultiZone:              multiZoneCluster,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}
 	case broker.AzurePlanID:
 		p = &AzureInputProvider{
+			Purpose:                defaultPurpose,
 			MultiZone:              multiZoneCluster,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}
 	case broker.AzureLitePlanID:
 		p = &AzureLiteInputProvider{
+			Purpose:                defaultPurpose,
 			UseSmallerMachineTypes: useSmallerMachineTypes,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}
 	case broker.GCPPlanID:
 		p = &GCPInputProvider{
+			Purpose:                defaultPurpose,
 			MultiZone:              multiZoneCluster,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}
@@ -62,6 +68,7 @@ func GenerateValues(
 		}
 	case broker.SapConvergedCloudPlanID:
 		p = &SapConvergedCloudInputProvider{
+			Purpose:                defaultPurpose,
 			MultiZone:              multiZoneCluster,
 			ProvisioningParameters: operation.ProvisioningParameters,
 		}

--- a/internal/provider/sap-converged-cloud.go
+++ b/internal/provider/sap-converged-cloud.go
@@ -12,6 +12,7 @@ const (
 
 type (
 	SapConvergedCloudInputProvider struct {
+		Purpose                string
 		MultiZone              bool
 		ProvisioningParameters internal.ProvisioningParameters
 	}
@@ -36,7 +37,7 @@ func (p *SapConvergedCloudInputProvider) Provide() Values {
 		ProviderType:         "openstack",
 		DefaultMachineType:   DefaultSapConvergedCloudMachineType,
 		Region:               region,
-		Purpose:              PurposeProduction,
+		Purpose:              p.Purpose,
 		DiskType:             "",
 	}
 }

--- a/internal/provider/sap-converged-cloud_test.go
+++ b/internal/provider/sap-converged-cloud_test.go
@@ -11,6 +11,7 @@ func TestSapConvergedCloudDefaults(t *testing.T) {
 
 	// given
 	sapCC := SapConvergedCloudInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: nil},
@@ -42,6 +43,7 @@ func TestSapConvergedCloudTwoZonesRegion(t *testing.T) {
 	// given
 	region := "eu-de-2"
 	sapCC := SapConvergedCloudInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: ptr.String(region)},
@@ -73,6 +75,7 @@ func TestSapConvergedCloudSingleZoneRegion(t *testing.T) {
 	// given
 	region := "ap-jp-1"
 	sapCC := SapConvergedCloudInputProvider{
+		Purpose:   PurposeProduction,
 		MultiZone: true,
 		ProvisioningParameters: internal.ProvisioningParameters{
 			Parameters:     internal.ProvisioningParametersDTO{Region: ptr.String(region)},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Freemium and Trial plans set default to `evaluation` regardless of landscape
- Remaining plans use configurable setting per landscape as default

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#905 