### PR TITLE
Change incorrect parameters response message

### DIFF
--- a/cmd/broker/binding_test.go
+++ b/cmd/broker/binding_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,10 @@ import (
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/stretchr/testify/assert"
 )
+
+type ErrorResponse struct {
+	Description string `json:"description"`
+}
 
 func TestBinding(t *testing.T) {
 	// given
@@ -62,6 +67,12 @@ func TestBinding(t *testing.T) {
 				}
                }`)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		b, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		var apiError ErrorResponse
+		err = json.Unmarshal(b, &apiError)
+		assert.NoError(t, err)
+		assert.Equal(t, "failed to unmarshal parameters: cannot unmarshal string into expiration_seconds of type int", apiError.Description)
 	})
 
 	t.Run("should return 200 when creating a second binding with the same id and params as an existing one", func(t *testing.T) {

--- a/cmd/broker/binding_test.go
+++ b/cmd/broker/binding_test.go
@@ -67,11 +67,14 @@ func TestBinding(t *testing.T) {
 				}
                }`)
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
 		b, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
+
 		var apiError ErrorResponse
 		err = json.Unmarshal(b, &apiError)
 		assert.NoError(t, err)
+
 		assert.Equal(t, "failed to unmarshal parameters: cannot unmarshal string into expiration_seconds of type int", apiError.Description)
 	})
 

--- a/internal/broker/bind_create.go
+++ b/internal/broker/bind_create.go
@@ -114,6 +114,8 @@ func (b *BindEndpoint) Bind(ctx context.Context, instanceID, bindingID string, d
 		err = json.Unmarshal(details.RawParameters, &parameters)
 		if err != nil {
 			message := fmt.Sprintf("failed to unmarshal parameters: %s", err)
+			message = strings.Replace(message, "json: ", "", 1)
+			message = strings.Replace(message, "Go struct field BindingParams.", "", 1)
 			return domain.Binding{}, apiresponses.NewFailureResponse(fmt.Errorf(message), http.StatusBadRequest, message)
 		}
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change incorrect parameters response message from `failed to unmarshal parameters: json: cannot unmarshal string into Go struct field BindingParams.expiration_seconds of type int` to `failed to unmarshal parameters: cannot unmarshal string into expiration_seconds of type int`.

**Related issue(s)**
See also #1349
