### PR TITLE
Remove logs from storage layer

### DIFF
--- a/internal/cis/e2e/tests_utils.go
+++ b/internal/cis/e2e/tests_utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -19,7 +18,7 @@ const (
 )
 
 func initTestDBInstancesTables(t *testing.T, connectionURL string) error {
-	connection, err := postsql.WaitForDatabaseAccess(connectionURL, 10, 100*time.Millisecond, logrus.New())
+	connection, err := postsql.WaitForDatabaseAccess(connectionURL, 10, 100*time.Millisecond)
 	if err != nil {
 		t.Logf("Cannot connect to database with URL %s", connectionURL)
 		return err

--- a/internal/storage/driver/postsql/initialization_test.go
+++ b/internal/storage/driver/postsql/initialization_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +29,7 @@ func TestInitialization(t *testing.T) {
 		connString := "bad connection string"
 
 		// when
-		connection, err := postsql.InitializeDatabase(connString, 3, logrus.New())
+		connection, err := postsql.InitializeDatabase(connString, 3)
 
 		// then
 		assert.Error(t, err)

--- a/internal/storage/driver/postsql/operation.go
+++ b/internal/storage/driver/postsql/operation.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
 
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -320,7 +319,6 @@ func (s *operations) GetLastOperation(instanceID string) (*internal.Operation, e
 				lastErr = dberr.NotFound("Operation with instance_id %s not exist", instanceID)
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -385,7 +383,6 @@ func (s *operations) GetNotFinishedOperationsByType(operationType internal.Opera
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		dto, err := session.GetNotFinishedOperationsByType(operationType)
 		if err != nil {
-			log.Errorf("while getting operations from the storage: %v", err)
 			return false, nil
 		}
 		operations = dto
@@ -470,7 +467,6 @@ func calFailedStatusForOrchestration(entries []dbmodel.OperationStatEntry) ([]st
 			}
 		}
 		if failedFound && !invalidFailed {
-			log.Info("calFailedStatusForOrchestration() append ", instanceID)
 			result = append(result, instanceID)
 		}
 	}
@@ -502,7 +498,6 @@ func (s *operations) GetOperationsForIDs(operationIDList []string) ([]internal.O
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		dto, err := session.GetOperationsForIDs(operationIDList)
 		if err != nil {
-			log.Errorf("while getting operations from the storage: %v", err)
 			return false, nil
 		}
 		operations = dto
@@ -526,7 +521,6 @@ func (s *operations) ListOperations(filter dbmodel.OperationFilter) ([]internal.
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, size, total, lastErr = session.ListOperations(filter)
 		if lastErr != nil {
-			log.Errorf("while getting operations from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -564,7 +558,6 @@ func (s *operations) ListOperationsByOrchestrationID(orchestrationID string, fil
 				lastErr = dberr.NotFound("Operations for orchestration ID %s not exist", orchestrationID)
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -642,7 +635,6 @@ func (s *operations) UpdateUpdatingOperation(operation internal.UpdatingOperatio
 		if lastErr != nil && dberr.IsNotFound(lastErr) {
 			_, lastErr = s.NewReadSession().GetOperationByID(operation.Operation.ID)
 			if lastErr != nil {
-				log.Errorf("while getting operation: %v", lastErr)
 				return false, nil
 			}
 
@@ -664,7 +656,6 @@ func (s *operations) ListUpdatingOperationsByInstanceID(instanceID string) ([]in
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, lastErr = session.GetOperationsByTypeAndInstanceID(instanceID, internal.OperationTypeUpdate)
 		if lastErr != nil {
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -705,7 +696,6 @@ func (s *operations) UpdateUpgradeClusterOperation(operation internal.UpgradeClu
 		if lastErr != nil && dberr.IsNotFound(lastErr) {
 			_, lastErr = s.NewReadSession().GetOperationByID(operation.Operation.ID)
 			if lastErr != nil {
-				log.Errorf("while getting operation: %v", lastErr)
 				return false, nil
 			}
 
@@ -741,7 +731,6 @@ func (s *operations) ListUpgradeClusterOperationsByInstanceID(instanceID string)
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, lastErr = session.GetOperationsByTypeAndInstanceID(instanceID, internal.OperationTypeUpgradeCluster)
 		if lastErr != nil {
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -772,7 +761,6 @@ func (s *operations) ListUpgradeClusterOperationsByOrchestrationID(orchestration
 				lastErr = dberr.NotFound("Operations for orchestration ID %s not exist", orchestrationID)
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -835,10 +823,7 @@ func (s *operations) toOperation(dto *dbmodel.OperationDTO, existingOp internal.
 		return internal.Operation{}, fmt.Errorf("while decrypting basic auth: %w", err)
 	}
 
-	err = s.cipher.DecryptKubeconfig(&provisioningParameters)
-	if err != nil {
-		log.Warn("decrypting skipped because kubeconfig is in a plain text")
-	}
+	_ = s.cipher.DecryptKubeconfig(&provisioningParameters)
 
 	stages := make([]string, 0)
 	finishedSteps := storage.SQLNullStringToString(dto.FinishedStages)
@@ -1123,7 +1108,6 @@ func (s *operations) getByID(id string) (*dbmodel.OperationDTO, error) {
 				lastErr = dberr.NotFound("Operation with id %s not exist", id)
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -1142,7 +1126,6 @@ func (s *operations) insert(dto dbmodel.OperationDTO) error {
 	_ = wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		lastErr = session.InsertOperation(dto)
 		if lastErr != nil {
-			log.Errorf("while insert operation: %v", lastErr)
 			return false, nil
 		}
 		// TODO: insert link to orchestration
@@ -1162,7 +1145,6 @@ func (s *operations) getByInstanceID(id string) (*dbmodel.OperationDTO, error) {
 				lastErr = dberr.NotFound("operation does not exist")
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -1182,7 +1164,6 @@ func (s *operations) getByTypeAndInstanceID(id string, opType internal.Operation
 				lastErr = dberr.NotFound("operation does not exist")
 				return false, lastErr
 			}
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -1203,7 +1184,6 @@ func (s *operations) update(operation dbmodel.OperationDTO) error {
 				return false, lastErr
 			}
 			if lastErr != nil {
-				log.Errorf("while getting operation: %v", lastErr)
 				return false, nil
 			}
 
@@ -1224,7 +1204,6 @@ func (s *operations) listOperationsByInstanceIdAndType(instanceId string, operat
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, lastErr = session.GetOperationsByTypeAndInstanceID(instanceId, operationType)
 		if lastErr != nil {
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -1243,7 +1222,6 @@ func (s *operations) listOperationsByType(operationType internal.OperationType) 
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, lastErr = session.ListOperationsByType(operationType)
 		if lastErr != nil {
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -1262,7 +1240,6 @@ func (s *operations) listOperationsByInstanceId(instanceId string) ([]dbmodel.Op
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		operations, lastErr = session.GetOperationsByInstanceID(instanceId)
 		if lastErr != nil {
-			log.Errorf("while reading operation from the storage: %v", lastErr)
 			return false, nil
 		}
 		return true, nil

--- a/internal/storage/driver/postsql/operation.go
+++ b/internal/storage/driver/postsql/operation.go
@@ -3,6 +3,7 @@ package postsql
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -823,7 +824,10 @@ func (s *operations) toOperation(dto *dbmodel.OperationDTO, existingOp internal.
 		return internal.Operation{}, fmt.Errorf("while decrypting basic auth: %w", err)
 	}
 
-	_ = s.cipher.DecryptKubeconfig(&provisioningParameters)
+	err = s.cipher.DecryptKubeconfig(&provisioningParameters)
+	if err != nil {
+		slog.Warn("decrypting skipped because kubeconfig is in a plain text")
+	}
 
 	stages := make([]string, 0)
 	finishedSteps := storage.SQLNullStringToString(dto.FinishedStages)

--- a/internal/storage/driver/postsql/orchestration.go
+++ b/internal/storage/driver/postsql/orchestration.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -36,7 +35,6 @@ func (s *orchestrations) Insert(orchestration internal.Orchestration) error {
 	return wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		err := sess.InsertOrchestration(dto)
 		if err != nil {
-			log.Errorf("while saving orchestration ID %s: %v", orchestration.OrchestrationID, err)
 			return false, nil
 		}
 		return true, nil
@@ -54,7 +52,6 @@ func (s *orchestrations) GetByID(orchestrationID string) (*internal.Orchestratio
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("Orchestration with id %s not exist", orchestrationID)
 			}
-			log.Errorf("while getting orchestration by ID %s: %v", orchestrationID, lastErr)
 			return false, nil
 		}
 		orchestration, lastErr = dto.ToOrchestration()
@@ -80,7 +77,6 @@ func (s *orchestrations) List(filter dbmodel.OrchestrationFilter) ([]internal.Or
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("Orchestrations not exist")
 			}
-			log.Errorf("while getting orchestration: %v", lastErr)
 			return false, nil
 		}
 		for _, dto := range dtos {
@@ -113,7 +109,6 @@ func (s *orchestrations) Update(orchestration internal.Orchestration) error {
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("Orchestration with id %s not exist", orchestration.OrchestrationID)
 			}
-			log.Errorf("while updating orchestration ID %s: %v", orchestration.OrchestrationID, lastErr)
 			return false, nil
 		}
 		return true, nil

--- a/internal/storage/driver/postsql/postsql_test.go
+++ b/internal/storage/driver/postsql/postsql_test.go
@@ -1,7 +1,7 @@
 package postsql_test
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -34,14 +34,10 @@ func TestMain(m *testing.M) {
 	config := brokerStorageDatabaseTestConfig()
 
 	docker, err := internal.NewDockerHandler()
-	if err != nil {
-		log.Fatal(err)
-	}
+	fatalOnError(err)
 	defer func(docker *internal.DockerHelper) {
 		err := docker.CloseDockerClient()
-		if err != nil {
-			log.Fatal(err)
-		}
+		fatalOnError(err)
 	}(docker)
 
 	cleanupContainer, err := docker.CreateDBContainer(internal.ContainerCreateRequest{
@@ -56,18 +52,21 @@ func TestMain(m *testing.M) {
 	defer func() {
 		if cleanupContainer != nil {
 			err := cleanupContainer()
-			if err != nil {
-				log.Fatal(err)
-			}
+			fatalOnError(err)
 		}
 	}()
-	if err != nil {
-		log.Fatal(err)
-	}
+	fatalOnError(err)
 
 	exitVal = m.Run()
 }
 
 func GetStorageForDatabaseTests() (func() error, storage.BrokerStorage, error) {
 	return storage.GetStorageForTest(brokerStorageDatabaseTestConfig())
+}
+
+func fatalOnError(err error) {
+	if err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
 }

--- a/internal/storage/driver/postsql/runtime_state.go
+++ b/internal/storage/driver/postsql/runtime_state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -39,7 +38,6 @@ func (s *runtimeState) Insert(runtimeState internal.RuntimeState) error {
 	return wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		err := sess.InsertRuntimeState(state)
 		if err != nil {
-			log.Errorf("while saving runtime state ID %s: %v", runtimeState.ID, err)
 			return false, nil
 		}
 		return true, nil
@@ -56,7 +54,6 @@ func (s *runtimeState) ListByRuntimeID(runtimeID string) ([]internal.RuntimeStat
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("RuntimeStates not found")
 			}
-			log.Errorf("while getting RuntimeState: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -81,7 +78,6 @@ func (s *runtimeState) GetByOperationID(operationID string) (internal.RuntimeSta
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("RuntimeState for operation %s not found", operationID)
 			}
-			log.Errorf("while getting RuntimeState: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -107,7 +103,6 @@ func (s *runtimeState) GetLatestByRuntimeID(runtimeID string) (internal.RuntimeS
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("RuntimeState for runtime %s not found", runtimeID)
 			}
-			log.Errorf("while getting RuntimeState: %v", lastErr)
 			return false, nil
 		}
 		return true, nil
@@ -133,7 +128,6 @@ func (s *runtimeState) GetLatestWithOIDCConfigByRuntimeID(runtimeID string) (int
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("RuntimeState for runtime %s not found", runtimeID)
 			}
-			log.Errorf("while getting RuntimeState: %v", lastErr)
 			return false, nil
 		}
 		return true, nil

--- a/internal/storage/driver/postsql/subaccount_state.go
+++ b/internal/storage/driver/postsql/subaccount_state.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -30,7 +29,6 @@ func (s *SubaccountState) UpsertState(subaccountState internal.SubaccountState) 
 	return wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		err := sess.UpsertSubaccountState(state)
 		if err != nil {
-			log.Errorf("while upserting subaccount state ID %s: %v", subaccountState.ID, err)
 			return false, nil
 		}
 		return true, nil
@@ -52,7 +50,6 @@ func (s *SubaccountState) ListStates() ([]internal.SubaccountState, error) {
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("subaccount_states not found")
 			}
-			log.Errorf("while getting subaccount states: %v", lastErr)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
**Description**

We can remove logs from storage layer, because errors are logged in calling functions.

Changes proposed in this pull request:

- remove logs from storage layer,
- use slog where logs are necessary.

**Related issue(s)**
See also #1469
