### PR TITLE
Use slog in env cleanup job

### DIFF
--- a/cmd/accountcleanup/main.go
+++ b/cmd/accountcleanup/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	// create storage connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, logs.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 	fatalOnError(err)
 
 	// create broker client

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/archive"
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 )
 
@@ -67,7 +66,7 @@ func main() {
 	slog.Info(fmt.Sprintf("PerformDeletion: %v", cfg.PerformDeletion))
 	slog.Info(fmt.Sprintf("Batch size: %v", cfg.BatchSize))
 
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, storage.NewEncrypter(cfg.Database.SecretKey), logrus.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, storage.NewEncrypter(cfg.Database.SecretKey))
 	fatalOnError(err)
 	defer func() {
 		err := conn.Close()

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -262,7 +262,7 @@ func main() {
 	if cfg.DbInMemory {
 		db = storage.NewMemoryStorage()
 	} else {
-		store, conn, err := storage.NewFromConfig(cfg.Database, cfg.Events, cipher, logs.WithField("service", "storage"))
+		store, conn, err := storage.NewFromConfig(cfg.Database, cfg.Events, cipher)
 		fatalOnError(err, logs)
 		db = store
 		dbStatsCollector := sqlstats.NewStatsCollector("broker", conn)

--- a/cmd/deprovisionretrigger/main.go
+++ b/cmd/deprovisionretrigger/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	// create storage connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, log.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 	fatalOnError(err)
 	svc := newDeprovisionRetriggerService(cfg, brokerClient, db.Instances())
 

--- a/cmd/expirator/main.go
+++ b/cmd/expirator/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/schemamigrator/cleaner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
-	log "github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 )
 
@@ -74,7 +73,7 @@ func main() {
 
 	// create storage connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, log.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 	fatalOnError(err)
 	svc := newCleanupService(cfg, brokerClient, db.Instances())
 

--- a/cmd/runtimereconciler/main.go
+++ b/cmd/runtimereconciler/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
 
-	db, _, err := storage.NewFromConfig(cfg.Database, cfg.Events, cipher, logs.WithField("service", "storage"))
+	db, _, err := storage.NewFromConfig(cfg.Database, cfg.Events, cipher)
 	fatalOnError(err, logs)
 	logs.Info("runtime-reconciler connected to database")
 

--- a/cmd/servicebindingcleanup/main.go
+++ b/cmd/servicebindingcleanup/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/schemamigrator/cleaner"
 	"github.com/kyma-project/kyma-environment-broker/internal/servicebindingcleanup"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	log "github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 )
 
@@ -45,7 +44,7 @@ func main() {
 	brokerClient.UserAgent = broker.ServiceBindingCleanupJobName
 
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, log.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 	fatalOnError(err)
 
 	svc := servicebindingcleanup.NewService(cfg.Job.DryRun, brokerClient, db.Bindings())

--- a/cmd/subaccountsync/main.go
+++ b/cmd/subaccountsync/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	// create DB connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, dbConn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, logrus.WithField("service", "storage"))
+	db, dbConn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 
 	// create and register metrics
 	metricsRegistry := prometheus.NewRegistry()

--- a/cmd/trialcleanup/main.go
+++ b/cmd/trialcleanup/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// create storage connection
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
-	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, log.WithField("service", "storage"))
+	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher)
 	fatalOnError(err)
 	svc := newTrialCleanupService(cfg, brokerClient, db.Instances())
 

--- a/common/setup/error_handlers.go
+++ b/common/setup/error_handlers.go
@@ -1,15 +1,19 @@
 package setup
 
-import log "github.com/sirupsen/logrus"
+import (
+	"log/slog"
+	"os"
+)
 
 func FatalOnError(err error) {
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 
 func LogOnError(err error) {
 	if err != nil {
-		log.Error(err)
+		slog.Error(err.Error())
 	}
 }

--- a/internal/cis/e2e/account_cleanup_test.go
+++ b/internal/cis/e2e/account_cleanup_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/driver/postsql/events"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +39,7 @@ func TestSubAccountCleanup(t *testing.T) {
 
 		t.Log("create storage manager")
 		cipher := storage.NewEncrypter(cfg.SecretKey)
-		storageManager, _, err := storage.NewFromConfig(cfg, events.Config{}, cipher, logrus.StandardLogger())
+		storageManager, _, err := storage.NewFromConfig(cfg, events.Config{}, cipher)
 		require.NoError(t, err)
 
 		t.Log("fill instances table")
@@ -92,7 +91,7 @@ func TestSubAccountCleanup(t *testing.T) {
 
 		t.Log("create storage manager")
 		cipher := storage.NewEncrypter(cfg.SecretKey)
-		storageManager, _, err := storage.NewFromConfig(cfg, events.Config{}, cipher, logrus.StandardLogger())
+		storageManager, _, err := storage.NewFromConfig(cfg, events.Config{}, cipher)
 		require.NoError(t, err)
 
 		t.Log("fill instances table")

--- a/internal/environmentscleanup/service_test.go
+++ b/internal/environmentscleanup/service_test.go
@@ -1,7 +1,6 @@
 package environmentscleanup
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	mocks "github.com/kyma-project/kyma-environment-broker/internal/environmentscleanup/automock"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -74,9 +72,8 @@ func TestService_PerformCleanup(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		logger := logrus.New()
 
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -96,9 +93,8 @@ func TestService_PerformCleanup(t *testing.T) {
 		bcMock := &mocks.BrokerClient{}
 
 		memoryStorage := storage.NewMemoryStorage()
-		logger := logrus.New()
 
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err := svc.PerformCleanup()
@@ -144,9 +140,8 @@ func TestService_PerformCleanup(t *testing.T) {
 			},
 		})
 		assert.NoError(t, err)
-		logger := logrus.New()
 
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -192,9 +187,7 @@ func TestService_PerformCleanup(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		logger := logrus.New()
-
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -266,14 +259,7 @@ func TestService_PerformCleanup(t *testing.T) {
 
 		memoryStorage := storage.NewMemoryStorage()
 
-		var actualLog bytes.Buffer
-		logger := logrus.New()
-		logger.SetFormatter(&logrus.TextFormatter{
-			DisableTimestamp: true,
-		})
-		logger.SetOutput(&actualLog)
-
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -327,9 +313,7 @@ func TestService_PerformCleanup(t *testing.T) {
 		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: fixRuntimeID3, Namespace: kcpNamespace}, &imv1.Runtime{})
 		assert.NoError(t, err)
 
-		logger := logrus.New()
-
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -386,9 +370,7 @@ func TestService_PerformCleanup(t *testing.T) {
 		err = k8sClient.Get(context.Background(), client.ObjectKey{Name: fixRuntimeID3, Namespace: kcpNamespace}, &imv1.Runtime{})
 		assert.NoError(t, err)
 
-		logger := logrus.New()
-
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.PerformCleanup()
@@ -411,7 +393,6 @@ func TestService_PerformCleanup(t *testing.T) {
 		bcMock := &mocks.BrokerClient{}
 		bcMock.On("Deprovision", mock.AnythingOfType("internal.Instance")).Return(fixOperationID, nil)
 		memoryStorage := storage.NewMemoryStorage()
-		logger := logrus.New()
 		k8sClient = fake.NewClientBuilder().WithScheme(sch).Build()
 
 		configMap := &corev1.ConfigMap{
@@ -427,7 +408,7 @@ func TestService_PerformCleanup(t *testing.T) {
 		err = k8sClient.Create(context.Background(), configMap)
 		assert.NoError(t, err)
 
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.Run()
@@ -445,7 +426,6 @@ func TestService_PerformCleanup(t *testing.T) {
 		bcMock := &mocks.BrokerClient{}
 		bcMock.On("Deprovision", mock.AnythingOfType("internal.Instance")).Return(fixOperationID, nil)
 		memoryStorage := storage.NewMemoryStorage()
-		logger := logrus.New()
 		k8sClient = fake.NewClientBuilder().WithScheme(sch).Build()
 
 		configMap := &corev1.ConfigMap{
@@ -461,7 +441,7 @@ func TestService_PerformCleanup(t *testing.T) {
 		err = k8sClient.Create(context.Background(), configMap)
 		assert.NoError(t, err)
 
-		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), logger, maxShootAge, shootLabelSelector)
+		svc := NewService(gcMock, bcMock, k8sClient, memoryStorage.Instances(), maxShootAge, shootLabelSelector)
 
 		// when
 		err = svc.Run()

--- a/internal/globalaccounts/globalaccounts.go
+++ b/internal/globalaccounts/globalaccounts.go
@@ -73,7 +73,7 @@ func initAll(ctx context.Context, cfg Config, logs *logrus.Logger) (*http.Client
 		cfg.Database,
 		events.Config{},
 		storage.NewEncrypter(cfg.Database.SecretKey),
-		logs.WithField("service", "storage"))
+	)
 
 	if err != nil {
 		logs.Error(err.Error())

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/gocraft/dbr"
-	"github.com/sirupsen/logrus"
-
 	eventsapi "github.com/kyma-project/kyma-environment-broker/common/events"
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/driver/memory"
@@ -33,7 +31,7 @@ const (
 	connectionRetries = 10
 )
 
-func NewFromConfig(cfg Config, evcfg events.Config, cipher postgres.Cipher, log logrus.FieldLogger) (BrokerStorage, *dbr.Connection, error) {
+func NewFromConfig(cfg Config, evcfg events.Config, cipher postgres.Cipher) (BrokerStorage, *dbr.Connection, error) {
 	slog.Info(fmt.Sprintf("Setting DB connection pool params: connectionMaxLifetime=%s maxIdleConnections=%d maxOpenConnections=%d",
 		cfg.ConnMaxLifetime, cfg.MaxIdleConns, cfg.MaxOpenConns))
 

--- a/internal/storage/storage_handler.go
+++ b/internal/storage/storage_handler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gocraft/dbr"
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 )
 
@@ -22,7 +21,7 @@ const (
 )
 
 func GetStorageForTest(config Config) (func() error, BrokerStorage, error) {
-	storage, connection, err := NewFromConfig(config, events.Config{}, NewEncrypter(config.SecretKey), logrus.StandardLogger())
+	storage, connection, err := NewFromConfig(config, events.Config{}, NewEncrypter(config.SecretKey))
 	if err != nil {
 		return nil, nil, fmt.Errorf("while creating storage: %w", err)
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in Environment Cleanup Job,
- since changes introduced in https://github.com/kyma-project/kyma-environment-broker/pull/1522, `logurs` is not used in `storage.NewFromConfig`, so it can be removed form function parameters. 

**Related issue(s)**
See also #1469
