### PR TITLE
Use slog in metrics

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -145,8 +145,11 @@ func NewBrokerSuitTestWithMetrics(t *testing.T, cfg *Config, version ...string) 
 			panic(r)
 		}
 	}()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	broker := NewBrokerSuiteTestWithConfig(t, cfg, version...)
-	broker.metrics = metricsv2.Register(context.Background(), broker.eventBroker, broker.db, cfg.MetricsV2, logrus.New())
+	broker.metrics = metricsv2.Register(context.Background(), broker.eventBroker, broker.db, cfg.MetricsV2, log)
 	broker.router.Handle("/metrics", promhttp.Handler())
 	return broker
 }

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -321,7 +321,7 @@ func main() {
 	eventBroker := event.NewPubSub(log)
 
 	// metrics collectors
-	_ = metricsv2.Register(ctx, eventBroker, db, cfg.MetricsV2, logs)
+	_ = metricsv2.Register(ctx, eventBroker, db, cfg.MetricsV2, log)
 
 	// run queues
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, logs.WithField("provisioning", "manager"))

--- a/internal/metricsv2/metrics.go
+++ b/internal/metricsv2/metrics.go
@@ -3,6 +3,7 @@ package metricsv2
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -49,9 +49,9 @@ type RegisterContainer struct {
 	InstancesCollector         *InstancesCollector
 }
 
-func Register(ctx context.Context, sub event.Subscriber, db storage.BrokerStorage, cfg Config, logger logrus.FieldLogger) *RegisterContainer {
-	logger = logger.WithField("from:", logPrefix)
-	logrus.Infof("Registering metricsv2")
+func Register(ctx context.Context, sub event.Subscriber, db storage.BrokerStorage, cfg Config, logger *slog.Logger) *RegisterContainer {
+	logger = logger.With("from:", logPrefix)
+	logger.Info("Registering metricsv2")
 	opDurationCollector := NewOperationDurationCollector(logger)
 	prometheus.MustRegister(opDurationCollector)
 
@@ -83,7 +83,7 @@ func Register(ctx context.Context, sub event.Subscriber, db storage.BrokerStorag
 	sub.Subscribe(broker.UnbindRequestProcessed{}, bindDurationCollector.OnUnbindingExecuted)
 	sub.Subscribe(broker.BindingCreated{}, bindCrestedCollector.OnBindingCreated)
 
-	logger.Infof(fmt.Sprintf("%s -> enabled", logPrefix))
+	logger.Info(fmt.Sprintf("%s -> enabled", logPrefix))
 
 	return &RegisterContainer{
 		OperationResult:            opResult,

--- a/internal/metricsv2/operation_duration.go
+++ b/internal/metricsv2/operation_duration.go
@@ -3,11 +3,10 @@ package metricsv2
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
-	"github.com/sirupsen/logrus"
-
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -22,10 +21,10 @@ import (
 type OperationDurationCollector struct {
 	provisioningHistogram   *prometheus.HistogramVec
 	deprovisioningHistogram *prometheus.HistogramVec
-	logger                  logrus.FieldLogger
+	logger                  *slog.Logger
 }
 
-func NewOperationDurationCollector(logger logrus.FieldLogger) *OperationDurationCollector {
+func NewOperationDurationCollector(logger *slog.Logger) *OperationDurationCollector {
 	return &OperationDurationCollector{
 		provisioningHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: prometheusNamespacev2,

--- a/internal/metricsv2/operations_result_test.go
+++ b/internal/metricsv2/operations_result_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,16 +40,16 @@ func TestOperationsResult(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))
+
 		operationResult := NewOperationResult(
 			context.Background(), operations, Config{
 				Enabled: true, OperationResultPollingInterval: 10 * time.Millisecond,
 				OperationStatsPollingInterval: 10 * time.Millisecond, OperationResultRetentionPeriod: 24 * time.Hour,
-			}, logrus.New(),
+			}, log,
 		)
-
-		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		}))
 
 		eventBroker := event.NewPubSub(log)
 		eventBroker.Subscribe(process.OperationFinished{}, operationResult.Handler)

--- a/internal/metricsv2/operations_stats_test.go
+++ b/internal/metricsv2/operations_stats_test.go
@@ -2,6 +2,8 @@ package metricsv2
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -12,7 +14,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,7 +78,10 @@ func TestOperationsStats(t *testing.T) {
 	}
 
 	t.Run("create counter key", func(t *testing.T) {
-		ctr = NewOperationsStats(operations, cfg, log.WithField("metrics", "test"))
+		log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		})).With("metrics", "test")
+		ctr = NewOperationsStats(operations, cfg, log)
 		ctr.MustRegister(context.Background())
 	})
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in metrics.

**Related issue(s)**
See also #1469
