### PR TITLE
Fixing not set `operation.CloudProvider` when provisioner is managing cluster

### DIFF
--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -235,7 +235,7 @@ func TestProvisioning_HappyPathAWS(t *testing.T) {
 
 	suite.AssertKymaResourceExists(opID)
 	suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
-	suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-central-1"})
+	suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-central-1", "kyma-project.io/provider": "AWS"})
 	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 }
 
@@ -335,7 +335,7 @@ func TestProvisioning_HappyPathSapConvergedCloud(t *testing.T) {
 
 		suite.AssertKymaResourceExists(opID)
 		suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
-		suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-de-1"})
+		suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-de-1", "kyma-project.io/provider": "SapConvergedCloud"})
 	})
 
 	t.Run("should fail for invalid platform region - invalid platform region", func(t *testing.T) {
@@ -431,7 +431,8 @@ func TestProvisioning_Preview(t *testing.T) {
 
 	suite.AssertKymaResourceExists(opID)
 	suite.AssertKymaLabelsExist(opID, map[string]string{
-		"kyma-project.io/region": "eu-central-1",
+		"kyma-project.io/region":   "eu-central-1",
+		"kyma-project.io/provider": "AWS",
 	})
 	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 }
@@ -597,6 +598,7 @@ func TestProvisioning_AzureWithEURestrictedAccessHappyFlow(t *testing.T) {
 	suite.AssertAzureRegion("switzerlandnorth")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region":          "switzerlandnorth",
+		"kyma-project.io/provider":        "Azure",
 		"kyma-project.io/platform-region": "cf-ch20"})
 }
 
@@ -633,6 +635,7 @@ func TestProvisioning_AzureWithEURestrictedAccessDefaultRegion(t *testing.T) {
 	suite.AssertAzureRegion("switzerlandnorth")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region":          "switzerlandnorth",
+		"kyma-project.io/provider":        "Azure",
 		"kyma-project.io/platform-region": "cf-ch20"})
 }
 
@@ -669,6 +672,7 @@ func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
 	suite.AssertAWSRegionAndZone("eu-central-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/provider":        "AWS",
 		"kyma-project.io/platform-region": "cf-eu11"})
 
 }
@@ -706,6 +710,7 @@ func TestProvisioning_AWSWithEURestrictedAccessDefaultRegion(t *testing.T) {
 	suite.AssertAWSRegionAndZone("eu-central-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/provider":        "AWS",
 		"kyma-project.io/platform-region": "cf-eu11"})
 
 }
@@ -742,7 +747,8 @@ func TestProvisioning_TrialWithEmptyRegion(t *testing.T) {
 	// then
 	suite.AssertAWSRegionAndZone("eu-west-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
-		"kyma-project.io/region": "eu-west-1"})
+		"kyma-project.io/provider": "AWS",
+		"kyma-project.io/region":   "eu-west-1"})
 	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 
 }
@@ -896,6 +902,7 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 	suite.AssertAWSRegionAndZone("eu-central-1")
 	suite.AssertKymaLabelsExist(opID, map[string]string{
 		"kyma-project.io/region":          "eu-central-1",
+		"kyma-project.io/provider":        "AWS",
 		"kyma-project.io/platform-region": "cf-eu11",
 	})
 

--- a/internal/process/steps/lifecycle_manager.go
+++ b/internal/process/steps/lifecycle_manager.go
@@ -18,7 +18,11 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 
 	l[customresources.RegionLabel] = operation.Region
 	l[customresources.ManagedByLabel] = "lifecycle-manager"
-	l[customresources.CloudProviderLabel] = operation.CloudProvider
+	if operation.CloudProvider != "" {
+		l[customresources.CloudProviderLabel] = operation.CloudProvider
+	} else { // fallback to inputCreator that will be removed when provisioner is decommissioned
+		l[customresources.CloudProviderLabel] = string(operation.InputCreator.Provider())
+	}
 
 	if isKymaResourceInternal(operation) {
 		l[customresources.InternalLabel] = "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fallback to `inputCreator` if `operation.CloudProvider` not set in `Create-Runtime-Resource-Step` (when KIM is driving)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.tools.sap/kyma/backlog/issues/6451