### PR TITLE
Change binding `created_by` format

### DIFF
--- a/cmd/broker/bind_create_test.go
+++ b/cmd/broker/bind_create_test.go
@@ -555,7 +555,7 @@ func TestCreatedBy(t *testing.T) {
 		{
 			name:     "Both Email and Origin are set",
 			context:  broker.BindingContext{Email: &email, Origin: &origin},
-			expected: "john.smith@email.com origin",
+			expected: "john.smith@email.com",
 		},
 	}
 

--- a/internal/broker/bind_create.go
+++ b/internal/broker/bind_create.go
@@ -48,25 +48,12 @@ type BindingContext struct {
 }
 
 func (b *BindingContext) CreatedBy() string {
-	if b.Email == nil && b.Origin == nil {
-		return ""
+	if b.Email != nil && *b.Email != "" {
+		return *b.Email
+	} else if b.Origin != nil && *b.Origin != "" {
+		return *b.Origin
 	}
-
-	email := ""
-	if b.Email != nil {
-		email = *b.Email
-	}
-
-	origin := ""
-	if b.Origin != nil {
-		origin = *b.Origin
-	}
-
-	if email != "" && origin != "" {
-		return email + " " + origin
-	}
-
-	return email + origin
+	return ""
 }
 
 type BindingParams struct {


### PR DESCRIPTION
**Description**

We've decided to change `created_by` format to store only email if request body contains email and origin.

Changes proposed in this pull request:

- set `created_by` to email if request body contains email and origin. 

**Related issue(s)**
See also #1348
