### PR TITLE
Add more check for PR's merged during release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Check if any PR was merged during release
         run: |
-          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits/main -q '.sha')
+          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits -q '.[0].sha')
           echo "Latest commit sha: $COMMIT_SHA"
           echo "Workflow sha: ${{ github.sha }}"
           if [ "$COMMIT_SHA" != "${{ github.sha }}" ]; then
@@ -268,6 +268,16 @@ jobs:
             echo "Step skipped"
           fi
 
+      - name: Check if any PR have been merged before merging the bump PR
+        run: |
+          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits -q '.[1].sha')
+          echo "Latest commit sha: $COMMIT_SHA"
+          echo "Bump sha: ${{ github.sha }}"
+          if [ "$COMMIT_SHA" != "${{ github.sha }}" ]; then
+            echo "::error ::a PR have been merged before merging the bump PR. Don't rerun this workflow. Create a new release with the same version"
+            exit 1 
+          fi
+
       - name: Save latest commit ref
         id: pull-ref
         env:
@@ -296,7 +306,7 @@ jobs:
 
       - name: Check if any PR was merged after bumps
         run: |
-          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits/main -q '.sha')
+          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits -q '.[0].sha')
           echo "Latest commit sha: $COMMIT_SHA"
           echo "Bump sha: ${{ needs.bumps.outputs.latest_commit}}"
           if [ "$COMMIT_SHA" != "${{ needs.bumps.outputs.latest_commit}}" ]; then
@@ -317,6 +327,16 @@ jobs:
         run: |
           git tag ${{ github.event.inputs.name }}
           git push origin ${{ github.event.inputs.name }}
+
+      - name: Check if any PR may have been merged before creating the tag and draft release
+        run: |
+          COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits -q '.[0].sha')
+          echo "Latest commit sha: $COMMIT_SHA"
+          echo "Bump sha: ${{ needs.bumps.outputs.latest_commit}}"
+          if [ "$COMMIT_SHA" != "${{ needs.bumps.outputs.latest_commit}}" ]; then
+            echo "::error ::a PR may have been merged before the tag and draft release were created. Delete the tag and the draft release. Don't rerun this workflow. Create a new release with the same version"
+            exit 1 
+          fi
 
     outputs:
       release_id: ${{ steps.create-draft.outputs.release_id }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

This checks if a PR has been merged after the first PR merge check and before the bumps are merged. 
This checks also if a PR has been merged after the second PR merge check and before the draft release and tag are created. 
This covers the corner case scenario where there is about a ~1 s window in the whole release where we could merge a PR and not detect it when needed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
