### PR TITLE
Apply kyma step does not set compass runtime id in the Kyma resource

### DIFF
--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -234,7 +234,6 @@ func TestProvisioning_HappyPathAWS(t *testing.T) {
 	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	suite.AssertKymaResourceExists(opID)
-	suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
 	suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-central-1", "kyma-project.io/provider": "AWS"})
 	suite.AssertKymaLabelNotExists(opID, "kyma-project.io/platform-region")
 }
@@ -334,7 +333,6 @@ func TestProvisioning_HappyPathSapConvergedCloud(t *testing.T) {
 		suite.WaitForOperationState(opID, domain.Succeeded)
 
 		suite.AssertKymaResourceExists(opID)
-		suite.AssertKymaAnnotationExists(opID, "compass-runtime-id-for-migration")
 		suite.AssertKymaLabelsExist(opID, map[string]string{"kyma-project.io/region": "eu-de-1", "kyma-project.io/provider": "SapConvergedCloud"})
 	})
 

--- a/internal/model.go
+++ b/internal/model.go
@@ -13,7 +13,6 @@ import (
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/events"
-	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	log "github.com/sirupsen/logrus"
 )
@@ -241,31 +240,8 @@ type InstanceDetails struct {
 
 	CloudProvider string `json:"cloud_provider"`
 
-	// CompassRuntimeId - a runtime ID created by the Compass. Existing instances has a nil value (because the field was not existing) - it means the compass runtime Id is equal to runtime ID.
-	// If the value is an empty string - it means the runtime was not registered by Provisioner in the Compass.
-	// Should be removed after the migration of compass registration is completed
-	CompassRuntimeId *string
-
 	// Used during KIM integration while deprovisioning - to be removed later on when provisioner not used anymore
 	KimDeprovisionsOnly *bool `json:"kim_deprovisions_only"`
-}
-
-// IsRegisteredInCompassByProvisioner returns true, if the runtime was registered in Compass by Provisioner
-func (i *InstanceDetails) IsRegisteredInCompassByProvisioner() bool {
-	return i.CompassRuntimeId == nil || *i.CompassRuntimeId != ""
-}
-
-func (i *InstanceDetails) SetCompassRuntimeIdNotRegisteredByProvisioner() {
-	i.CompassRuntimeId = ptr.String("")
-}
-
-// GetCompassRuntimeId provides a compass runtime Id registered by Provisioner or empty string if it was not provisioned by Provisioner.
-func (i *InstanceDetails) GetCompassRuntimeId() string {
-	// for backward compatibility, if CompassRuntimeID field was not set, use RuntimeId
-	if i.CompassRuntimeId == nil {
-		return i.RuntimeID
-	}
-	return *i.CompassRuntimeId
 }
 
 func (i *InstanceDetails) GetRuntimeResourceName() string {

--- a/internal/process/provisioning/apply_kyma_step.go
+++ b/internal/process/provisioning/apply_kyma_step.go
@@ -91,16 +91,6 @@ func (a *ApplyKymaStep) addLabelsAndName(operation internal.Operation, obj *unst
 	oldLabels := obj.GetLabels()
 	steps.ApplyLabelsAndAnnotationsForLM(obj, operation)
 
-	// this if-block is a temporary solution, should be removed after the migration of compass registration is completed
-	if operation.IsRegisteredInCompassByProvisioner() {
-		annotations := obj.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		annotations["compass-runtime-id-for-migration"] = operation.GetCompassRuntimeId()
-		obj.SetAnnotations(annotations)
-	}
-
 	// Kyma resource name must be created once again
 	obj.SetName(steps.CreateKymaNameFromOperation(operation))
 	return !reflect.DeepEqual(obj.GetLabels(), oldLabels)

--- a/internal/process/provisioning/apply_kyma_step_test.go
+++ b/internal/process/provisioning/apply_kyma_step_test.go
@@ -121,49 +121,9 @@ func TestCreatingKymaResourceWithCloudProviderInOperation(t *testing.T) {
 }
 
 func TestCreatingInternalKymaResource(t *testing.T) {
-	t.Run("With compass runtime ID", func(t *testing.T) {
-		// given
-		operation, cli := fixOperationForApplyKymaResource(t)
-		storage := storage.NewMemoryStorage()
-		err := storage.Operations().InsertOperation(operation)
-		require.NoError(t, err)
-		svc := NewApplyKymaStep(storage.Operations(), cli)
-
-		// when
-		_, backoff, err := svc.Run(operation, logrus.New())
-
-		// then
-		require.NoError(t, err)
-		require.Zero(t, backoff)
-		aList := unstructured.UnstructuredList{}
-		aList.SetGroupVersionKind(schema.GroupVersionKind{Group: "operator.kyma-project.io", Version: "v1beta2", Kind: "KymaList"})
-
-		err = cli.List(context.Background(), &aList)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(aList.Items))
-		expectedLabels := map[string]string{
-			"kyma-project.io/instance-id":         "inst-id",
-			"kyma-project.io/runtime-id":          "runtime-inst-id",
-			"kyma-project.io/global-account-id":   "e8f7ec0a-0cd6-41f0-905d-5d1efa9fb6c4",
-			"kyma-project.io/subaccount-id":       "SA-op-id",
-			"kyma-project.io/shoot-name":          "Shoot-inst-id",
-			"kyma-project.io/platform-region":     "westeurope",
-			"operator.kyma-project.io/kyma-name":  "runtime-inst-id",
-			"kyma-project.io/broker-plan-id":      "4deee563-e5ec-4731-b9b1-53b42d855f0c",
-			"kyma-project.io/broker-plan-name":    "azure",
-			"operator.kyma-project.io/managed-by": "lifecycle-manager",
-			"kyma-project.io/provider":            "Test"}
-		assertLabelsExistsForInternalKymaResource(t, expectedLabels, aList.Items[0])
-
-		assertCompassRuntimeIdAnnotationExists(t, aList.Items[0])
-		_, _, err = svc.Run(operation, logrus.New())
-		require.NoError(t, err)
-	})
-
 	t.Run("Without compass runtime ID", func(t *testing.T) {
 		// given
 		operation, cli := fixOperationForApplyKymaResource(t)
-		operation.SetCompassRuntimeIdNotRegisteredByProvisioner()
 		storage := storage.NewMemoryStorage()
 		err := storage.Operations().InsertOperation(operation)
 		require.NoError(t, err)

--- a/internal/process/provisioning/apply_kyma_step_test.go
+++ b/internal/process/provisioning/apply_kyma_step_test.go
@@ -154,8 +154,6 @@ func TestCreatingInternalKymaResource(t *testing.T) {
 			"operator.kyma-project.io/managed-by": "lifecycle-manager",
 			"kyma-project.io/provider":            "Test"}
 		assertLabelsExistsForInternalKymaResource(t, expectedLabels, aList.Items[0])
-
-		assertCompassRuntimeIdAnnotationNotExists(t, aList.Items[0])
 		_, _, err = svc.Run(operation, logrus.New())
 		require.NoError(t, err)
 	})

--- a/internal/process/provisioning/apply_kyma_step_test.go
+++ b/internal/process/provisioning/apply_kyma_step_test.go
@@ -353,16 +353,6 @@ func assertLabelsExistsForInternalKymaResource(t *testing.T, expectedLabels map[
 	assertLabelsExists(t, expectedLabels, obj)
 }
 
-func assertCompassRuntimeIdAnnotationExists(t *testing.T, obj unstructured.Unstructured) {
-	t.Helper()
-	assert.Contains(t, obj.GetAnnotations(), "compass-runtime-id-for-migration")
-}
-
-func assertCompassRuntimeIdAnnotationNotExists(t *testing.T, obj unstructured.Unstructured) {
-	t.Helper()
-	assert.NotContains(t, obj.GetAnnotations(), "compass-runtime-id-for-migration")
-}
-
 func assertLabelsExistsForExternalKymaResource(t *testing.T, expectedLabels map[string]string, obj unstructured.Unstructured) {
 	assert.NotContains(t, obj.GetLabels(), "operator.kyma-project.io/internal")
 	assertLabelsExists(t, expectedLabels, obj)

--- a/internal/process/provisioning/create_runtime_without_kyma_step.go
+++ b/internal/process/provisioning/create_runtime_without_kyma_step.go
@@ -94,11 +94,6 @@ func (s *CreateRuntimeWithoutKymaStep) Run(operation internal.Operation, log log
 			operation.RuntimeID = *provisionerResponse.RuntimeID
 			operation.Region = requestInput.ClusterConfig.GardenerConfig.Region
 		}
-		if provisionerResponse.CompassRuntimeID != nil && len(*provisionerResponse.CompassRuntimeID) > 0 {
-			operation.CompassRuntimeId = provisionerResponse.CompassRuntimeID
-		} else {
-			operation.SetCompassRuntimeIdNotRegisteredByProvisioner()
-		}
 	}, log)
 	if repeat != 0 {
 		log.Errorf("cannot save neither runtime ID nor region from provisioner")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- KEB should not add compass-runtime-id on Kyma resource because Provisioner is no longer responsible for getting compass runtime ID

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
