### PR TITLE
Fix runtimes endpoint for suspended filter

### DIFF
--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -134,11 +134,6 @@ func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]pkg.RuntimeDTO
 	}
 
 	var result []pkg.RuntimeDTO
-	if filter.Suspended != nil {
-		if *filter.Suspended {
-			filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
-		}
-	}
 	instances, count, total, err := h.instancesDb.List(filter)
 	if err != nil {
 		return []pkg.RuntimeDTO{}, 0, 0, err

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -134,6 +134,11 @@ func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]pkg.RuntimeDTO
 	}
 
 	var result []pkg.RuntimeDTO
+	if filter.Suspended != nil {
+		if *filter.Suspended {
+			filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
+		}
+	}
 	instances, count, total, err := h.instancesDb.List(filter)
 	if err != nil {
 		return []pkg.RuntimeDTO{}, 0, 0, err
@@ -497,7 +502,8 @@ func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {
 			case pkg.StateUpdating:
 				filter.States = append(filter.States, dbmodel.InstanceUpdating)
 			case pkg.StateSuspended:
-				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
+				suspended := true
+				filter.Suspended = &suspended
 			case pkg.StateDeprovisioned:
 				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
 			case pkg.StateDeprovisionIncomplete:

--- a/internal/storage/dbmodel/instance.go
+++ b/internal/storage/dbmodel/instance.go
@@ -36,6 +36,7 @@ type InstanceFilter struct {
 	Expired                      *bool
 	DeletionAttempted            *bool
 	BindingExists                *bool
+	Suspended                    *bool
 }
 
 type InstanceDTO struct {

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -815,6 +815,74 @@ func TestInstance(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 3, notCompletelyDeleted)
 	})
+
+	t.Run("Should list suspended instances", func(t *testing.T) {
+		storageCleanup, brokerStorage, err := GetStorageForDatabaseTests()
+		require.NoError(t, err)
+		require.NotNil(t, brokerStorage)
+		defer func() {
+			err := storageCleanup()
+			assert.NoError(t, err)
+		}()
+
+		// populate database with samples
+		inst1 := fixInstance(instanceData{val: "inst1"})
+		inst2 := fixInstance(instanceData{val: "inst2"})
+		inst3 := fixInstance(instanceData{val: "inst3"})
+		inst3.Parameters.ErsContext.Active = ptr.Bool(false)
+		inst4 := fixInstance(instanceData{val: "inst4"})
+		fixInstances := []internal.Instance{*inst1, *inst2, *inst3, *inst4}
+
+		for _, i := range fixInstances {
+			err = brokerStorage.Instances().Insert(i)
+			require.NoError(t, err)
+		}
+
+		// inst1 is in succeeded state
+		provOp1 := fixProvisionOperation("inst1")
+		provOp1.State = domain.Succeeded
+		err = brokerStorage.Operations().InsertOperation(provOp1)
+		require.NoError(t, err)
+
+		// inst2 is in succeeded state
+		provOp2 := fixProvisionOperation("inst2")
+		provOp2.State = domain.Succeeded
+		err = brokerStorage.Operations().InsertOperation(provOp2)
+		require.NoError(t, err)
+		deprovOp2 := fixDeprovisionOperation("inst2")
+		deprovOp2.Temporary = true
+		deprovOp2.State = domain.Succeeded
+		deprovOp2.CreatedAt = deprovOp2.CreatedAt.Add(2 * time.Minute)
+		err = brokerStorage.Operations().InsertDeprovisioningOperation(deprovOp2)
+		require.NoError(t, err)
+
+		// inst3 is in succeeded state
+		provOp3 := fixProvisionOperation("inst3")
+		provOp3.State = domain.Succeeded
+		err = brokerStorage.Operations().InsertOperation(provOp3)
+		require.NoError(t, err)
+		deprovOp3 := fixDeprovisionOperation("inst3")
+		deprovOp3.Temporary = true
+		deprovOp3.State = domain.Succeeded
+		deprovOp3.CreatedAt = deprovOp3.CreatedAt.Add(2 * time.Minute)
+		err = brokerStorage.Operations().InsertDeprovisioningOperation(deprovOp3)
+		require.NoError(t, err)
+
+		// inst4 is in failed state
+		provOp4 := fixProvisionOperation("inst4")
+		provOp4.State = domain.Failed
+		err = brokerStorage.Operations().InsertOperation(provOp4)
+		require.NoError(t, err)
+
+		// when
+		suspendedFilter := dbmodel.InstanceFilter{Suspended: ptr.Bool(true)}
+
+		_, suspended, _, err := brokerStorage.Instances().List(suspendedFilter)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, 1, suspended)
+	})
 }
 
 func assertInstanceByIgnoreTime(t *testing.T, want, got internal.Instance) {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -867,6 +867,10 @@ func buildInstanceStateFilters(table string, filter dbmodel.InstanceFilter) dbr.
 			))
 		}
 	}
+	if filter.Suspended != nil && *filter.Suspended {
+		exprs = append(exprs, dbr.And(
+			dbr.Expr("((provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")))
+	}
 
 	return dbr.Or(exprs...)
 }
@@ -918,10 +922,6 @@ func addInstanceFilters(stmt *dbr.SelectStmt, filter dbmodel.InstanceFilter) {
 
 	if filter.BindingExists != nil && *filter.BindingExists {
 		stmt.Where("exists (select instance_id from bindings where bindings.instance_id=instances.instance_id)")
-	}
-
-	if filter.Suspended != nil && *filter.Suspended {
-		stmt.Where("((instances.provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")
 	}
 }
 

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -868,8 +868,7 @@ func buildInstanceStateFilters(table string, filter dbmodel.InstanceFilter) dbr.
 		}
 	}
 	if filter.Suspended != nil && *filter.Suspended {
-		exprs = append(exprs, dbr.And(
-			dbr.Expr("((provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")))
+		exprs = append(exprs, dbr.Expr("((instances.provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false"))
 	}
 
 	return dbr.Or(exprs...)

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -921,7 +921,7 @@ func addInstanceFilters(stmt *dbr.SelectStmt, filter dbmodel.InstanceFilter) {
 	}
 
 	if filter.Suspended != nil && *filter.Suspended {
-		stmt.Where("((provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")
+		stmt.Where("(provisioning_parameters->'ers_context'->'active')::BOOLEAN IS false")
 	}
 }
 

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -757,6 +757,7 @@ func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.Ins
 	}
 
 	addInstanceFilters(stmt, filter)
+	fmt.Println(stmt)
 
 	_, err := stmt.Load(&instances)
 	if err != nil {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -867,7 +867,7 @@ func buildInstanceStateFilters(table string, filter dbmodel.InstanceFilter) dbr.
 			))
 		}
 	}
-	if *filter.Suspended {
+	if filter.Suspended != nil && *filter.Suspended {
 		exprs = append(exprs, dbr.Expr("((instances.provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false"))
 	}
 

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -757,7 +757,9 @@ func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.Ins
 	}
 
 	addInstanceFilters(stmt, filter)
-	fmt.Println(stmt)
+	buf := dbr.NewBuffer()
+	_ = stmt.Build(stmt.Dialect, buf)
+	fmt.Println(buf.String())
 
 	_, err := stmt.Load(&instances)
 	if err != nil {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -921,7 +921,7 @@ func addInstanceFilters(stmt *dbr.SelectStmt, filter dbmodel.InstanceFilter) {
 	}
 
 	if filter.Suspended != nil && *filter.Suspended {
-		stmt.Where("(provisioning_parameters->'ers_context'->'active')::BOOLEAN IS false")
+		stmt.Where("(instances.provisioning_parameters->'ers_context'->'active')::BOOLEAN IS false")
 	}
 }
 

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -919,6 +919,10 @@ func addInstanceFilters(stmt *dbr.SelectStmt, filter dbmodel.InstanceFilter) {
 	if filter.BindingExists != nil && *filter.BindingExists {
 		stmt.Where("exists (select instance_id from bindings where bindings.instance_id=instances.instance_id)")
 	}
+
+	if filter.Suspended != nil && *filter.Suspended {
+		stmt.Where("((provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")
+	}
 }
 
 func addOrchestrationFilters(stmt *dbr.SelectStmt, filter dbmodel.OrchestrationFilter) {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -921,7 +921,7 @@ func addInstanceFilters(stmt *dbr.SelectStmt, filter dbmodel.InstanceFilter) {
 	}
 
 	if filter.Suspended != nil && *filter.Suspended {
-		stmt.Where("(instances.provisioning_parameters->'ers_context'->'active')::BOOLEAN IS false")
+		stmt.Where("((instances.provisioning_parameters::JSONB->>'ers_context')::JSONB->>'active')::BOOLEAN IS false")
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The suspended state is a "virtual" state that is calculated. It seems that we can recognise the instances by the ersContext active field. It is set to false when we receive a suspend call from CIS or when an instance has expired.

Previously, when the suspended parameter was sent to the KEB runtimes endpoint, we got all deprovisioned instances from the instances archived table instead of just the suspended ones from the instances table. This PR fixes it so that only suspended instances are retrieved.

Changes proposed in this pull request:

- Fix suspended parameter handling
- Add test

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
