### PR TITLE
Environment cleanup job sanity check

### DIFF
--- a/cmd/environmentscleanup/main.go
+++ b/cmd/environmentscleanup/main.go
@@ -11,6 +11,7 @@ func main() {
 	builder.WithGardenerClient()
 	builder.WithBrokerClient()
 	builder.WithStorage()
+	builder.WithK8sClient()
 
 	defer builder.Cleanup()
 

--- a/common/setup/builder.go
+++ b/common/setup/builder.go
@@ -106,9 +106,9 @@ func (b *AppBuilder) WithStorage() {
 }
 
 func (b *AppBuilder) WithK8sClient() {
-  err := imv1.AddToScheme(scheme.Scheme)
+	err := imv1.AddToScheme(scheme.Scheme)
 	FatalOnError(err)
-  err = corev1.AddToScheme(scheme.Scheme)
+	err = corev1.AddToScheme(scheme.Scheme)
 	FatalOnError(err)
 	k8sCfg, err := k8scfg.GetConfig()
 	FatalOnError(err)

--- a/common/setup/builder.go
+++ b/common/setup/builder.go
@@ -18,7 +18,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 	"golang.org/x/oauth2/clientcredentials"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	k8scfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type config struct {
@@ -36,6 +43,7 @@ type AppBuilder struct {
 	conn           *dbr.Connection
 	logger         *logrus.Logger
 	brokerClient   *broker.Client
+	k8sClient      client.Client
 }
 
 type App interface {
@@ -96,6 +104,37 @@ func (b *AppBuilder) WithStorage() {
 
 }
 
+func (b *AppBuilder) WithK8sClient() {
+	err := corev1.AddToScheme(scheme.Scheme)
+	FatalOnError(err)
+	k8sCfg, err := k8scfg.GetConfig()
+	FatalOnError(err)
+	cli, err := createK8sClient(k8sCfg)
+	FatalOnError(err)
+	b.k8sClient = cli
+}
+
+func createK8sClient(cfg *rest.Config) (client.Client, error) {
+	mapper, err := apiutil.NewDiscoveryRESTMapper(cfg)
+	if err != nil {
+		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			mapper, err = apiutil.NewDiscoveryRESTMapper(cfg)
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("while waiting for client mapper: %w", err)
+		}
+	}
+	cli, err := client.New(cfg, client.Options{Mapper: mapper})
+	if err != nil {
+		return nil, fmt.Errorf("while creating a client: %w", err)
+	}
+	return cli, nil
+}
+
 func (b *AppBuilder) Cleanup() {
 	err := b.conn.Close()
 	if err != nil {
@@ -116,6 +155,7 @@ func (b *AppBuilder) Create() App {
 	return environmentscleanup.NewService(
 		b.gardenerClient,
 		b.brokerClient,
+		b.k8sClient,
 		b.db.Instances(),
 		b.logger,
 		b.cfg.MaxAgeHours,

--- a/internal/environmentscleanup/service.go
+++ b/internal/environmentscleanup/service.go
@@ -13,14 +13,19 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	shootAnnotationRuntimeId                      = "kcp.provisioner.kyma-project.io/runtime-id"
 	shootAnnotationInfrastructureManagerRuntimeId = "infrastructuremanager.kyma-project.io/runtime-id"
 	shootLabelAccountId                           = "account"
+	kcpNamespace                                  = "kcp-system"
+	kebConfigMap                                  = "kcp-kyma-environment-broker"
 )
 
 //go:generate mockery --name=GardenerClient --output=automock
@@ -39,6 +44,7 @@ type BrokerClient interface {
 type Service struct {
 	gardenerService GardenerClient
 	brokerService   BrokerClient
+	k8sClient       client.Client
 	instanceStorage storage.Instances
 	logger          *log.Logger
 	MaxShootAge     time.Duration
@@ -50,10 +56,17 @@ type runtime struct {
 	AccountID string
 }
 
-func NewService(gardenerClient GardenerClient, brokerClient BrokerClient, instanceStorage storage.Instances, logger *log.Logger, maxShootAge time.Duration, labelSelector string) *Service {
+type providers struct {
+	Providers []struct {
+		DomainsInclude []string `yaml:"domainsInclude"`
+	} `yaml:"providers"`
+}
+
+func NewService(gardenerClient GardenerClient, brokerClient BrokerClient, k8sClient client.Client, instanceStorage storage.Instances, logger *log.Logger, maxShootAge time.Duration, labelSelector string) *Service {
 	return &Service{
 		gardenerService: gardenerClient,
 		brokerService:   brokerClient,
+		k8sClient:       k8sClient,
 		instanceStorage: instanceStorage,
 		logger:          logger,
 		MaxShootAge:     maxShootAge,
@@ -62,7 +75,43 @@ func NewService(gardenerClient GardenerClient, brokerClient BrokerClient, instan
 }
 
 func (s *Service) Run() error {
+	environment, err := s.getEnvironment()
+	if err != nil {
+		return err
+	}
+	log.Infof("Current environment: %s", environment)
+	if environment != "dev.kyma.ondemand.com" {
+		return fmt.Errorf("job must run only in the dev environment, current environment: %s", environment)
+	}
 	return s.PerformCleanup()
+}
+
+func (s *Service) getEnvironment() (string, error) {
+	configMap := &coreV1.ConfigMap{}
+	err := s.k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: kcpNamespace,
+		Name:      kebConfigMap,
+	}, configMap)
+	if err != nil {
+		return "", fmt.Errorf("while getting ConfigMap %s from namespace %s: %w", kebConfigMap, kcpNamespace, err)
+	}
+
+	data, exists := configMap.Data["skrDNSProvidersValues.yaml"]
+	if !exists {
+		return "", fmt.Errorf("while checking skrDNSProvidersValues.yaml key in ConfigMap %s: key is missing", kebConfigMap)
+	}
+
+	var providers providers
+	err = yaml.Unmarshal([]byte(data), &providers)
+	if err != nil {
+		return "", fmt.Errorf("while unmarshalling YAML data from skrDNSProvidersValues.yaml: %w", err)
+	}
+
+	if len(providers.Providers) != 1 && len(providers.Providers[0].DomainsInclude) != 1 {
+		return "", fmt.Errorf("while validating structure of skrDNSProvidersValues.yaml: expected 1 provider with 1 domain, found %d providers", len(providers.Providers))
+	}
+
+	return providers.Providers[0].DomainsInclude[0], nil
 }
 
 func (s *Service) PerformCleanup() error {

--- a/internal/environmentscleanup/service_test.go
+++ b/internal/environmentscleanup/service_test.go
@@ -15,9 +15,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-
-	corev1 "k8s.io/api/core/v1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -41,10 +40,10 @@ const (
 
 func TestService_PerformCleanup(t *testing.T) {
 	sch := k8sruntime.NewScheme()
-  err := imv1.AddToScheme(sch)
+	err := imv1.AddToScheme(sch)
 	assert.NoError(t, err)
 	err = corev1.AddToScheme(sch)
-  assert.NoError(t, err)
+	assert.NoError(t, err)
 	k8sClient := fake.NewClientBuilder().WithScheme(sch).Build()
 
 	t.Run("happy path", func(t *testing.T) {
@@ -369,8 +368,8 @@ func TestService_PerformCleanup(t *testing.T) {
 		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: fixRuntimeID3, Namespace: kcpNamespace}, &imv1.Runtime{})
 		assert.NoError(t, err)
 	})
-  
-  t.Run("should work on dev environment", func(t *testing.T) {
+
+	t.Run("should work on dev environment", func(t *testing.T) {
 		// given
 		gcMock := &mocks.GardenerClient{}
 		gcMock.On("List", mock.Anything, mock.AnythingOfType("v1.ListOptions")).Return(fixShootList(), nil)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- check if job is running in dev environment based on `kcp-kyma-environment-broker` config map.

**Related issue(s)**
See also #1417
