### PR TITLE
Hide targetsecret in runtimes endpoint

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -62,6 +62,7 @@ type RuntimeDTO struct {
 	Bindings                    []BindingDTO                   `json:"bindings,omitempty"`
 	BetaEnabled                 string                         `json:"betaEnabled,omitempty"`
 	UsedForProduction           string                         `json:"usedForProduction,omitempty"`
+	SubscriptionSecretName      *string                        `json:"subscriptionSecretName,omitempty"`
 }
 
 type CloudProvider string

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -69,6 +69,7 @@ func (c *converter) applyOperation(source *internal.Operation, target *pkg.Opera
 		target.ExecutedButNotCompletedSteps = source.ExcutedButNotCompleted
 		target.Parameters = source.ProvisioningParameters.Parameters
 		target.Parameters.TargetSecret = nil
+		target.Parameters.Kubeconfig = ""
 		if !reflect.DeepEqual(source.LastError, kebError.LastError{}) {
 			target.Error = &source.LastError
 		}

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -101,6 +101,7 @@ func (c *converter) NewDTO(instance internal.Instance) (pkg.RuntimeDTO, error) {
 	toReturn.SubscriptionSecretName = instance.Parameters.Parameters.TargetSecret
 
 	toReturn.Parameters.TargetSecret = nil // TargetSecret is not a parameter sent by a customer
+	toReturn.Parameters.Kubeconfig = ""    // Kubeconfig should not be visible
 	if !instance.DeletedAt.IsZero() {
 		toReturn.Status.DeletedAt = &instance.DeletedAt
 	}

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -43,6 +43,7 @@ func (c *converter) ApplyProvisioningOperation(dto *pkg.RuntimeDTO, pOpr *intern
 		dto.Status.Provisioning = &pkg.Operation{}
 		c.applyOperation(&pOpr.Operation, dto.Status.Provisioning)
 		c.adjustRuntimeState(dto)
+		dto.SubscriptionSecretName = pOpr.ProvisioningParameters.Parameters.TargetSecret
 	}
 }
 

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -68,6 +68,7 @@ func (c *converter) applyOperation(source *internal.Operation, target *pkg.Opera
 		target.FinishedStages = source.FinishedStages
 		target.ExecutedButNotCompletedSteps = source.ExcutedButNotCompleted
 		target.Parameters = source.ProvisioningParameters.Parameters
+		target.Parameters.TargetSecret = nil
 		if !reflect.DeepEqual(source.LastError, kebError.LastError{}) {
 			target.Error = &source.LastError
 		}
@@ -96,6 +97,10 @@ func (c *converter) NewDTO(instance internal.Instance) (pkg.RuntimeDTO, error) {
 		},
 		Parameters: instance.Parameters.Parameters,
 	}
+
+	toReturn.SubscriptionSecretName = instance.Parameters.Parameters.TargetSecret
+
+	toReturn.Parameters.TargetSecret = nil // TargetSecret is not a parameter sent by a customer
 	if !instance.DeletedAt.IsZero() {
 		toReturn.Status.DeletedAt = &instance.DeletedAt
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- hide target secret in parameter list for (KCP CLI)
- provide subscription secret name (KCP CLI)
- clear kubeconfig field

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
