### PR TITLE
Provision only SKR in SKR suspension test

### DIFF
--- a/scripts/testing/get-latest-k3s-releases.sh
+++ b/scripts/testing/get-latest-k3s-releases.sh
@@ -27,7 +27,7 @@ GITHUB_URL=https://api.github.com/repos/${REPOSITORY}
 #   outputs:
 #             "v1.25.14+k3s1" "v1.26.9+k3s1" "v1.27.6+k3s1" "v1.28.1+k3s1"
 LATEST_RELEASES=($(curl -sS "${GITHUB_URL}/releases" \
-| jq '.[] | select(.name|test("v[0-9]{1,2}.[0-9]{1,3}.[0-9]{1,3}\\+")) | .name' \
+| jq '.[] | select(.prerelease == false) | select(.name|test("v[0-9]{1,2}.[0-9]{1,3}.[0-9]{1,3}\\+")) | .name' \
 | sort -rV\
 | awk -F. '/k3s1/ {if ($2 != p) {print $0; p=$2}}' \
 | head -n ${LIST_LEN}))

--- a/testing/e2e/skr/kyma-environment-broker/helpers.js
+++ b/testing/e2e/skr/kyma-environment-broker/helpers.js
@@ -26,11 +26,6 @@ async function provisionSKR(
   debug(`Operation ID ${operationID}`);
 
   await ensureOperationSucceeded(keb, kcp, instanceID, operationID, timeout);
-
-  debug('Fetching runtime operation status...');
-  const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
-  const objRuntimeStatus = JSON.parse(runtimeStatus);
-  expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;
 }
 
 async function getShoot(kcp, shootName) {

--- a/testing/e2e/skr/kyma-environment-broker/helpers.js
+++ b/testing/e2e/skr/kyma-environment-broker/helpers.js
@@ -6,7 +6,6 @@ const os = require('os');
 async function provisionSKR(
     keb,
     kcp,
-    gardener,
     instanceID,
     name,
     platformCreds,
@@ -32,20 +31,6 @@ async function provisionSKR(
   const runtimeStatus = await kcp.getRuntimeStatusOperations(instanceID);
   const objRuntimeStatus = JSON.parse(runtimeStatus);
   expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;
-  let shoot;
-  if (process.env['GARDENER_KUBECONFIG']) {
-    debug('Fetching shoot info from gardener...');
-    shoot = await gardener.getShoot(objRuntimeStatus.data[0].shootName);
-    debug(`Compass ID ${shoot.compassID}`);
-  } else {
-    debug('Fetching shoot info using kcp cli...');
-    shoot = await getShoot(kcp, objRuntimeStatus.data[0].shootName);
-  }
-
-  return {
-    operationID,
-    shoot,
-  };
 }
 
 async function getShoot(kcp, shootName) {

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -8,7 +8,7 @@ const {
   initializeK8sClient,
 } = require('../helpers');
 const {expect} = require('chai');
-const {provisionSKR}= require('../../kyma-environment-broker');
+const {provisionSKR, getShoot}= require('../../kyma-environment-broker');
 const {BTPOperatorCreds} = require('../../smctl/helpers');
 const {getSecret} = require('../../utils');
 

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -16,6 +16,7 @@ async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
   await provisionSKRInstance(options, provisioningTimeout);
 
+  debug('Fetching runtime operation status...');
   const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
   const objRuntimeStatus = JSON.parse(runtimeStatus);
   expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -15,7 +15,7 @@ const {getSecret} = require('../../utils');
 async function provisionSKRAndInitK8sConfig(options, provisioningTimeout) {
   console.log('Provisioning new SKR instance...');
   await provisionSKRInstance(options, provisioningTimeout);
-  
+
   const runtimeStatus = await kcp.getRuntimeStatusOperations(options.instanceID);
   const objRuntimeStatus = JSON.parse(runtimeStatus);
   expect(objRuntimeStatus).to.have.nested.property('data[0].shootName').not.empty;

--- a/testing/e2e/skr/skr-test/provision/provision-skr.js
+++ b/testing/e2e/skr/skr-test/provision/provision-skr.js
@@ -7,7 +7,7 @@ const {
   getSKRRuntimeStatus,
   initializeK8sClient,
 } = require('../helpers');
-
+const {expect} = require('chai');
 const {provisionSKR}= require('../../kyma-environment-broker');
 const {BTPOperatorCreds} = require('../../smctl/helpers');
 const {getSecret} = require('../../utils');

--- a/testing/e2e/skr/trial-suspension-test/test.js
+++ b/testing/e2e/skr/trial-suspension-test/test.js
@@ -1,7 +1,7 @@
 const {KCPWrapper, KCPConfig} = require('../kcp/client');
 const {KEBClient, KEBConfig} = require('../kyma-environment-broker');
 const {gatherOptions} = require('../skr-test/helpers');
-const {provisionSKRAndInitK8sConfig} = require('../skr-test/provision/provision-skr');
+const {provisionSKRInstance} = require('../skr-test/provision/provision-skr');
 const {deprovisionAndUnregisterSKR} = require('../skr-test/provision/deprovision-skr');
 const {debug} = require('../utils');
 const {assert} = require('chai');
@@ -31,7 +31,7 @@ describe('SKR Trial suspension test', function() {
 
   before('Ensure SKR Trial is provisioned', async function() {
     try {
-      await callFuncAndPrintExecutionTime(provisionSKRAndInitK8sConfig, [options, provisioningTimeout]);
+      await callFuncAndPrintExecutionTime(provisionSKRInstance, [options, provisioningTimeout]);
     } catch (e) {
       throw new Error(`${e.toString()}\n`);
     }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- For trial suspension test only provision SKR without fetching kubeconfig
- Refactor functions

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1434 