### PR TITLE
Remove unused env variables from KEB deployment

### DIFF
--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -207,10 +207,6 @@ spec:
               value: "{{ .Values.gardener.shootDomain }}"
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
-            - name: APP_KUBECONFIG_ISSUER_URL
-              value: {{ .Values.kubeconfig.issuerURL }}
-            - name: APP_KUBECONFIG_CLIENT_ID
-              value: {{ .Values.kubeconfig.clientID }}
             - name: APP_KUBECONFIG_ALLOW_ORIGINS
               value: "{{ .Values.kubeconfig.allowOrigins }}"
             - name: APP_PROVISIONER_KUBERNETES_VERSION
@@ -237,8 +233,6 @@ spec:
               value: "{{ .Values.osbUpdateProcessingEnabled }}"
             - name: APP_NOTIFICATION_URL
               value: "{{ .Values.notification.url }}"
-            - name: APP_NOTIFICATION_DISABLED
-              value: "{{ .Values.notification.disabled }}"
             - name: APP_DOMAIN_NAME
               value: "{{ .Values.global.ingress.domainName }}"
             - name: APP_SKR_OIDC_DEFAULT_VALUES_YAML_FILE_PATH

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -29,16 +29,6 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret }}
       {{- end }}
-      {{ if .Values.global.isLocalEnv }}
-      # HostAliases are used by Pod to resolve kyma.local domain
-      hostAliases:
-        - ip: {{ .Values.global.minikubeIP }}
-          hostnames:
-            # Used for calls to Director
-            - "{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
-            # Used for calls for oauth token
-            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
-      {{ end }}
       serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
     {{- with .Values.deployment.securityContext }}
       securityContext:
@@ -142,30 +132,6 @@ spec:
               value: "{{ .Values.broker.port }}"
             - name: APP_STATUS_PORT
               value: "{{ .Values.broker.statusPort }}"
-            - name: APP_DIRECTOR_DEFAULT_TENANT
-              value: "{{ .Values.global.defaultTenant }}"
-            - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
-            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
-                  key: tokens_endpoint
-                  optional: true
-            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
-                  key: client_id
-                  optional: true
-            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
-                  key: client_secret
-                  optional: true
-            - name: APP_DIRECTOR_OAUTH_SCOPE
-              value: "{{ .Values.director.scope }}"
             - name: APP_EDP_AUTH_URL
               value: "{{ .Values.edp.authURL }}"
             - name: APP_EDP_ADMIN_URL

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -1,5 +1,4 @@
 global:
-  defaultTenant: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae
   ingress:
     domainName: localhost
   images:
@@ -41,17 +40,6 @@ global:
       
   kyma_environment_broker:
     serviceAccountName: "kcp-kyma-environment-broker"
-    secrets:
-      integrationSystemCredentials:
-        name: kcp-kyma-environment-broker-credentials
-  isLocalEnv: false
-  oauth2:
-    host: oauth2
-  compass:
-    tls:
-      secure:
-        oauth:
-          host: compass-gateway-auth-oauth
   istio:
     gateway: "kyma-system/kyma-gateway"
     proxy:
@@ -222,9 +210,6 @@ provisioner:
 
   gardener:
     enableShootAndSeedSameRegion: "false"
-
-director:
-  scope: "runtime:read runtime:write"
 
 additionalRuntimeComponents: |-
   - name: "service-manager-proxy"

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -288,8 +288,6 @@ gardener:
   multiZoneCluster: "false"
 
 kubeconfig:
-  issuerURL: "TBD"
-  clientID: "TBD"
   allowOrigins: "*"
 
 edp:
@@ -328,7 +326,6 @@ cis:
 
 notification:
   url: "TBD"
-  disabled: true
 
 kim:
   enabled: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

These variables were defined in the envs, but were not read in the app. Also they were not used in any conditions and parts of the chart.

Changes proposed in this pull request:

- Remove unused env variables from KEB deployment
- Remove unused `hostAliases` section

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
