### PR TITLE
Fix instance stats metric

### DIFF
--- a/internal/metricsv2/instances_collector.go
+++ b/internal/metricsv2/instances_collector.go
@@ -18,7 +18,7 @@ import (
 // - kcp_keb_global_account_id_instances_total - total number of all instances per global account
 // - kcp_keb_ers_context_license_type_total - count of instances grouped by license types
 type InstancesStatsGetter interface {
-	GetInstanceStats() (internal.InstanceStats, error)
+	GetActiveInstanceStats() (internal.InstanceStats, error)
 	GetERSContextStats() (internal.ERSContextStats, error)
 }
 
@@ -61,7 +61,7 @@ func (c *InstancesCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (c *InstancesCollector) Collect(ch chan<- prometheus.Metric) {
-	stats, err := c.statsGetter.GetInstanceStats()
+	stats, err := c.statsGetter.GetActiveInstanceStats()
 	if err != nil {
 		c.logger.Error(err)
 	} else {

--- a/internal/storage/driver/memory/instance.go
+++ b/internal/storage/driver/memory/instance.go
@@ -209,7 +209,7 @@ func (s *instances) Update(instance internal.Instance) (*internal.Instance, erro
 	return &instance, nil
 }
 
-func (s *instances) GetInstanceStats() (internal.InstanceStats, error) {
+func (s *instances) GetActiveInstanceStats() (internal.InstanceStats, error) {
 	return internal.InstanceStats{}, fmt.Errorf("not implemented")
 }
 

--- a/internal/storage/driver/postsql/instance.go
+++ b/internal/storage/driver/postsql/instance.go
@@ -496,8 +496,8 @@ func (s *Instance) Delete(instanceID string) error {
 	return sess.DeleteInstance(instanceID)
 }
 
-func (s *Instance) GetInstanceStats() (internal.InstanceStats, error) {
-	entries, err := s.NewReadSession().GetInstanceStats()
+func (s *Instance) GetActiveInstanceStats() (internal.InstanceStats, error) {
+	entries, err := s.NewReadSession().GetActiveInstanceStats()
 	if err != nil {
 		return internal.InstanceStats{}, err
 	}

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -114,6 +114,7 @@ func TestInstance(t *testing.T) {
 		fixInstances := []internal.Instance{
 			*fixInstance(instanceData{val: "A1", globalAccountID: "A"}),
 			*fixInstance(instanceData{val: "A2", globalAccountID: "A", deletedAt: time.Time{}}),
+			*fixInstance(instanceData{val: "A3", globalAccountID: "A"}),
 			*fixInstance(instanceData{val: "C1", globalAccountID: "C"}),
 			*fixInstance(instanceData{val: "C2", globalAccountID: "C", deletedAt: time.Now()}),
 			*fixInstance(instanceData{val: "B1", globalAccountID: "B", deletedAt: time.Now()}),
@@ -124,21 +125,22 @@ func TestInstance(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		fixOperation := []internal.Operation{
+		fixOperations := []internal.Operation{
 			fixture.FixProvisioningOperation("op1", "A1"),
 			fixture.FixProvisioningOperation("op2", "A2"),
-			fixture.FixProvisioningOperation("op3", "C1"),
-			fixture.FixProvisioningOperation("op4", "C2"),
-			fixture.FixProvisioningOperation("op5", "B1"),
+			fixture.FixSuspensionOperationAsOperation("op3", "A3"),
+			fixture.FixProvisioningOperation("op4", "C1"),
+			fixture.FixProvisioningOperation("op5", "C2"),
+			fixture.FixProvisioningOperation("op6", "B1"),
 		}
 
-		for _, i := range fixOperation {
+		for _, i := range fixOperations {
 			err = brokerStorage.Operations().InsertOperation(i)
 			require.NoError(t, err)
 		}
 
 		// when
-		stats, err := brokerStorage.Instances().GetInstanceStats()
+		stats, err := brokerStorage.Instances().GetActiveInstanceStats()
 		require.NoError(t, err)
 		numberOfInstancesA, err := brokerStorage.Instances().GetNumberOfInstancesForGlobalAccountID("A")
 		require.NoError(t, err)
@@ -154,7 +156,7 @@ func TestInstance(t *testing.T) {
 			TotalNumberOfInstances: 3,
 			PerGlobalAccountID:     map[string]int{"A": 2, "C": 1},
 		}, stats)
-		assert.Equal(t, 2, numberOfInstancesA)
+		assert.Equal(t, 3, numberOfInstancesA)
 		assert.Equal(t, 1, numberOfInstancesC)
 		assert.Equal(t, 0, numberOfInstancesB)
 	})

--- a/internal/storage/ext.go
+++ b/internal/storage/ext.go
@@ -17,7 +17,7 @@ type Instances interface {
 	Insert(instance internal.Instance) error
 	Update(instance internal.Instance) (*internal.Instance, error)
 	Delete(instanceID string) error
-	GetInstanceStats() (internal.InstanceStats, error)
+	GetActiveInstanceStats() (internal.InstanceStats, error)
 	GetERSContextStats() (internal.ERSContextStats, error)
 	GetDistinctSubAccounts() ([]string, error)
 	GetNumberOfInstancesForGlobalAccountID(globalAccountID string) (int, error)

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -36,7 +36,7 @@ type ReadSession interface {
 	ListOperations(filter dbmodel.OperationFilter) ([]dbmodel.OperationDTO, int, int, error)
 	ListOperationsByType(operationType internal.OperationType) ([]dbmodel.OperationDTO, dberr.Error)
 	GetOperationStats() ([]dbmodel.OperationStatEntry, error)
-	GetInstanceStats() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error)
+	GetActiveInstanceStats() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error)
 	GetERSContextStats() ([]dbmodel.InstanceERSContextStatsEntry, error)
 	GetNumberOfInstancesForGlobalAccountID(globalAccountID string) (int, error)
 	GetRuntimeStateByOperationID(operationID string) (dbmodel.RuntimeStateDTO, dberr.Error)

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -673,7 +673,7 @@ func (r readSession) GetOperationStatsForOrchestration(orchestrationID string) (
 	return rows, err
 }
 
-func (r readSession) GetInstanceStats() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error) {
+func (r readSession) GetActiveInstanceStats() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error) {
 	var rows []dbmodel.InstanceByGlobalAccountIDStatEntry
 	var stmt *dbr.SelectStmt
 	filter := dbmodel.InstanceFilter{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

GetActiveInstanceStats method (GetInstanceStats formerly) is used for metrics to get active SKR's. It used to get suspended SKRs too, but it shouldn't.

Changes proposed in this pull request:

- Adjust instances querying (changed to a similar query that is run on the `kcp rt` command)
- Add test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
