### PR TITLE
Additional Test Case for Invalidating a Kubeconfig

### DIFF
--- a/cmd/broker/bindings_envtest_test.go
+++ b/cmd/broker/bindings_envtest_test.go
@@ -332,7 +332,7 @@ func TestCreateBindingEndpoint(t *testing.T) {
 		// when
 		err = clientFirst.Delete(context.Background(), &rbacv1.ClusterRoleBinding{
 			ObjectMeta: v1.ObjectMeta{
-				Name: brokerBindings.BindingName(bindingID),
+				Name:      brokerBindings.BindingName(bindingID),
 				Namespace: brokerBindings.BindingNamespace,
 			},
 		})

--- a/cmd/broker/bindings_envtest_test.go
+++ b/cmd/broker/bindings_envtest_test.go
@@ -312,6 +312,36 @@ func TestCreateBindingEndpoint(t *testing.T) {
 		assertClusterAccess(t, "secret-to-check-first", binding)
 	})
 
+	t.Run("should invalidate binding when cluster role binding is removed", func(t *testing.T) {
+		// given
+		bindingID := uuid.New().String()
+
+		response := createBinding(instanceID1, bindingID, t)
+		defer response.Body.Close()
+
+		require.Equal(t, http.StatusCreated, response.StatusCode)
+
+		binding := getBindingUnmarshalled(instanceID1, bindingID, t)
+
+		duration, err := getTokenDurationFromBinding(t, binding)
+		require.NoError(t, err)
+		assert.Equal(t, expirationSeconds*time.Second, duration)
+
+		assertClusterAccess(t, "secret-to-check-first", binding)
+
+		// when
+		err = clientFirst.Delete(context.Background(), &rbacv1.ClusterRoleBinding{
+			ObjectMeta: v1.ObjectMeta{
+				Name: brokerBindings.BindingName(bindingID),
+				Namespace: brokerBindings.BindingNamespace,
+			},
+		})
+		assert.NoError(t, err)
+
+		// then
+		assertClusterNoAccess(t, "secret-to-check-first", binding)
+	})
+
 	t.Run("should return created bindings when multiple bindings created", func(t *testing.T) {
 		// given
 		firstInstanceFirstBindingID, firstInstancefirstBinding := createBindingWithRandomBindingID(instanceID1, httpServer, t)
@@ -542,6 +572,18 @@ func assertClusterAccess(t *testing.T, controlSecretName string, binding domain.
 
 	_, err := newClient.CoreV1().Secrets("default").Get(context.Background(), controlSecretName, v1.GetOptions{})
 	assert.NoError(t, err)
+}
+
+func assertClusterNoAccess(t *testing.T, controlSecretName string, binding domain.Binding) {
+
+	credentials, ok := binding.Credentials.(map[string]interface{})
+	require.True(t, ok)
+	kubeconfig := credentials["kubeconfig"].(string)
+
+	newClient := kubeconfigClient(t, kubeconfig)
+
+	_, err := newClient.CoreV1().Secrets("default").Get(context.Background(), controlSecretName, v1.GetOptions{})
+	assert.True(t, apierrors.IsForbidden(err))
 }
 
 func assertRolesExistence(t *testing.T, bindingID string, binding domain.Binding) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Additional test case for Kyma bindings that checks if removal of a ClusterRoleBinding invalidates the binding.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
