### PR TITLE
Add request logging for service bindings

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -451,6 +451,7 @@ func createAPI(router *mux.Router, servicesConfig broker.ServicesConfig, planVal
 		LastBindingOperationEndpoint: broker.NewLastBindingOperation(logs),
 	}
 
+	router.Use(middleware.AddRequestLogging(logs))
 	router.Use(middleware.AddRegionToContext(cfg.DefaultRequestRegion))
 	router.Use(middleware.AddProviderToContext())
 	for _, prefix := range []string{

--- a/internal/middleware/request_logging.go
+++ b/internal/middleware/request_logging.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+func AddRequestLogging(logs logrus.FieldLogger) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if strings.Contains(req.URL.Path, "service_bindings") {
+				logs.WithFields(logrus.Fields{
+					"method":      req.Method,
+					"url":         req.URL.String(),
+					"query":       req.URL.Query(),
+					"headers":     req.Header,
+					"remote_addr": req.RemoteAddr,
+					"host":        req.Host,
+					"user_agent":  req.UserAgent(),
+				}).Info("Request details")
+
+				if req.Body != nil {
+					bodyBytes, err := io.ReadAll(req.Body)
+					if err != nil {
+						logs.Error("Failed to read request body:", err)
+					} else {
+						logs.WithField("body", string(bodyBytes)).Info("Request body")
+
+						req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+					}
+				}
+			}
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}

--- a/internal/middleware/request_logging.go
+++ b/internal/middleware/request_logging.go
@@ -24,7 +24,9 @@ func AddRequestLogging(logs logrus.FieldLogger) mux.MiddlewareFunc {
 					"user_agent":  req.UserAgent(),
 				}).Info("Request details")
 
-				if req.Body != nil {
+				if req.Body == nil {
+					logs.Info("Request body is nil")
+				} else {
 					bodyBytes, err := io.ReadAll(req.Body)
 					if err != nil {
 						logs.Error("Failed to read request body:", err)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add request logging for service bindings to check if context contains `user_id`.

**Related issue(s)**
See also #1203, https://github.com/kyma-project/kyma-environment-broker/issues/284#issuecomment-2396292417
