### PR TITLE
Use slog in orchestration

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -254,8 +254,8 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	notificationFakeClient := notification.NewFakeClient()
 	notificationBundleBuilder := notification.NewBundleBuilder(notificationFakeClient, cfg.Notification)
 
-	runtimeLister := kebOrchestration.NewRuntimeLister(db.Instances(), db.Operations(), kebRuntime.NewConverter(defaultRegion), logs)
-	runtimeResolver := orchestration.NewGardenerRuntimeResolver(gardenerClient, fixedGardenerNamespace, runtimeLister, logs)
+	runtimeLister := kebOrchestration.NewRuntimeLister(db.Instances(), db.Operations(), kebRuntime.NewConverter(defaultRegion), log)
+	runtimeResolver := orchestration.NewGardenerRuntimeResolver(gardenerClient, fixedGardenerNamespace, runtimeLister, log)
 
 	clusterQueue := NewClusterOrchestrationProcessingQueue(ctx, db, provisionerClient, eventBroker, inputFactory, &upgrade_cluster.TimeSchedule{
 		Retry:                 10 * time.Millisecond,
@@ -266,7 +266,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	clusterQueue.SpeedUp(1000)
 
 	// TODO: in case of cluster upgrade the same Azure Zones must be send to the Provisioner
-	orchestrationHandler := orchestrate.NewOrchestrationHandler(db, clusterQueue, cfg.MaxPaginationPage, logs)
+	orchestrationHandler := orchestrate.NewOrchestrationHandler(db, clusterQueue, cfg.MaxPaginationPage, log)
 	orchestrationHandler.AttachRoutes(ts.router)
 
 	expirationHandler := expiration.NewHandler(db.Instances(), db.Operations(), deprovisioningQueue, log)

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -354,14 +354,14 @@ func main() {
 	kcHandler := kubeconfig.NewHandler(db, kcBuilder, cfg.Kubeconfig.AllowOrigins, broker.OwnClusterPlanID, log.With("service", "kubeconfigHandle"))
 	kcHandler.AttachRoutes(router)
 
-	runtimeLister := orchestration.NewRuntimeLister(db.Instances(), db.Operations(), runtime.NewConverter(cfg.DefaultRequestRegion), logs)
-	runtimeResolver := orchestrationExt.NewGardenerRuntimeResolver(dynamicGardener, gardenerNamespace, runtimeLister, logs)
+	runtimeLister := orchestration.NewRuntimeLister(db.Instances(), db.Operations(), runtime.NewConverter(cfg.DefaultRequestRegion), log)
+	runtimeResolver := orchestrationExt.NewGardenerRuntimeResolver(dynamicGardener, gardenerNamespace, runtimeLister, log)
 
 	clusterQueue := NewClusterOrchestrationProcessingQueue(ctx, db, provisionerClient, eventBroker, inputFactory,
 		nil, time.Minute, runtimeResolver, notificationBuilder, logs, kcpK8sClient, cfg, 1)
 
 	// TODO: in case of cluster upgrade the same Azure Zones must be send to the Provisioner
-	orchestrationHandler := orchestrate.NewOrchestrationHandler(db, clusterQueue, cfg.MaxPaginationPage, logs)
+	orchestrationHandler := orchestrate.NewOrchestrationHandler(db, clusterQueue, cfg.MaxPaginationPage, log)
 
 	if !cfg.DisableProcessOperationsInProgress {
 		err = processOperationsInProgressByType(internal.OperationTypeProvision, db.Operations(), provisionQueue, logs)

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -156,8 +156,8 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 
 	eventBroker := event.NewPubSub(log)
 
-	runtimeLister := kebOrchestration.NewRuntimeLister(db.Instances(), db.Operations(), kebRuntime.NewConverter(defaultRegion), logs)
-	runtimeResolver := orchestration.NewGardenerRuntimeResolver(gardenerClient, gardenerNamespace, runtimeLister, logs)
+	runtimeLister := kebOrchestration.NewRuntimeLister(db.Instances(), db.Operations(), kebRuntime.NewConverter(defaultRegion), log)
+	runtimeResolver := orchestration.NewGardenerRuntimeResolver(gardenerClient, gardenerNamespace, runtimeLister, log)
 
 	notificationFakeClient := notification.NewFakeClient()
 	notificationBundleBuilder := notification.NewBundleBuilder(notificationFakeClient, cfg.Notification)

--- a/common/orchestration/resolver_test.go
+++ b/common/orchestration/resolver_test.go
@@ -2,11 +2,11 @@ package orchestration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
@@ -409,12 +409,10 @@ func newRuntimeListerMock() *RuntimeListerMock {
 	return lister
 }
 
-func newLogDummy() *logrus.Entry {
-	rawLgr := logrus.New()
-	rawLgr.Out = ioutil.Discard
-	lgr := rawLgr.WithField("testing", true)
-
-	return lgr
+func newLogDummy() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})).With("testing", true)
 }
 
 func lookupRuntime(runtimeID string, runtimes []Runtime) *Runtime {

--- a/internal/orchestration/handlers/cancel.go
+++ b/internal/orchestration/handlers/cancel.go
@@ -2,19 +2,19 @@ package handlers
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	orchestrationExt "github.com/kyma-project/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 )
 
 type Canceler struct {
 	orchestrations storage.Orchestrations
-	log            logrus.FieldLogger
+	log            *slog.Logger
 }
 
-func NewCanceler(orchestrations storage.Orchestrations, logger logrus.FieldLogger) *Canceler {
+func NewCanceler(orchestrations storage.Orchestrations, logger *slog.Logger) *Canceler {
 	return &Canceler{
 		orchestrations: orchestrations,
 		log:            logger,

--- a/internal/orchestration/handlers/cancel_test.go
+++ b/internal/orchestration/handlers/cancel_test.go
@@ -1,13 +1,14 @@
 package handlers
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,12 +18,15 @@ const (
 )
 
 func TestCanceler_CancelForID(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	t.Run("should cancel orchestration", func(t *testing.T) {
 		s := storage.NewMemoryStorage()
 		err := s.Orchestrations().Insert(fixOrchestration())
 		require.NoError(t, err)
 
-		c := NewCanceler(s.Orchestrations(), logrus.New())
+		c := NewCanceler(s.Orchestrations(), log)
 
 		err = c.CancelForID(fixOrchestrationID)
 		require.NoError(t, err)
@@ -39,7 +43,7 @@ func TestCanceler_CancelForID(t *testing.T) {
 		err := s.Orchestrations().Insert(o)
 		require.NoError(t, err)
 
-		c := NewCanceler(s.Orchestrations(), logrus.New())
+		c := NewCanceler(s.Orchestrations(), log)
 
 		err = c.CancelForID(fixOrchestrationID)
 		require.NoError(t, err)
@@ -56,7 +60,7 @@ func TestCanceler_CancelForID(t *testing.T) {
 		err := s.Orchestrations().Insert(o)
 		require.NoError(t, err)
 
-		c := NewCanceler(s.Orchestrations(), logrus.New())
+		c := NewCanceler(s.Orchestrations(), log)
 
 		err = c.CancelForID(fixOrchestrationID)
 		require.NoError(t, err)
@@ -68,7 +72,7 @@ func TestCanceler_CancelForID(t *testing.T) {
 	})
 	t.Run("should return error when orchestration not found", func(t *testing.T) {
 		s := storage.NewMemoryStorage()
-		c := NewCanceler(s.Orchestrations(), logrus.New())
+		c := NewCanceler(s.Orchestrations(), log)
 
 		err := c.CancelForID(fixOrchestrationID)
 		assert.Error(t, err)

--- a/internal/orchestration/handlers/cluster_handler_test.go
+++ b/internal/orchestration/handlers/cluster_handler_test.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -61,9 +63,12 @@ func TestClusterHandler_AttachRoutes(t *testing.T) {
 
 func fixClusterHandler(t *testing.T) *clusterHandler {
 	db := storage.NewMemoryStorage()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	logs := logrus.New()
 	q := process.NewQueue(&testExecutor{}, logs, "test-handler", 10*time.Second, 10*time.Second)
-	handler := NewClusterHandler(db.Orchestrations(), q, logs)
+	handler := NewClusterHandler(db.Orchestrations(), q, log)
 
 	return handler
 }

--- a/internal/orchestration/handlers/handlers.go
+++ b/internal/orchestration/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -9,7 +10,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type Handler interface {
@@ -20,7 +20,7 @@ type handler struct {
 	handlers []Handler
 }
 
-func NewOrchestrationHandler(db storage.BrokerStorage, clusterQueue *process.Queue, defaultMaxPage int, log logrus.FieldLogger) Handler {
+func NewOrchestrationHandler(db storage.BrokerStorage, clusterQueue *process.Queue, defaultMaxPage int, log *slog.Logger) Handler {
 	return &handler{
 		handlers: []Handler{
 			NewKymaHandler(),


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in orchestration.

**Related issue(s)**
See also #1469
