### PR TITLE
Provide valid binding expiration time in cmd/broker tests

### DIFF
--- a/cmd/broker/binding_test.go
+++ b/cmd/broker/binding_test.go
@@ -41,7 +41,6 @@ func TestBinding(t *testing.T) {
 		`{
                 "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
                 "plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15"
-
                }`)
 
 	b, _ := io.ReadAll(resp.Body)
@@ -53,7 +52,6 @@ func TestBinding(t *testing.T) {
 	suite.Log(string(b))
 	suite.Log(resp.Status)
 
-<<<<<<< Updated upstream
 	t.Run("should return 400 when expiration seconds parameter is string instead of int", func(t *testing.T) {
 		resp = suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s/service_bindings/%s", iid, bid),
 			`{
@@ -65,12 +63,5 @@ func TestBinding(t *testing.T) {
                }`)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
-=======
-	resp = suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s/service_bindings/%s", iid, bid),
-		`{
-                "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
-                "plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15"
-               }`)
-	suite.Log(resp.Status)
->>>>>>> Stashed changes
+
 }

--- a/cmd/broker/binding_test.go
+++ b/cmd/broker/binding_test.go
@@ -41,6 +41,7 @@ func TestBinding(t *testing.T) {
 		`{
                 "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
                 "plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15"
+
                }`)
 
 	b, _ := io.ReadAll(resp.Body)
@@ -52,6 +53,7 @@ func TestBinding(t *testing.T) {
 	suite.Log(string(b))
 	suite.Log(resp.Status)
 
+<<<<<<< Updated upstream
 	t.Run("should return 400 when expiration seconds parameter is string instead of int", func(t *testing.T) {
 		resp = suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s/service_bindings/%s", iid, bid),
 			`{
@@ -63,4 +65,12 @@ func TestBinding(t *testing.T) {
                }`)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
+=======
+	resp = suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s/service_bindings/%s", iid, bid),
+		`{
+                "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+                "plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15"
+               }`)
+	suite.Log(resp.Status)
+>>>>>>> Stashed changes
 }

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -200,6 +200,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	require.NoError(t, err)
 
 	fakeK8sSKRClient := fake.NewClientBuilder().WithScheme(sch).Build()
+
 	k8sClientProvider := kubeconfig.NewFakeK8sClientProvider(fakeK8sSKRClient)
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, logs.WithField("provisioning", "manager"))
 	provisioningQueue := NewProvisioningProcessingQueue(context.Background(), provisionManager, workersAmount, cfg, db, provisionerClient, inputFactory,

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -200,7 +200,6 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	require.NoError(t, err)
 
 	fakeK8sSKRClient := fake.NewClientBuilder().WithScheme(sch).Build()
-
 	k8sClientProvider := kubeconfig.NewFakeK8sClientProvider(fakeK8sSKRClient)
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, logs.WithField("provisioning", "manager"))
 	provisioningQueue := NewProvisioningProcessingQueue(context.Background(), provisionManager, workersAmount, cfg, db, provisionerClient, inputFactory,

--- a/internal/kubeconfig/provider.go
+++ b/internal/kubeconfig/provider.go
@@ -3,12 +3,13 @@ package kubeconfig
 import (
 	"context"
 	"fmt"
+	"time"
+
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	machineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"

--- a/internal/kubeconfig/provider.go
+++ b/internal/kubeconfig/provider.go
@@ -3,9 +3,12 @@ package kubeconfig
 import (
 	"context"
 	"fmt"
-
+	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	machineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -137,6 +140,16 @@ func (p *FakeProvider) K8sClientSetForRuntimeID(runtimeID string) (kubernetes.In
 
 func createFakeClientset() kubernetes.Interface {
 	c := fake.NewSimpleClientset()
+	c.PrependReactor("create", "serviceaccounts", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+		obj := action.(testing.CreateAction).GetObject()
+		subresource := action.GetSubresource()
+		if subresource == "token" {
+			tokenObject := obj.(*authv1.TokenRequest)
+			tokenObject.Status.ExpirationTimestamp = machineryv1.Time{Time: time.Now().Add(time.Duration(*tokenObject.Spec.ExpirationSeconds) * time.Second)}
+			return true, tokenObject, nil
+		}
+		return true, obj, nil
+	})
 	_, err := c.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
 		ObjectMeta: machineryv1.ObjectMeta{Name: "kyma-system", Namespace: ""},
 	}, machineryv1.CreateOptions{})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
The fake clientset for k8s does not fill expiration time in the token (subresource of service account) status which makes all bindings expirat just after creation in all cmd/broker tests which uses BrokerTestSuite
The solution is to apply simple logic as `Reactor` to the fake client to fill this field as in real scenario.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
