### PR TITLE
Use slog in Account Cleanup Job

### DIFF
--- a/cmd/accountcleanup/main.go
+++ b/cmd/accountcleanup/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"os"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -9,7 +12,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/kyma-environment-broker/internal/schemamigrator/cleaner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 )
 
@@ -27,24 +29,26 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// create logs
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
 	// create and fill config
 	var cfg Config
 	err := envconfig.InitWithPrefix(&cfg, "APP")
 	fatalOnError(err)
 
-	// create logs
-	logs := logrus.New()
-	logs.SetFormatter(&logrus.JSONFormatter{})
-
 	// create CIS client
 	var client cis.CisClient
 	switch cfg.ClientVersion {
 	case "v1.0":
-		client = cis.NewClientVer1(ctx, cfg.CIS, logs)
+		client = cis.NewClientVer1(ctx, cfg.CIS)
 	case "v2.0":
-		client = cis.NewClient(ctx, cfg.CIS, logs)
+		client = cis.NewClient(ctx, cfg.CIS)
 	default:
-		logs.Fatalf("Client version %s is not supported", cfg.ClientVersion)
+		fatalOnError(fmt.Errorf("client version %s is not supported", cfg.ClientVersion))
 	}
 
 	// create storage connection
@@ -57,7 +61,7 @@ func main() {
 	brokerClient.UserAgent = broker.AccountCleanupJob
 
 	// create SubAccountCleanerService and execute process
-	sacs := cis.NewSubAccountCleanupService(client, brokerClient, db.Instances(), logs)
+	sacs := cis.NewSubAccountCleanupService(client, brokerClient, db.Instances())
 	fatalOnError(sacs.Run())
 
 	// do not use defer, close must be done before halting
@@ -76,12 +80,13 @@ func main() {
 
 func fatalOnError(err error) {
 	if err != nil {
-		logrus.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }
 
 func logOnError(err error) {
 	if err != nil {
-		logrus.Error(err)
+		slog.Error(err.Error())
 	}
 }

--- a/cmd/accountcleanup/main.go
+++ b/cmd/accountcleanup/main.go
@@ -44,9 +44,15 @@ func main() {
 	var client cis.CisClient
 	switch cfg.ClientVersion {
 	case "v1.0":
-		client = cis.NewClientVer1(ctx, cfg.CIS)
+		log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})).With("client", "CIS-1.0")
+		client = cis.NewClientVer1(ctx, cfg.CIS, log)
 	case "v2.0":
-		client = cis.NewClient(ctx, cfg.CIS)
+		log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})).With("client", "CIS-2.0")
+		client = cis.NewClient(ctx, cfg.CIS, log)
 	default:
 		fatalOnError(fmt.Errorf("client version %s is not supported", cfg.ClientVersion))
 	}

--- a/internal/cis/client.go
+++ b/internal/cis/client.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
 
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -34,10 +34,9 @@ type Config struct {
 type Client struct {
 	httpClient *http.Client
 	config     Config
-	log        logrus.FieldLogger
 }
 
-func NewClient(ctx context.Context, config Config, log logrus.FieldLogger) *Client {
+func NewClient(ctx context.Context, config Config) *Client {
 	cfg := clientcredentials.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
@@ -52,7 +51,6 @@ func NewClient(ctx context.Context, config Config, log logrus.FieldLogger) *Clie
 	return &Client{
 		httpClient: httpClientOAuth,
 		config:     config,
-		log:        log.WithField("client", "CIS-2.0"),
 	}
 }
 
@@ -76,12 +74,8 @@ func (c *Client) FetchSubaccountsToDelete() ([]string, error) {
 		return []string{}, fmt.Errorf("while fetching subaccounts from delete events: %w", err)
 	}
 
-	c.log.Infof("CIS returned total amount of delete events: %d, client fetched %d subaccounts to delete. "+
-		"The events includes a range of time from %s to %s",
-		subaccounts.total,
-		len(subaccounts.ids),
-		subaccounts.from,
-		subaccounts.to)
+	slog.Info(fmt.Sprintf("CIS returned total amount of delete events: %d, client fetched %d subaccounts to delete. "+
+		"The events include a range of time from %s to %s", subaccounts.total, len(subaccounts.ids), subaccounts.from, subaccounts.to))
 
 	return subaccounts.ids, nil
 }
@@ -167,7 +161,7 @@ func (c *Client) handleWrongStatusCode(response *http.Response) string {
 func (c *Client) appendSubaccountsFromDeleteEvents(cisResp *CisResponse, subaccs *subaccounts) {
 	for _, event := range cisResp.Events {
 		if event.Type != eventType {
-			c.log.Warnf("event type %s is not equal to %s, skip event", event.Type, eventType)
+			slog.Warn(fmt.Sprintf("event type %s is not equal to %s, skip event", event.Type, eventType))
 			continue
 		}
 		subaccs.ids = append(subaccs.ids, event.SubAccount)

--- a/internal/cis/client_test.go
+++ b/internal/cis/client_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/logger"
-
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +26,7 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -50,7 +48,7 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -73,7 +71,7 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 			EventServiceURL:   testServer.URL,
 			PageSize:          "3",
 			MaxRequestRetries: 3,
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -97,7 +95,7 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 			EventServiceURL:   testServer.URL,
 			PageSize:          "3",
 			MaxRequestRetries: 3,
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When

--- a/internal/cis/client_test.go
+++ b/internal/cis/client_test.go
@@ -3,8 +3,10 @@ package cis
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -23,10 +25,14 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServer(newServer(t))
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -45,10 +51,14 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServer(srv)
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -67,11 +77,15 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServer(srv)
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL:   testServer.URL,
 			PageSize:          "3",
 			MaxRequestRetries: 3,
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -91,11 +105,15 @@ func TestClient_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServer(srv)
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClient(context.TODO(), Config{
 			EventServiceURL:   testServer.URL,
 			PageSize:          "3",
 			MaxRequestRetries: 3,
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When

--- a/internal/cis/client_ver_1.go
+++ b/internal/cis/client_ver_1.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -21,10 +21,9 @@ const (
 type ClientVer1 struct {
 	httpClient *http.Client
 	config     Config
-	log        logrus.FieldLogger
 }
 
-func NewClientVer1(ctx context.Context, config Config, log logrus.FieldLogger) *ClientVer1 {
+func NewClientVer1(ctx context.Context, config Config) *ClientVer1 {
 	cfg := clientcredentials.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
@@ -39,7 +38,6 @@ func NewClientVer1(ctx context.Context, config Config, log logrus.FieldLogger) *
 	return &ClientVer1{
 		httpClient: httpClientOAuth,
 		config:     config,
-		log:        log.WithField("client", "CIS-1.0"),
 	}
 }
 
@@ -61,9 +59,8 @@ func (c *ClientVer1) FetchSubaccountsToDelete() ([]string, error) {
 		return []string{}, fmt.Errorf("while fetching subaccounts from delete events: %w", err)
 	}
 
-	c.log.Infof("CIS returned total amount of delete events: %d, client fetched %d subaccounts to delete.",
-		subaccounts.total,
-		len(subaccounts.ids))
+	slog.Info(fmt.Sprintf("CIS returned total amount of delete events: %d, client fetched %d subaccounts to delete.",
+		subaccounts.total, len(subaccounts.ids)))
 
 	return subaccounts.ids, nil
 }
@@ -92,7 +89,7 @@ func (c *ClientVer1) fetchSubaccountsFromDeleteEvents(collection *subaccountsVer
 	collection.total = cisResponse.Total
 	for _, event := range cisResponse.Events {
 		if event.Type != eventTypeVer1 {
-			c.log.Warnf("event type %s is not equal to %s, skip event", event.Type, eventTypeVer1)
+			slog.Warn(fmt.Sprintf("event type %s is not equal to %s, skip event", event.Type, eventTypeVer1))
 			continue
 		}
 		collection.ids = append(collection.ids, event.Data.SubAccount)

--- a/internal/cis/client_ver_1_test.go
+++ b/internal/cis/client_ver_1_test.go
@@ -3,8 +3,10 @@ package cis
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -23,10 +25,14 @@ func TestClientVer1_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServerVer1(newServerVer1(t))
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClientVer1(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -45,10 +51,14 @@ func TestClientVer1_FetchSubaccountsToDelete(t *testing.T) {
 		testServer := fixHTTPServerVer1(srv)
 		defer testServer.Close()
 
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		client := NewClientVer1(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		// When

--- a/internal/cis/client_ver_1_test.go
+++ b/internal/cis/client_ver_1_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/logger"
-
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +26,7 @@ func TestClientVer1_FetchSubaccountsToDelete(t *testing.T) {
 		client := NewClientVer1(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When
@@ -50,7 +48,7 @@ func TestClientVer1_FetchSubaccountsToDelete(t *testing.T) {
 		client := NewClientVer1(context.TODO(), Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "3",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		// When

--- a/internal/cis/e2e/account_cleanup_test.go
+++ b/internal/cis/e2e/account_cleanup_test.go
@@ -5,10 +5,10 @@ package e2e
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/cis"
-	"github.com/kyma-project/kyma-environment-broker/internal/logger"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/driver/postsql/events"
 
@@ -52,11 +52,16 @@ func TestSubAccountCleanup(t *testing.T) {
 		testServer := fixHTTPServer(t)
 		defer testServer.Close()
 
+		t.Log("create logger")
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		t.Log("create CIS client")
 		client := cis.NewClientVer1(context.TODO(), cis.Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "10",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		t.Log("create broker client mock and assert execution deprovisioning for first 30 instances")
@@ -104,11 +109,16 @@ func TestSubAccountCleanup(t *testing.T) {
 		testServer := fixHTTPServer(t)
 		defer testServer.Close()
 
+		t.Log("create logger")
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		t.Log("create CIS client")
 		client := cis.NewClient(context.TODO(), cis.Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "10",
-		})
+		}, logger)
 		client.SetHttpClient(testServer.Client())
 
 		t.Log("create broker client mock and assert execution deprovisioning for first 30 instances")

--- a/internal/cis/e2e/account_cleanup_test.go
+++ b/internal/cis/e2e/account_cleanup_test.go
@@ -56,7 +56,7 @@ func TestSubAccountCleanup(t *testing.T) {
 		client := cis.NewClientVer1(context.TODO(), cis.Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "10",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		t.Log("create broker client mock and assert execution deprovisioning for first 30 instances")
@@ -108,7 +108,7 @@ func TestSubAccountCleanup(t *testing.T) {
 		client := cis.NewClient(context.TODO(), cis.Config{
 			EventServiceURL: testServer.URL,
 			PageSize:        "10",
-		}, logger.NewLogDummy())
+		})
 		client.SetHttpClient(testServer.Client())
 
 		t.Log("create broker client mock and assert execution deprovisioning for first 30 instances")

--- a/internal/cis/fake_server.go
+++ b/internal/cis/fake_server.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -118,7 +118,7 @@ func (e *subaccountsEndpoint) getSubaccount(w http.ResponseWriter, r *http.Reque
 
 	data, err := json.Marshal(e.subaccounts[subaccountID])
 	if err != nil {
-		log.Println("error while marshalling subaccount data: %w", err)
+		slog.Error(fmt.Sprintf("error while marshalling subaccount data: %v", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -126,7 +126,7 @@ func (e *subaccountsEndpoint) getSubaccount(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusOK)
 	if _, err = w.Write(data); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		log.Println("error while writing subaccount data: %w", err)
+		slog.Error(fmt.Sprintf("error while writing subaccount data: %v", err))
 		return
 	}
 }
@@ -222,14 +222,14 @@ func (e *eventsEndpoint) getEvents(w http.ResponseWriter, r *http.Request) {
 
 	data, err := json.Marshal(resp)
 	if err != nil {
-		log.Println("error while marshalling events data: %w", err)
+		slog.Error(fmt.Sprintf("error while marshalling events data: %v", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
 	if _, err = w.Write(data); err != nil {
-		log.Println("error while writing events data: %w", err)
+		slog.Error(fmt.Sprintf("error while writing events data: %v", err))
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in Account Cleanup Job.

**Related issue(s)**
See also #1469
