### PR TITLE
Increase provisioning and deprovisioning duration metric range

### DIFF
--- a/internal/metricsv2/operation_duration.go
+++ b/internal/metricsv2/operation_duration.go
@@ -32,14 +32,14 @@ func NewOperationDurationCollector(logger logrus.FieldLogger) *OperationDuration
 			Subsystem: prometheusSubsystemv2,
 			Name:      "provisioning_duration_minutes",
 			Help:      "The time of the provisioning process",
-			Buckets:   prometheus.LinearBuckets(10, 2, 56),
+			Buckets:   prometheus.LinearBuckets(6, 2, 58),
 		}, []string{"plan_id"}),
 		deprovisioningHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: prometheusNamespacev2,
 			Subsystem: prometheusSubsystemv2,
 			Name:      "deprovisioning_duration_minutes",
 			Help:      "The time of the deprovisioning process",
-			Buckets:   prometheus.LinearBuckets(10, 2, 56),
+			Buckets:   prometheus.LinearBuckets(6, 2, 58),
 		}, []string{"plan_id"}),
 		logger: logger,
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Provisioning and deprovisioning often take less than 10 min. The metric can currently only say that the operation was less than 10 minutes without any further detail. This PR adds 2 more buckets so that we can determine if the operation was less than 8 min or less than 6 min.

Changes proposed in this pull request:

- Add 2 more buckets to the lower bound of the provisioning and deprovisioning duration metric

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1418