### PR TITLE
Use slog in Subaccount Sync Job

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -171,9 +173,12 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	additionalKymaVersions := []string{"1.19", "1.20", "main", "2.0"}
 	additionalKymaVersions = append(additionalKymaVersions, version...)
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(defaultKymaVer, additionalKymaVersions)...).Build()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
+		kebConfig.NewConfigMapReader(ctx, cli, log, "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/cmd/broker/deprovisioning_suite_test.go
+++ b/cmd/broker/deprovisioning_suite_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -67,6 +69,10 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	logs := logrus.New()
 	logs.Formatter.(*logrus.TextFormatter).TimestampFormat = "15:04:05.000"
 
@@ -104,7 +110,7 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(defaultKymaVer, []string{})...).Build()
 
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
+		kebConfig.NewConfigMapReader(ctx, cli, log, "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -226,8 +226,10 @@ func main() {
 		TimestampFormat: time.RFC3339Nano,
 	})
 
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelInfo)
 	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: logLevel,
 	}))
 	slog.SetDefault(log)
 
@@ -240,12 +242,7 @@ func main() {
 		l, _ := logrus.ParseLevel(cfg.LogLevel)
 		logs.SetLevel(l)
 
-		logLevel := new(slog.LevelVar)
 		logLevel.Set(cfg.getLogLevel())
-		log = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			Level: logLevel,
-		}))
-		slog.SetDefault(log)
 	}
 
 	cfg.OrchestrationConfig.KubernetesVersion = cfg.Provisioner.KubernetesVersion

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	gruntime "runtime"
 	"runtime/pprof"
 	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -224,6 +226,11 @@ func main() {
 		TimestampFormat: time.RFC3339Nano,
 	})
 
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(log)
+
 	// create and fill config
 	var cfg Config
 	err = envconfig.InitWithPrefix(&cfg, "APP")
@@ -232,6 +239,13 @@ func main() {
 	if cfg.LogLevel != "" {
 		l, _ := logrus.ParseLevel(cfg.LogLevel)
 		logs.SetLevel(l)
+
+		logLevel := new(slog.LevelVar)
+		logLevel.Set(cfg.getLogLevel())
+		log = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: logLevel,
+		}))
+		slog.SetDefault(log)
 	}
 
 	cfg.OrchestrationConfig.KubernetesVersion = cfg.Provisioner.KubernetesVersion
@@ -278,7 +292,7 @@ func main() {
 
 	// provides configuration for specified Kyma version and plan
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, kcpK8sClient, logs, cfg.RuntimeConfigurationConfigMapName),
+		kebConfig.NewConfigMapReader(ctx, kcpK8sClient, log, cfg.RuntimeConfigurationConfigMapName),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	gardenerClusterConfig, err := gardener.NewGardenerClusterConfig(cfg.Gardener.KubeconfigPath)
@@ -583,5 +597,20 @@ func fatalOnError(err error, log logrus.FieldLogger) {
 func panicOnError(err error) {
 	if err != nil {
 		panic(err)
+	}
+}
+
+func (c Config) getLogLevel() slog.Level {
+	switch strings.ToUpper(c.LogLevel) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "INFO":
+		return slog.LevelInfo
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
 }

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -101,6 +103,10 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 			panic(r)
 		}
 	}()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	logs := logrus.New()
 	logs.Formatter.(*logrus.TextFormatter).TimestampFormat = "15:04:05.000"
 
@@ -130,7 +136,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 	kymaVer := "2.4.0"
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(kymaVer, additionalKymaVersions)...).Build()
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
+		kebConfig.NewConfigMapReader(ctx, cli, log, "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	inputFactory, err := input.NewInputBuilderFactory(configProvider, input.Config{
@@ -537,6 +543,9 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 		}
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	logs := logrus.New()
 	storageCleanup, db, err := GetStorageForE2ETests()
 	assert.NoError(t, err)
@@ -559,7 +568,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 	additionalKymaVersions := []string{"1.19", "1.20", "main"}
 	cli := fake.NewFakeClientWithScheme(sch, fixK8sResources(defaultKymaVer, additionalKymaVersions)...)
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.New(), "keb-runtime-config"),
+		kebConfig.NewConfigMapReader(ctx, cli, log, "keb-runtime-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	inputFactory, err := input.NewInputBuilderFactory(configProvider, input.Config{

--- a/cmd/subaccountsync/main.go
+++ b/cmd/subaccountsync/main.go
@@ -13,10 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
-
 	"github.com/kyma-project/kyma-environment-broker/internal/kymacustomresource"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kebConfig "github.com/kyma-project/kyma-environment-broker/internal/config"
@@ -49,9 +47,10 @@ func main() {
 
 	logLevel := new(slog.LevelVar)
 	logLevel.Set(cfg.GetLogLevel())
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: logLevel,
-	})).With("service", "subaccount-sync"))
+	})).With("service", "subaccount-sync")
+	slog.SetDefault(logger)
 
 	slog.Info(fmt.Sprintf("Configuration: events window size:%s, events sync interval:%s, accounts sync interval: %s, storage sync interval: %s, queue sleep interval: %s",
 		cfg.EventsWindowSize, cfg.EventsWindowInterval, cfg.AccountsSyncInterval, cfg.StorageSyncInterval, cfg.SyncQueueSleepInterval))
@@ -63,9 +62,9 @@ func main() {
 		cfg.EventsWindowSize = cfg.EventsWindowInterval
 	}
 
-	// create config provider - provider still uses logrus logger
+	// create config provider
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logrus.WithField("service", "storage"), cfg.RuntimeConfigurationConfigMapName),
+		kebConfig.NewConfigMapReader(ctx, cli, logger.With("service", "storage"), cfg.RuntimeConfigurationConfigMapName),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/cmd/subaccountsync/main.go
+++ b/cmd/subaccountsync/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	// create config provider
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(ctx, cli, logger.With("service", "storage"), cfg.RuntimeConfigurationConfigMapName),
+		kebConfig.NewConfigMapReader(ctx, cli, logger.With("component", "config-map-reader"), cfg.RuntimeConfigurationConfigMapName),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/config"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -25,9 +26,10 @@ func TestConfigProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	fakeK8sClient := fake.NewClientBuilder().WithRuntimeObjects(cfgMap).Build()
-	logger := logrus.New()
-	logger.SetFormatter(&logrus.JSONFormatter{})
-	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, logger, "keb-config")
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	cfgReader := config.NewConfigMapReader(ctx, fakeK8sClient, log, "keb-config")
 	cfgValidator := config.NewConfigMapKeysValidator()
 	cfgConverter := config.NewConfigMapConverter()
 	cfgProvider := config.NewConfigProvider(cfgReader, cfgValidator, cfgConverter)

--- a/internal/process/provisioning/create_resource_names_step_test.go
+++ b/internal/process/provisioning/create_resource_names_step_test.go
@@ -3,6 +3,8 @@ package provisioning
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/common/gardener"
@@ -159,8 +161,11 @@ func fixProvisioningParametersWithPlanID(planID, region string, platformRegion s
 
 func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	cli := fake.NewClientBuilder().WithRuntimeObjects(fixConfigMap(kymaVersion)).Build()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	configProvider := kebConfig.NewConfigProvider(
-		kebConfig.NewConfigMapReader(context.TODO(), cli, logrus.New(), "keb-config"),
+		kebConfig.NewConfigMapReader(context.TODO(), cli, log, "keb-config"),
 		kebConfig.NewConfigMapKeysValidator(),
 		kebConfig.NewConfigMapConverter())
 	ibf, err := input.NewInputBuilderFactory(configProvider, input.Config{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in Subaccount Sync Job,
- change `ConfigMapReader` logger to `slog`.

**Related issue(s)**
See also #1469
