### PR TITLE
Use slog in handlers

### DIFF
--- a/cmd/broker/bindings_envtest_test.go
+++ b/cmd/broker/bindings_envtest_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -75,6 +77,10 @@ func TestCreateBindingEndpoint(t *testing.T) {
 
 	// Given
 	//// logger
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
 	logs := logrus.New()
 	logs.SetLevel(logrus.DebugLevel)
 	logs.SetFormatter(&logrus.JSONFormatter{
@@ -200,7 +206,7 @@ func TestCreateBindingEndpoint(t *testing.T) {
 		MaxBindingsCount:     maxBindingsCount,
 	}
 
-	publisher := event.NewPubSub(logs)
+	publisher := event.NewPubSub(log)
 
 	//// api handler
 	bindEndpoint := broker.NewBind(*bindingCfg, db, logs, skrK8sClientProvider, skrK8sClientProvider, publisher)

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -174,7 +174,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	additionalKymaVersions = append(additionalKymaVersions, version...)
 	cli := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(fixK8sResources(defaultKymaVer, additionalKymaVersions)...).Build()
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: slog.LevelDebug,
 	}))
 
 	configProvider := kebConfig.NewConfigProvider(
@@ -203,7 +203,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	gardenerClient := gardener.NewDynamicFakeClient()
 
 	provisionerClient := provisioner.NewFakeClientWithGardener(gardenerClient, "kcp-system")
-	eventBroker := event.NewPubSub(logs)
+	eventBroker := event.NewPubSub(log)
 
 	edpClient := edp.NewFakeClient()
 	accountProvider := fixAccountProvider()

--- a/cmd/broker/deprovisioning_suite_test.go
+++ b/cmd/broker/deprovisioning_suite_test.go
@@ -88,7 +88,7 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 			assert.NoError(t, err)
 		}
 	})
-	eventBroker := event.NewPubSub(logs)
+	eventBroker := event.NewPubSub(log)
 	provisionerClient := provisioner.NewFakeClient()
 
 	edpClient := fixEDPClient(t)

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -154,7 +154,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 	const gardenerProject = "testing"
 	gardenerNamespace := fmt.Sprintf("garden-%s", gardenerProject)
 
-	eventBroker := event.NewPubSub(logs)
+	eventBroker := event.NewPubSub(log)
 
 	runtimeLister := kebOrchestration.NewRuntimeLister(db.Instances(), db.Operations(), kebRuntime.NewConverter(defaultRegion), logs)
 	runtimeResolver := orchestration.NewGardenerRuntimeResolver(gardenerClient, gardenerNamespace, runtimeLister, logs)
@@ -589,7 +589,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 
 	accountProvider := fixAccountProvider()
 
-	eventBroker := event.NewPubSub(logs)
+	eventBroker := event.NewPubSub(log)
 
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, logs.WithField("provisioning", "manager"))
 	provisioningQueue := NewProvisioningProcessingQueue(ctx, provisionManager, workersAmount, cfg, db, provisionerClient, inputFactory, edpClient, accountProvider,

--- a/internal/broker/bind_create_test.go
+++ b/internal/broker/bind_create_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -43,6 +45,10 @@ func TestCreateBindingEndpoint(t *testing.T) {
 
 	// Given
 	//// logger
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
 	logs := logrus.New()
 	logs.SetLevel(logrus.DebugLevel)
 	logs.SetFormatter(&logrus.JSONFormatter{
@@ -74,7 +80,7 @@ func TestCreateBindingEndpoint(t *testing.T) {
 	}
 
 	// event publisher
-	publisher := event.NewPubSub(logrus.New())
+	publisher := event.NewPubSub(log)
 
 	//// api handler
 	bindEndpoint := NewBind(*bindingCfg, db, logs, &provider{}, &provider{}, publisher)
@@ -182,7 +188,11 @@ func TestCreateSecondBindingWithTheSameIdButDifferentParams(t *testing.T) {
 	err = brokerStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	publisher := event.NewPubSub(logrus.New())
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	publisher := event.NewPubSub(log)
 
 	svc := NewBind(*bindingCfg, brokerStorage, logrus.New(), nil, nil, publisher)
 	params := BindingParams{
@@ -229,7 +239,11 @@ func TestCreateSecondBindingWithTheSameIdAndParams(t *testing.T) {
 	err = brokerStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	publisher := event.NewPubSub(logrus.New())
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	publisher := event.NewPubSub(log)
 
 	svc := NewBind(*bindingCfg, brokerStorage, logrus.New(), nil, nil, publisher)
 	params := BindingParams{
@@ -276,8 +290,12 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForExpired(t *testing.T) {
 	err = brokerStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	// event publisher
-	publisher := event.NewPubSub(logrus.New())
+	publisher := event.NewPubSub(log)
 
 	svc := NewBind(*bindingCfg, brokerStorage, logrus.New(), nil, nil, publisher)
 	params := BindingParams{
@@ -326,8 +344,12 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForBindingInProgress(t *testin
 	err = brokerStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	// event publisher
-	publisher := event.NewPubSub(logrus.New())
+	publisher := event.NewPubSub(log)
 
 	svc := NewBind(*bindingCfg, brokerStorage, logrus.New(), nil, nil, publisher)
 	params := BindingParams{
@@ -374,7 +396,11 @@ func TestCreateSecondBindingWithTheSameIdAndParamsNotExplicitlyDefined(t *testin
 	err = brokerStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
 
-	publisher := event.NewPubSub(logrus.New())
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	publisher := event.NewPubSub(log)
 
 	svc := NewBind(*bindingCfg, brokerStorage, logrus.New(), nil, nil, publisher)
 

--- a/internal/event/pubsub.go
+++ b/internal/event/pubsub.go
@@ -2,10 +2,10 @@ package event
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"reflect"
 	"sync"
-
-	"github.com/sirupsen/logrus"
 )
 
 type Handler = func(ctx context.Context, ev interface{}) error
@@ -21,12 +21,12 @@ type Subscriber interface {
 // PubSub implements a simple event broker which allows to send event across the application.
 type PubSub struct {
 	mu  sync.Mutex
-	log logrus.FieldLogger
+	log *slog.Logger
 
 	handlers map[reflect.Type][]Handler
 }
 
-func NewPubSub(log logrus.FieldLogger) *PubSub {
+func NewPubSub(log *slog.Logger) *PubSub {
 	return &PubSub{
 		log:      log,
 		handlers: make(map[reflect.Type][]Handler),
@@ -41,7 +41,7 @@ func (b *PubSub) Publish(ctx context.Context, ev interface{}) {
 			go func(h Handler) {
 				err := h(ctx, ev)
 				if err != nil {
-					b.log.Errorf("error while calling pubsub event handler: %s", err.Error())
+					b.log.Error(fmt.Sprintf("error while calling pubsub event handler: %s", err.Error()))
 				}
 			}(handler)
 		}

--- a/internal/event/pubsub_test.go
+++ b/internal/event/pubsub_test.go
@@ -3,15 +3,16 @@ package event_test
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/event"
-	"github.com/sirupsen/logrus"
-	logrusTest "github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/event"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -39,7 +40,10 @@ func TestPubSub(t *testing.T) {
 		gotEventBList = append(gotEventBList, ev.(eventB))
 		return nil
 	}
-	svc := event.NewPubSub(logrus.New())
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	svc := event.NewPubSub(log)
 	svc.Subscribe(eventA{}, handlerA1)
 	svc.Subscribe(eventB{}, handlerB)
 	svc.Subscribe(eventA{}, handlerA2)
@@ -63,14 +67,16 @@ func TestPubSub(t *testing.T) {
 
 func TestPubSub_WhenHandlerReturnsError(t *testing.T) {
 	// given
-	logger, hook := logrusTest.NewNullLogger()
+	cw := &captureWriter{entries: []string{}}
+	handler := slog.NewTextHandler(cw, nil)
+	log := slog.New(handler)
 	var mu sync.Mutex
 	handlerA1 := func(ctx context.Context, ev interface{}) error {
 		mu.Lock()
 		defer mu.Unlock()
 		return fmt.Errorf("some error")
 	}
-	svc := event.NewPubSub(logger)
+	svc := event.NewPubSub(log)
 	svc.Subscribe(eventA{}, handlerA1)
 
 	// when
@@ -79,8 +85,8 @@ func TestPubSub_WhenHandlerReturnsError(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	// then
-	require.Equal(t, 1, len(hook.Entries))
-	require.Equal(t, hook.LastEntry().Message, "error while calling pubsub event handler: some error")
+	require.Equal(t, 1, len(cw.entries))
+	require.Contains(t, cw.entries[0], "error while calling pubsub event handler: some error")
 }
 
 func containsA(slice []eventA, item eventA) bool {
@@ -107,4 +113,14 @@ type eventA struct {
 
 type eventB struct {
 	msg string
+}
+
+type captureWriter struct {
+	entries []string
+}
+
+func (c *captureWriter) Write(p []byte) (n int, err error) {
+	entry := string(p)
+	c.entries = append(c.entries, entry)
+	return len(p), nil
 }

--- a/internal/health/server.go
+++ b/internal/health/server.go
@@ -2,21 +2,21 @@ package health
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/gorilla/mux"
-	log "github.com/sirupsen/logrus"
 )
 
 type Server struct {
 	Address string
-	Log     log.FieldLogger
+	Log     *slog.Logger
 }
 
-func NewServer(host, port string, log *log.Logger) *Server {
+func NewServer(host, port string, log *slog.Logger) *Server {
 	return &Server{
 		Address: fmt.Sprintf("%s:%s", host, port),
-		Log:     log.WithField("server", "health"),
+		Log:     log.With("server", "health"),
 	}
 }
 
@@ -26,7 +26,7 @@ func (srv *Server) ServeAsync() {
 	go func() {
 		err := http.ListenAndServe(srv.Address, healthRouter)
 		if err != nil {
-			srv.Log.Errorf("HTTP Health server ListenAndServe: %v", err)
+			srv.Log.Error(fmt.Sprintf("HTTP Health server ListenAndServe: %v", err))
 		}
 	}()
 }

--- a/internal/kubeconfig/handler_test.go
+++ b/internal/kubeconfig/handler_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +15,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/kubeconfig/automock"
-	"github.com/kyma-project/kyma-environment-broker/internal/logger"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 
 	"github.com/gorilla/mux"
@@ -120,9 +121,13 @@ func TestHandler_GetKubeconfig(t *testing.T) {
 				builder.On("Build", &instance).Return("", fmt.Errorf("builder error"))
 			}
 
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
+
 			router := mux.NewRouter()
 
-			handler := NewHandler(db, builder, "", ownClusterPlanID, logger.NewLogDummy())
+			handler := NewHandler(db, builder, "", ownClusterPlanID, log)
 			handler.AttachRoutes(router)
 
 			server := httptest.NewServer(router)
@@ -193,9 +198,13 @@ func TestHandler_GetKubeconfigForOwnCluster(t *testing.T) {
 	builder := &automock.KcBuilder{}
 	defer builder.AssertExpectations(t)
 
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	router := mux.NewRouter()
 
-	handler := NewHandler(db, builder, "", ownClusterPlanID, logger.NewLogDummy())
+	handler := NewHandler(db, builder, "", ownClusterPlanID, log)
 	handler.AttachRoutes(router)
 
 	server := httptest.NewServer(router)

--- a/internal/metricsv2/operations_result_test.go
+++ b/internal/metricsv2/operations_result_test.go
@@ -2,6 +2,8 @@ package metricsv2
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -46,7 +48,11 @@ func TestOperationsResult(t *testing.T) {
 			}, logrus.New(),
 		)
 
-		eventBroker := event.NewPubSub(logrus.New())
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
+		eventBroker := event.NewPubSub(log)
 		eventBroker.Subscribe(process.OperationFinished{}, operationResult.Handler)
 
 		time.Sleep(20 * time.Millisecond)

--- a/internal/process/upgrade_cluster/manager_test.go
+++ b/internal/process/upgrade_cluster/manager_test.go
@@ -2,6 +2,8 @@ package upgrade_cluster
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -63,6 +65,9 @@ func TestManager_Execute(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			// given
+			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
 			log := logrus.New()
 			memoryStorage := storage.NewMemoryStorage()
 			operations := memoryStorage.Operations()
@@ -75,7 +80,7 @@ func TestManager_Execute(t *testing.T) {
 			s3 := testStep{t: t, name: "to be skipped", storage: operations}
 			sFinal := testStep{t: t, name: "final", storage: operations}
 
-			eventBroker := event.NewPubSub(logrus.New())
+			eventBroker := event.NewPubSub(logger)
 			eventCollector := &collectingEventHandler{}
 			eventBroker.Subscribe(process.UpgradeClusterStepProcessed{}, eventCollector.OnEvent)
 

--- a/internal/provisioner/client.go
+++ b/internal/provisioner/client.go
@@ -3,13 +3,12 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"reflect"
 
+	schema "github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/httputil"
-	"github.com/sirupsen/logrus"
-
-	schema "github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	gcli "github.com/kyma-project/kyma-environment-broker/internal/third_party/machinebox/graphql"
 )
 
@@ -37,11 +36,11 @@ type client struct {
 	graphqlizer   Graphqlizer
 }
 
-func NewProvisionerClient(endpoint string, queryDumping bool, log logrus.FieldLogger) Client {
+func NewProvisionerClient(endpoint string, queryDumping bool, log *slog.Logger) Client {
 	graphQlClient := gcli.NewClient(endpoint, gcli.WithHTTPClient(httputil.NewClient(120, false)))
 	if queryDumping {
 		graphQlClient.Log = func(s string) {
-			log.Infof("graphql message: %s", s)
+			log.Info(fmt.Sprintf("graphql message: %s", s))
 		}
 	}
 

--- a/internal/provisioner/client_test.go
+++ b/internal/provisioner/client_test.go
@@ -3,8 +3,10 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/99designs/gqlgen/handler"
@@ -12,7 +14,6 @@ import (
 	schema "github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,8 +43,11 @@ func TestClient_ProvisionRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 
 		// When
 		status, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
@@ -62,8 +66,11 @@ func TestClient_ProvisionRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 
 		// When
 		status, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInputWithoutDnsConfig())
@@ -82,8 +89,11 @@ func TestClient_ProvisionRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}, failed: true}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 
 		// When
 		status, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
@@ -102,8 +112,11 @@ func TestClient_DeprovisionRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -122,8 +135,11 @@ func TestClient_DeprovisionRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -146,8 +162,11 @@ func TestClient_UpgradeRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -167,8 +186,11 @@ func TestClient_UpgradeRuntime(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -191,8 +213,11 @@ func TestClient_UpgradeShoot(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -212,8 +237,11 @@ func TestClient_UpgradeShoot(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -236,8 +264,11 @@ func TestClient_ReconnectRuntimeAgent(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -254,8 +285,11 @@ func TestClient_ReconnectRuntimeAgent(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		operation, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -290,8 +324,11 @@ func TestClient_ReconnectRuntimeAgent(t *testing.T) {
 			  }
 			}`)
 		defer server.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(server.URL, false, logrus.New())
+		client := NewProvisionerClient(server.URL, false, log)
 
 		// when
 		_, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
@@ -325,8 +362,11 @@ func TestClient_ReconnectRuntimeAgent(t *testing.T) {
 			  }
 			}`)
 		defer server.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(server.URL, false, logrus.New())
+		client := NewProvisionerClient(server.URL, false, log)
 
 		// when
 		_, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
@@ -341,7 +381,10 @@ func TestClient_ReconnectRuntimeAgent(t *testing.T) {
 	})
 
 	t.Run("network error", func(t *testing.T) {
-		client := NewProvisionerClient("http://not-existing", false, logrus.New())
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+		client := NewProvisionerClient("http://not-existing", false, log)
 
 		// when
 		_, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
@@ -358,8 +401,11 @@ func TestClient_RuntimeOperationStatus(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		_, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 
@@ -379,8 +425,11 @@ func TestClient_RuntimeOperationStatus(t *testing.T) {
 		tr := &testResolver{t: t, runtime: &testRuntime{}}
 		testServer := fixHTTPServer(tr)
 		defer testServer.Close()
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
 
-		client := NewProvisionerClient(testServer.URL, false, logrus.New())
+		client := NewProvisionerClient(testServer.URL, false, log)
 		_, err := client.ProvisionRuntime(testAccountID, testSubAccountID, fixProvisionRuntimeInput())
 		assert.NoError(t, err)
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` in health, kubeconfig, event handlers and provisioning client.

**Related issue(s)**
See also #1469
