### PR TITLE
Use slog in queues

### DIFF
--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/hyperscaler"
@@ -12,7 +13,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -20,7 +20,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 	cfg *Config, db storage.BrokerStorage, pub event.Publisher,
 	provisionerClient provisioner.Client,
 	edpClient deprovisioning.EDPClient, accountProvider hyperscaler.AccountProvider,
-	k8sClientProvider K8sClientProvider, cli client.Client, configProvider input.ConfigurationProvider, logs logrus.FieldLogger) *process.Queue {
+	k8sClientProvider K8sClientProvider, cli client.Client, configProvider input.ConfigurationProvider, logs *slog.Logger) *process.Queue {
 
 	deprovisioningSteps := []struct {
 		disabled bool

--- a/cmd/broker/deprovisioning_suite_test.go
+++ b/cmd/broker/deprovisioning_suite_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -73,9 +72,6 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 		Level: slog.LevelInfo,
 	}))
 
-	logs := logrus.New()
-	logs.Formatter.(*logrus.TextFormatter).TimestampFormat = "15:04:05.000"
-
 	cfg := fixConfig()
 	cfg.EDP.Environment = edpEnvironment
 
@@ -116,7 +112,7 @@ func NewDeprovisioningSuite(t *testing.T) *DeprovisioningSuite {
 
 	deprovisioningQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, cfg, db, eventBroker,
 		provisionerClient,
-		edpClient, accountProvider, kubeconfig.NewFakeK8sClientProvider(fakeK8sSKRClient), fakeK8sSKRClient, configProvider, logs,
+		edpClient, accountProvider, kubeconfig.NewFakeK8sClientProvider(fakeK8sSKRClient), fakeK8sSKRClient, configProvider, log,
 	)
 
 	deprovisioningQueue.SpeedUp(10000)

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/provider"
 
@@ -13,14 +14,13 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *process.StagedManager, workersAmount int, cfg *Config,
 	db storage.BrokerStorage, provisionerClient provisioner.Client, inputFactory input.CreatorForPlan,
 	edpClient provisioning.EDPClient, accountProvider hyperscaler.AccountProvider,
-	k8sClientProvider provisioning.K8sClientProvider, cli client.Client, defaultOIDC pkg.OIDCConfigDTO, logs logrus.FieldLogger) *process.Queue {
+	k8sClientProvider provisioning.K8sClientProvider, cli client.Client, defaultOIDC pkg.OIDCConfigDTO, logs *slog.Logger) *process.Queue {
 
 	trialRegionsMapping, err := provider.ReadPlatformRegionMappingFromFile(cfg.TrialRegionMappingFilePath)
 	if err != nil {

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -41,7 +41,6 @@ import (
 	kebRuntime "github.com/kyma-project/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -107,9 +106,6 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 		Level: slog.LevelInfo,
 	}))
 
-	logs := logrus.New()
-	logs.Formatter.(*logrus.TextFormatter).TimestampFormat = "15:04:05.000"
-
 	var cfg Config
 	cfg.OrchestrationConfig = kebOrchestration.Config{
 		KubernetesVersion: "",
@@ -166,7 +162,7 @@ func NewOrchestrationSuite(t *testing.T, additionalKymaVersions []string) *Orche
 		Retry:                 2 * time.Millisecond,
 		StatusCheck:           20 * time.Millisecond,
 		UpgradeClusterTimeout: 4 * time.Second,
-	}, 250*time.Millisecond, runtimeResolver, notificationBundleBuilder, logs, cli, cfg, 1000)
+	}, 250*time.Millisecond, runtimeResolver, notificationBundleBuilder, log, cli, cfg, 1000)
 
 	clusterQueue.SpeedUp(1000)
 
@@ -546,7 +542,6 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
-	logs := logrus.New()
 	storageCleanup, db, err := GetStorageForE2ETests()
 	assert.NoError(t, err)
 	t.Cleanup(func() {
@@ -593,7 +588,7 @@ func NewProvisioningSuite(t *testing.T, multiZoneCluster bool, controlPlaneFailu
 
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, log.With("provisioning", "manager"))
 	provisioningQueue := NewProvisioningProcessingQueue(ctx, provisionManager, workersAmount, cfg, db, provisionerClient, inputFactory, edpClient, accountProvider,
-		kubeconfig.NewFakeK8sClientProvider(cli), cli, defaultOIDCValues(), logs)
+		kubeconfig.NewFakeK8sClientProvider(cli), cli, defaultOIDCValues(), log)
 
 	provisioningQueue.SpeedUp(10000)
 	provisionManager.SpeedUp(10000)

--- a/cmd/broker/update.go
+++ b/cmd/broker/update.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 
@@ -11,13 +12,12 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/process/update"
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManager, workersAmount int, db storage.BrokerStorage, inputFactory input.CreatorForPlan,
 	provisionerClient provisioner.Client, publisher event.Publisher,
-	cfg Config, k8sClientProvider K8sClientProvider, cli client.Client, logs logrus.FieldLogger) *process.Queue {
+	cfg Config, k8sClientProvider K8sClientProvider, cli client.Client, logs *slog.Logger) *process.Queue {
 
 	manager.DefineStages([]string{"cluster", "btp-operator", "btp-operator-check", "check", "runtime_resource", "check_runtime_resource"})
 	updateSteps := []struct {

--- a/common/orchestration/strategies/parallel_test.go
+++ b/common/orchestration/strategies/parallel_test.go
@@ -1,13 +1,14 @@
 package strategies
 
 import (
+	"log/slog"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/orchestration"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
@@ -38,7 +39,7 @@ func (t *testExecutor) Reschedule(operationID string, maintenanceWindowBegin, ma
 func TestNewParallelOrchestrationStrategy_Immediate(t *testing.T) {
 	// given
 	executor := &testExecutor{opCalled: map[string]bool{}}
-	s := NewParallelOrchestrationStrategy(executor, logrus.New(), 0)
+	s := NewParallelOrchestrationStrategy(executor, fixLogger(), 0)
 
 	ops := make([]orchestration.RuntimeOperation, 3)
 	for i := range ops {
@@ -58,7 +59,7 @@ func TestNewParallelOrchestrationStrategy_Immediate(t *testing.T) {
 func TestNewParallelOrchestrationStrategy_MaintenanceWindow(t *testing.T) {
 	// given
 	executor := &testExecutor{opCalled: map[string]bool{}}
-	s := NewParallelOrchestrationStrategy(executor, logrus.New(), 0)
+	s := NewParallelOrchestrationStrategy(executor, fixLogger(), 0)
 
 	start := time.Now().Add(3 * time.Second)
 
@@ -84,7 +85,7 @@ func TestNewParallelOrchestrationStrategy_MaintenanceWindow(t *testing.T) {
 func TestNewParallelOrchestrationStrategy_Reschedule(t *testing.T) {
 	// given
 	executor := &testExecutor{opCalled: map[string]bool{}}
-	s := NewParallelOrchestrationStrategy(executor, logrus.New(), 5*time.Second)
+	s := NewParallelOrchestrationStrategy(executor, fixLogger(), 5*time.Second)
 
 	start := time.Now().Add(-5 * time.Second)
 
@@ -105,4 +106,10 @@ func TestNewParallelOrchestrationStrategy_Reschedule(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	s.Wait(id)
+}
+
+func fixLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 }

--- a/internal/orchestration/handlers/cluster_handler_test.go
+++ b/internal/orchestration/handlers/cluster_handler_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,8 +65,7 @@ func fixClusterHandler(t *testing.T) *clusterHandler {
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
-	logs := logrus.New()
-	q := process.NewQueue(&testExecutor{}, logs, "test-handler", 10*time.Second, 10*time.Second)
+	q := process.NewQueue(&testExecutor{}, log, "test-handler", 10*time.Second, 10*time.Second)
 	handler := NewClusterHandler(db.Orchestrations(), q, log)
 
 	return handler

--- a/internal/orchestration/handlers/orchestration_handler_test.go
+++ b/internal/orchestration/handlers/orchestration_handler_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -251,8 +250,7 @@ func TestStatusRetryHandler_AttachRoutes(t *testing.T) {
 		err = db.Operations().InsertUpgradeClusterOperation(sameInstOp)
 		require.NoError(t, err)
 
-		logs := logrus.New()
-		clusterQueue := process.NewQueue(&testExecutor{}, logs, "orchestration-test", 10*time.Second, 10*time.Second)
+		clusterQueue := process.NewQueue(&testExecutor{}, log, "orchestration-test", 10*time.Second, 10*time.Second)
 		kymaHandler := NewOrchestrationStatusHandler(db.Operations(), db.Orchestrations(), db.RuntimeStates(), clusterQueue, 100, log)
 
 		for i, id := range operationIDs {
@@ -334,8 +332,7 @@ func TestStatusRetryHandler_AttachRoutes(t *testing.T) {
 		err = db.Operations().InsertUpgradeClusterOperation(sameInstOp)
 		require.NoError(t, err)
 
-		logs := logrus.New()
-		clusterQueue := process.NewQueue(&testExecutor{}, logs, "status-retry", 10*time.Second, 10*time.Second)
+		clusterQueue := process.NewQueue(&testExecutor{}, log, "status-retry", 10*time.Second, 10*time.Second)
 		kymaHandler := NewOrchestrationStatusHandler(db.Operations(), db.Orchestrations(), db.RuntimeStates(), clusterQueue, 100, log)
 
 		req, err := http.NewRequest("POST", fmt.Sprintf("/orchestrations/%s/retry", orchestrationID), nil)
@@ -417,8 +414,7 @@ func TestStatusRetryHandler_AttachRoutes(t *testing.T) {
 		err = db.Operations().InsertDeprovisioningOperation(deprovisioningOperation)
 		require.NoError(t, err)
 
-		logs := logrus.New()
-		clusterQueue := process.NewQueue(&testExecutor{}, logs, "status-retry", 10*time.Second, 10*time.Second)
+		clusterQueue := process.NewQueue(&testExecutor{}, log, "status-retry", 10*time.Second, 10*time.Second)
 		kymaHandler := NewOrchestrationStatusHandler(db.Operations(), db.Orchestrations(), db.RuntimeStates(), clusterQueue, 100, log)
 
 		req, err := http.NewRequest("POST", fmt.Sprintf("/orchestrations/%s/retry", orchestrationID), nil)
@@ -480,8 +476,7 @@ func TestStatusRetryHandler_AttachRoutes(t *testing.T) {
 		err = fixInProgressOrchestrationOperations(db, orchestrationID)
 		require.NoError(t, err)
 
-		logs := logrus.New()
-		clusterQueue := process.NewQueue(&testExecutor{}, logs, "status-retry", 10*time.Second, 10*time.Second)
+		clusterQueue := process.NewQueue(&testExecutor{}, log, "status-retry", 10*time.Second, 10*time.Second)
 		kymaHandler := NewOrchestrationStatusHandler(db.Operations(), db.Orchestrations(), db.RuntimeStates(), clusterQueue, 100, log)
 
 		req, err := http.NewRequest("POST", fmt.Sprintf("/orchestrations/%s/retry", orchestrationID), nil)

--- a/internal/orchestration/manager/upgrade_cluster.go
+++ b/internal/orchestration/manager/upgrade_cluster.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	internalOrchestration "github.com/kyma-project/kyma-environment-broker/internal/orchestration"
@@ -17,7 +18,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 )
 
 type upgradeClusterFactory struct {
@@ -26,7 +26,7 @@ type upgradeClusterFactory struct {
 
 func NewUpgradeClusterManager(orchestrationStorage storage.Orchestrations, operationStorage storage.Operations, instanceStorage storage.Instances,
 	kymaClusterExecutor orchestration.OperationExecutor, resolver orchestration.RuntimeResolver, pollingInterval time.Duration,
-	log logrus.FieldLogger, cli client.Client, cfg internalOrchestration.Config, bundleBuilder notification.BundleBuilder, speedFactor int) process.Executor {
+	log *slog.Logger, cli client.Client, cfg internalOrchestration.Config, bundleBuilder notification.BundleBuilder, speedFactor int) process.Executor {
 	return &orchestrationManager{
 		orchestrationStorage: orchestrationStorage,
 		operationStorage:     operationStorage,

--- a/internal/orchestration/manager/upgrade_cluster_test.go
+++ b/internal/orchestration/manager/upgrade_cluster_test.go
@@ -2,6 +2,8 @@ package manager_test
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -14,7 +16,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/orchestration/manager"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +33,9 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		Namespace:         "default",
 		Name:              "policyConfig",
 	}
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 
 	t.Run("Empty", func(t *testing.T) {
 		// given
@@ -72,7 +76,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		bundle.On("CreateNotificationEvent").Return(nil).Once()
 
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), nil,
-			resolver, 20*time.Millisecond, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			resolver, 20*time.Millisecond, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)
@@ -118,7 +122,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		bundle.On("CreateNotificationEvent").Return(nil).Once()
 
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &testExecutor{},
-			resolver, poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			resolver, poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)
@@ -166,7 +170,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		bundle.On("CreateNotificationEvent").Return(nil).Once()
 
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), nil,
-			resolver, poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			resolver, poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)
@@ -241,7 +245,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		bundle.On("CreateNotificationEvent").Return(nil).Once()
 
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &testExecutor{},
-			resolver, poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			resolver, poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)
@@ -294,7 +298,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 		bundle.On("CancelNotificationEvent").Return(nil).Once()
 
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &testExecutor{}, resolver,
-			poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)
@@ -370,7 +374,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			upgradeType: orchestration.UpgradeClusterOrchestration,
 		}
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &executor, resolver,
-			poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		_, err = store.Orchestrations().GetByID(id)
 		require.NoError(t, err)
@@ -474,7 +478,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			upgradeType: orchestration.UpgradeClusterOrchestration,
 		}
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &executor, resolver,
-			poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		_, err = store.Operations().GetUpgradeClusterOperationByID(opId)
 		require.NoError(t, err)
@@ -566,7 +570,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			upgradeType: orchestration.UpgradeClusterOrchestration,
 		}
 		svc := manager.NewUpgradeClusterManager(store.Orchestrations(), store.Operations(), store.Instances(), &executor, resolver,
-			poolingInterval, logrus.New(), k8sClient, orchestrationConfig, notificationBuilder, 1000)
+			poolingInterval, log, k8sClient, orchestrationConfig, notificationBuilder, 1000)
 
 		// when
 		_, err = svc.Execute(id)

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -3,11 +3,11 @@ package process
 import (
 	"bytes"
 	"fmt"
+	"log/slog"
 	"runtime/debug"
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -20,7 +20,7 @@ type Queue struct {
 	queue                   workqueue.RateLimitingInterface
 	executor                Executor
 	waitGroup               sync.WaitGroup
-	log                     logrus.FieldLogger
+	log                     *slog.Logger
 	name                    string
 	workerExecutionTimes    map[string]time.Time
 	warnAfterTime           time.Duration
@@ -29,13 +29,13 @@ type Queue struct {
 	speedFactor int64
 }
 
-func NewQueue(executor Executor, log logrus.FieldLogger, name string, warnAfterTime, healthCheckIntervalTime time.Duration) *Queue {
+func NewQueue(executor Executor, log *slog.Logger, name string, warnAfterTime, healthCheckIntervalTime time.Duration) *Queue {
 	// add queue name field that could be logged later on
 	return &Queue{
 		queue:                   workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: "operations"}),
 		executor:                executor,
 		waitGroup:               sync.WaitGroup{},
-		log:                     log.WithField("queueName", name),
+		log:                     log.With("queueName", name),
 		speedFactor:             1,
 		name:                    name,
 		workerExecutionTimes:    make(map[string]time.Time),
@@ -46,26 +46,26 @@ func NewQueue(executor Executor, log logrus.FieldLogger, name string, warnAfterT
 
 func (q *Queue) Add(processId string) {
 	q.queue.Add(processId)
-	q.log.Infof("added item %s to the queue %s, queue length is %d", processId, q.name, q.queue.Len())
+	q.log.Info(fmt.Sprintf("added item %s to the queue %s, queue length is %d", processId, q.name, q.queue.Len()))
 }
 
 func (q *Queue) AddAfter(processId string, duration time.Duration) {
 	q.queue.AddAfter(processId, duration)
-	q.log.Infof("item %s will be added to the queue %s after duration of %d, queue length is %d", processId, q.name, duration, q.queue.Len())
+	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %d, queue length is %d", processId, q.name, duration, q.queue.Len()))
 }
 
 func (q *Queue) ShutDown() {
-	q.log.Infof("shutting down the queue, queue length is %d", q.queue.Len())
+	q.log.Info(fmt.Sprintf("shutting down the queue, queue length is %d", q.queue.Len()))
 	q.queue.ShutDown()
 }
 
 func (q *Queue) Run(stop <-chan struct{}, workersAmount int) {
-	q.log.Infof("starting %d worker(s), queue length is %d", workersAmount, q.queue.Len())
+	q.log.Info(fmt.Sprintf("starting %d worker(s), queue length is %d", workersAmount, q.queue.Len()))
 	for i := 0; i < workersAmount; i++ {
 		q.waitGroup.Add(1)
 
-		workerLogger := q.log.WithField("workerId", i)
-		workerLogger.Infof("starting worker with id %d", i)
+		workerLogger := q.log.With("workerId", i)
+		workerLogger.Info(fmt.Sprintf("starting worker with id %d", i))
 
 		q.createWorker(q.queue, q.executor.Execute, stop, &q.waitGroup, workerLogger, fmt.Sprintf("%s-%d", q.name, i))
 	}
@@ -83,10 +83,10 @@ func (q *Queue) Run(stop <-chan struct{}, workersAmount int) {
 // This method should only be used for testing purposes
 func (q *Queue) SpeedUp(speedFactor int64) {
 	q.speedFactor = speedFactor
-	q.log.Infof("queue speed factor set to %d", speedFactor)
+	q.log.Info(fmt.Sprintf("queue speed factor set to %d", speedFactor))
 }
 
-func (q *Queue) createWorker(queue workqueue.RateLimitingInterface, process func(id string) (time.Duration, error), stopCh <-chan struct{}, waitGroup *sync.WaitGroup, log logrus.FieldLogger, nameId string) {
+func (q *Queue) createWorker(queue workqueue.RateLimitingInterface, process func(id string) (time.Duration, error), stopCh <-chan struct{}, waitGroup *sync.WaitGroup, log *slog.Logger, nameId string) {
 	go func() {
 		log.Info("worker routine - starting")
 		wait.Until(q.worker(queue, process, log, nameId), time.Second, stopCh)
@@ -95,25 +95,25 @@ func (q *Queue) createWorker(queue workqueue.RateLimitingInterface, process func
 	}()
 }
 
-func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key string) (time.Duration, error), log logrus.FieldLogger, nameId string) func() {
+func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key string) (time.Duration, error), log *slog.Logger, nameId string) func() {
 	return func() {
 		exit := false
 		for !exit {
 			exit = func() bool {
 				key, shutdown := queue.Get()
 				if shutdown {
-					log.Infof("shutting down")
+					log.Info("shutting down")
 					return true
 				}
 
 				id := key.(string)
-				log = log.WithField("operationID", id)
-				log.Infof("about to process item %s, queue length is %d", id, q.queue.Len())
+				log = log.With("operationID", id)
+				log.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
 				q.logAndUpdateWorkerTimes(key.(string), nameId, log)
 
 				defer func() {
 					if err := recover(); err != nil {
-						log.Errorf("panic error from process: %v. Stacktrace: %s", err, debug.Stack())
+						log.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					queue.Done(key)
 					log.Info("queue done processing")
@@ -121,17 +121,17 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 
 				when, err := process(id)
 				if err == nil && when != 0 {
-					log.Infof("Adding %q item after %s, queue length %d", id, when, q.queue.Len())
+					log.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
 					afterDuration := time.Duration(int64(when) / q.speedFactor)
 					queue.AddAfter(key, afterDuration)
 					return false
 				}
 				if err != nil {
-					log.Errorf("Error from process: %v", err)
+					log.Error(fmt.Sprintf("Error from process: %v", err))
 				}
 
 				queue.Forget(key)
-				log.Infof("item for %s has been processed, no retry, element forgotten", id)
+				log.Info(fmt.Sprintf("item for %s has been processed, no retry, element forgotten", id))
 
 				return false
 			}()
@@ -139,20 +139,20 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 	}
 }
 
-func (q *Queue) logAndUpdateWorkerTimes(key string, name string, log logrus.FieldLogger) {
+func (q *Queue) logAndUpdateWorkerTimes(key string, name string, log *slog.Logger) {
 	// log time
 	now := time.Now()
 	lastTime, ok := q.workerExecutionTimes[name]
 	if ok {
-		log.Infof("execution - worker %s last execution time %s, executed after %s", name, lastTime, now.Sub(lastTime))
+		log.Info(fmt.Sprintf("execution - worker %s last execution time %s, executed after %s", name, lastTime, now.Sub(lastTime)))
 	}
 	q.workerExecutionTimes[name] = now
 
-	log.Infof("processing item %s, queue length is %d", key, q.queue.Len())
+	log.Info(fmt.Sprintf("processing item %s, queue length is %d", key, q.queue.Len()))
 }
 
 func (q *Queue) logWorkersSummary() {
-	healthCheckLog := q.log.WithField("summary", q.name)
+	healthCheckLog := q.log.With("summary", q.name)
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("health - queue length %d", q.queue.Len()))
 
@@ -167,7 +167,7 @@ func (q *Queue) logWorkersSummary() {
 	for name, lastTime := range q.workerExecutionTimes {
 		timeSinceLastExecution := time.Since(lastTime)
 		if timeSinceLastExecution > q.warnAfterTime {
-			healthCheckLog.Infof("worker %s exceeded allowed limit of %s since last execution, its last execution is %s, time since last execution %s", name, q.warnAfterTime, lastTime, timeSinceLastExecution)
+			healthCheckLog.Info(fmt.Sprintf("worker %s exceeded allowed limit of %s since last execution, its last execution is %s, time since last execution %s", name, q.warnAfterTime, lastTime, timeSinceLastExecution))
 		}
 	}
 }

--- a/internal/process/upgrade_cluster/initialisation_test.go
+++ b/internal/process/upgrade_cluster/initialisation_test.go
@@ -1,6 +1,8 @@
 package upgrade_cluster
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -23,7 +25,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -43,9 +44,11 @@ type fixHyperscalerInputProvider interface {
 }
 
 func TestInitialisationStep_Run(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	t.Run("should mark operation as Succeeded when upgrade was successful", func(t *testing.T) {
 		// given
-		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
 		orch := internal.Orchestration{
@@ -114,7 +117,6 @@ func TestInitialisationStep_Run(t *testing.T) {
 
 	t.Run("should initialize UpgradeRuntimeInput request when run", func(t *testing.T) {
 		// given
-		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
 		err := memoryStorage.Orchestrations().Insert(fixOrchestrationWithKymaVer())
@@ -178,7 +180,6 @@ func TestInitialisationStep_Run(t *testing.T) {
 
 	t.Run("should mark finish if orchestration was canceled", func(t *testing.T) {
 		// given
-		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
 		err := memoryStorage.Orchestrations().Insert(internal.Orchestration{

--- a/internal/process/upgrade_cluster/log_skipping_upgrade.go
+++ b/internal/process/upgrade_cluster/log_skipping_upgrade.go
@@ -1,12 +1,11 @@
 package upgrade_cluster
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 )
@@ -25,7 +24,7 @@ func NewLogSkippingUpgradeStep(os storage.Operations) *LogSkippingUpgradeStep {
 	}
 }
 
-func (s *LogSkippingUpgradeStep) Run(operation internal.UpgradeClusterOperation, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (s *LogSkippingUpgradeStep) Run(operation internal.UpgradeClusterOperation, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	log.Info("Skipping cluster upgrade due to step condition not met")
 
 	return s.operationManager.OperationSucceeded(operation, "upgrade cluster skipped due to step condition", log)

--- a/internal/process/upgrade_cluster/manager.go
+++ b/internal/process/upgrade_cluster/manager.go
@@ -3,6 +3,7 @@ package upgrade_cluster
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"time"
 
@@ -12,12 +13,11 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/event"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 )
 
 type Step interface {
 	Name() string
-	Run(operation internal.UpgradeClusterOperation, logger logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error)
+	Run(operation internal.UpgradeClusterOperation, logger *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error)
 }
 
 type StepCondition func(operation internal.Operation) bool
@@ -28,14 +28,14 @@ type StepWithCondition struct {
 }
 
 type Manager struct {
-	log              logrus.FieldLogger
+	log              *slog.Logger
 	steps            map[int][]StepWithCondition
 	operationStorage storage.Operations
 
 	publisher event.Publisher
 }
 
-func NewManager(storage storage.Operations, pub event.Publisher, logger logrus.FieldLogger) *Manager {
+func NewManager(storage storage.Operations, pub event.Publisher, logger *slog.Logger) *Manager {
 	return &Manager{
 		log:              logger,
 		steps:            make(map[int][]StepWithCondition, 0),
@@ -55,10 +55,10 @@ func (m *Manager) AddStep(weight int, step Step, condition StepCondition) {
 	m.steps[weight] = append(m.steps[weight], StepWithCondition{Step: step, condition: condition})
 }
 
-func (m *Manager) runStep(step Step, operation internal.UpgradeClusterOperation, logger logrus.FieldLogger) (processedOperation internal.UpgradeClusterOperation, when time.Duration, err error) {
+func (m *Manager) runStep(step Step, operation internal.UpgradeClusterOperation, logger *slog.Logger) (processedOperation internal.UpgradeClusterOperation, when time.Duration, err error) {
 	defer func() {
 		if pErr := recover(); pErr != nil {
-			logger.Println("panic in RunStep during cluster upgrade: ", pErr)
+			logger.Error(fmt.Sprintf("panic in RunStep during cluster upgrade: %v", pErr))
 			err = errors.New(fmt.Sprintf("%v", pErr))
 			om := process.NewUpgradeClusterOperationManager(m.operationStorage)
 			processedOperation, _, _ = om.OperationFailed(operation, "recovered from panic", err, m.log)
@@ -93,7 +93,7 @@ func (m *Manager) sortWeight() []int {
 func (m *Manager) Execute(operationID string) (time.Duration, error) {
 	op, err := m.operationStorage.GetUpgradeClusterOperationByID(operationID)
 	if err != nil {
-		m.log.Errorf("Cannot fetch operation from storage: %s", err)
+		m.log.Error(fmt.Sprintf("Cannot fetch operation from storage: %s", err))
 		return 3 * time.Second, nil
 	}
 	operation := *op
@@ -102,27 +102,27 @@ func (m *Manager) Execute(operationID string) (time.Duration, error) {
 	}
 
 	var when time.Duration
-	logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID})
+	logOperation := m.log.With("operation", operationID, "instanceID", operation.InstanceID)
 
 	logOperation.Info("Start process operation steps")
 	for _, weightStep := range m.sortWeight() {
 		steps := m.steps[weightStep]
 		for _, step := range steps {
-			logStep := logOperation.WithField("step", step.Name())
+			logStep := logOperation.With("step", step.Name())
 
 			if step.condition != nil && !step.condition(operation.Operation) {
-				logStep.Debugf("Skipping due to not met condition")
+				logStep.Debug("Skipping due to not met condition")
 				continue
 			}
-			logStep.Infof("Start step")
+			logStep.Info("Start step")
 
 			operation, when, err = m.runStep(step, operation, logStep)
 			if err != nil {
-				logStep.Errorf("Process operation failed: %s", err)
+				logStep.Error(fmt.Sprintf("Process operation failed: %s", err))
 				return 0, err
 			}
 			if operation.IsFinished() {
-				logStep.Infof("Operation %q got status %s. Process finished.", operation.Operation.ID, operation.State)
+				logStep.Info(fmt.Sprintf("Operation %q got status %s. Process finished.", operation.Operation.ID, operation.State))
 				return 0, nil
 			}
 			if when == 0 {
@@ -130,26 +130,26 @@ func (m *Manager) Execute(operationID string) (time.Duration, error) {
 				continue
 			}
 
-			logStep.Infof("Process operation will be repeated in %s ...", when)
+			logStep.Info(fmt.Sprintf("Process operation will be repeated in %s ...", when))
 			return when, nil
 		}
 	}
 
-	logOperation.Infof("Operation %q got status %s. All steps finished.", operation.Operation.ID, operation.State)
+	logOperation.Info(fmt.Sprintf("Operation %q got status %s. All steps finished.", operation.Operation.ID, operation.State))
 	return 0, nil
 }
 
 func (m Manager) Reschedule(operationID string, maintenanceWindowBegin, maintenanceWindowEnd time.Time) error {
 	op, err := m.operationStorage.GetUpgradeClusterOperationByID(operationID)
 	if err != nil {
-		m.log.Errorf("Cannot fetch operation %s from storage: %s", operationID, err)
+		m.log.Error(fmt.Sprintf("Cannot fetch operation %s from storage: %s", operationID, err))
 		return err
 	}
 	op.MaintenanceWindowBegin = maintenanceWindowBegin
 	op.MaintenanceWindowEnd = maintenanceWindowEnd
 	op, err = m.operationStorage.UpdateUpgradeClusterOperation(*op)
 	if err != nil {
-		m.log.Errorf("Cannot update (reschedule) operation %s in storage: %s", operationID, err)
+		m.log.Error(fmt.Sprintf("Cannot update (reschedule) operation %s in storage: %s", operationID, err))
 	}
 
 	return err

--- a/internal/process/upgrade_cluster/send_notification_test.go
+++ b/internal/process/upgrade_cluster/send_notification_test.go
@@ -1,11 +1,12 @@
 package upgrade_cluster
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
-	"github.com/kyma-project/kyma-environment-broker/internal/logger"
 	"github.com/kyma-project/kyma-environment-broker/internal/notification"
 	"github.com/kyma-project/kyma-environment-broker/internal/notification/mocks"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
@@ -16,6 +17,9 @@ import (
 func TestSendNotificationStep_Run(t *testing.T) {
 	// given
 	memoryStorage := storage.NewMemoryStorage()
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	tenants := []notification.NotificationTenant{
 		{
 			InstanceID: notification.FakeInstanceID,
@@ -42,7 +46,7 @@ func TestSendNotificationStep_Run(t *testing.T) {
 	step := NewSendNotificationStep(memoryStorage.Operations(), bundleBuilder)
 
 	// when
-	_, repeat, err := step.Run(operation, logger.NewLogDummy())
+	_, repeat, err := step.Run(operation, log)
 
 	// then
 	assert.NoError(t, err)

--- a/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -1,6 +1,8 @@
 package upgrade_cluster
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -12,7 +14,6 @@ import (
 	provisionerAutomock "github.com/kyma-project/kyma-environment-broker/internal/provisioner/automock"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,9 @@ const (
 func TestUpgradeClusterStep_Run(t *testing.T) {
 	// given
 	expectedOIDC := fixture.FixOIDCConfigDTO()
-	log := logrus.New()
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
 	memoryStorage := storage.NewMemoryStorage()
 
 	operation := fixUpgradeClusterOperationWithInputCreator(t)
@@ -97,7 +100,7 @@ func TestUpgradeClusterStep_Run(t *testing.T) {
 
 	// when
 
-	operation, repeat, err := step.Run(operation, log.WithFields(logrus.Fields{"step": "TEST"}))
+	operation, repeat, err := step.Run(operation, log.With("step", "TEST"))
 
 	// then
 	assert.NoError(t, err)

--- a/internal/process/upgrade_cluster_operation.go
+++ b/internal/process/upgrade_cluster_operation.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/orchestration"
@@ -9,7 +10,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 )
 
 type UpgradeClusterOperationManager struct {
@@ -21,7 +21,7 @@ func NewUpgradeClusterOperationManager(storage storage.Operations) *UpgradeClust
 }
 
 // OperationSucceeded marks the operation as succeeded and only repeats it if there is a storage error
-func (om *UpgradeClusterOperationManager) OperationSucceeded(operation internal.UpgradeClusterOperation, description string, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) OperationSucceeded(operation internal.UpgradeClusterOperation, description string, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	updatedOperation, repeat, _ := om.update(operation, orchestration.Succeeded, description, log)
 	// repeat in case of storage error
 	if repeat != 0 {
@@ -32,7 +32,7 @@ func (om *UpgradeClusterOperationManager) OperationSucceeded(operation internal.
 }
 
 // OperationFailed marks the operation as failed and only repeats it if there is a storage error
-func (om *UpgradeClusterOperationManager) OperationFailed(operation internal.UpgradeClusterOperation, description string, err error, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) OperationFailed(operation internal.UpgradeClusterOperation, description string, err error, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	updatedOperation, repeat, _ := om.update(operation, orchestration.Failed, description, log)
 	// repeat in case of storage error
 	if repeat != 0 {
@@ -52,7 +52,7 @@ func (om *UpgradeClusterOperationManager) OperationFailed(operation internal.Upg
 }
 
 // OperationSucceeded marks the operation as succeeded and only repeats it if there is a storage error
-func (om *UpgradeClusterOperationManager) OperationCanceled(operation internal.UpgradeClusterOperation, description string, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) OperationCanceled(operation internal.UpgradeClusterOperation, description string, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	updatedOperation, repeat, _ := om.update(operation, orchestration.Canceled, description, log)
 	if repeat != 0 {
 		return updatedOperation, repeat, nil
@@ -62,20 +62,20 @@ func (om *UpgradeClusterOperationManager) OperationCanceled(operation internal.U
 }
 
 // RetryOperation retries an operation for at maxTime in retryInterval steps and fails the operation if retrying failed
-func (om *UpgradeClusterOperationManager) RetryOperation(operation internal.UpgradeClusterOperation, errorMessage string, err error, retryInterval time.Duration, maxTime time.Duration, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) RetryOperation(operation internal.UpgradeClusterOperation, errorMessage string, err error, retryInterval time.Duration, maxTime time.Duration, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
-	log.Infof("Retry Operation was triggered with message: %s", errorMessage)
-	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
+	log.Info(fmt.Sprintf("Retry Operation was triggered with message: %s", errorMessage))
+	log.Info(fmt.Sprintf("Retrying for %s in %s steps", maxTime.String(), retryInterval.String()))
 	if since < maxTime {
 		return operation, retryInterval, nil
 	}
-	log.Errorf("Aborting after %s of failing retries", maxTime.String())
+	log.Error(fmt.Sprintf("Aborting after %s of failing retries", maxTime.String()))
 	return om.OperationFailed(operation, errorMessage, err, log)
 }
 
 // UpdateOperation updates a given operation
-func (om *UpgradeClusterOperationManager) UpdateOperation(operation internal.UpgradeClusterOperation, update func(operation *internal.UpgradeClusterOperation), log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) UpdateOperation(operation internal.UpgradeClusterOperation, update func(operation *internal.UpgradeClusterOperation), log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	update(&operation)
 	updatedOperation, err := om.storage.UpdateUpgradeClusterOperation(operation)
 	switch {
@@ -83,19 +83,19 @@ func (om *UpgradeClusterOperationManager) UpdateOperation(operation internal.Upg
 		{
 			op, err := om.storage.GetUpgradeClusterOperationByID(operation.Operation.ID)
 			if err != nil {
-				log.Errorf("while getting operation: %v", err)
+				log.Error(fmt.Sprintf("while getting operation: %v", err))
 				return operation, 1 * time.Minute, err
 			}
 			op.Merge(&operation.Operation)
 			update(op)
 			updatedOperation, err = om.storage.UpdateUpgradeClusterOperation(*op)
 			if err != nil {
-				log.Errorf("while updating operation after conflict: %v", err)
+				log.Error(fmt.Sprintf("while updating operation after conflict: %v", err))
 				return operation, 1 * time.Minute, err
 			}
 		}
 	case err != nil:
-		log.Errorf("while updating operation: %v", err)
+		log.Error(fmt.Sprintf("while updating operation: %v", err))
 		return operation, 1 * time.Minute, err
 	}
 	return *updatedOperation, 0, nil
@@ -105,20 +105,20 @@ func (om *UpgradeClusterOperationManager) UpdateOperation(operation internal.Upg
 func (om *UpgradeClusterOperationManager) SimpleUpdateOperation(operation internal.UpgradeClusterOperation) (internal.UpgradeClusterOperation, time.Duration) {
 	updatedOperation, err := om.storage.UpdateUpgradeClusterOperation(operation)
 	if err != nil {
-		logrus.WithField("orchestrationID", operation.OrchestrationID).
-			WithField("instanceID", operation.InstanceID).
-			Errorf("Update upgradeCluster operation failed: %s", err.Error())
+		slog.With("orchestrationID", operation.OrchestrationID).
+			With("instanceID", operation.InstanceID).
+			Error(fmt.Sprintf("Update upgradeCluster operation failed: %s", err.Error()))
 		return operation, 1 * time.Minute
 	}
 	return *updatedOperation, 0
 }
 
 // RetryOperationWithoutFail retries an operation for at maxTime in retryInterval steps and omits the operation if retrying failed
-func (om *UpgradeClusterOperationManager) RetryOperationWithoutFail(operation internal.UpgradeClusterOperation, description string, retryInterval, maxTime time.Duration, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) RetryOperationWithoutFail(operation internal.UpgradeClusterOperation, description string, retryInterval, maxTime time.Duration, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
-	log.Infof("Retry Operation was triggered with message: %s", description)
-	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
+	log.Info(fmt.Sprintf("Retry Operation was triggered with message: %s", description))
+	log.Info(fmt.Sprintf("Retrying for %s in %s steps", maxTime.String(), retryInterval.String()))
 	if since < maxTime {
 		return operation, retryInterval, nil
 	}
@@ -128,11 +128,11 @@ func (om *UpgradeClusterOperationManager) RetryOperationWithoutFail(operation in
 		return updatedOperation, repeat, nil
 	}
 
-	log.Errorf("Omitting after %s of failing retries", maxTime.String())
+	log.Error(fmt.Sprintf("Omitting after %s of failing retries", maxTime.String()))
 	return updatedOperation, 0, nil
 }
 
-func (om *UpgradeClusterOperationManager) update(operation internal.UpgradeClusterOperation, state domain.LastOperationState, description string, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
+func (om *UpgradeClusterOperationManager) update(operation internal.UpgradeClusterOperation, state domain.LastOperationState, description string, log *slog.Logger) (internal.UpgradeClusterOperation, time.Duration, error) {
 	return om.UpdateOperation(operation, func(operation *internal.UpgradeClusterOperation) {
 		operation.State = state
 		operation.Description = description

--- a/internal/process/upgrade_cluster_operation_test.go
+++ b/internal/process/upgrade_cluster_operation_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +23,7 @@ func TestUpgradeClusterOperationManager_OperationSucceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	op, when, err := opManager.OperationSucceeded(op, "task succeeded", logrus.New())
+	op, when, err := opManager.OperationSucceeded(op, "task succeeded", fixLogger())
 
 	// then
 	assert.NoError(t, err)
@@ -45,7 +44,7 @@ func TestUpgradeClusterOperationManager_OperationFailed(t *testing.T) {
 	errOut := fmt.Errorf("error occurred")
 
 	// when
-	op, when, err := opManager.OperationFailed(op, errMsg, errOut, logrus.New())
+	op, when, err := opManager.OperationFailed(op, errMsg, errOut, fixLogger())
 
 	// then
 	assert.Error(t, err)
@@ -54,7 +53,7 @@ func TestUpgradeClusterOperationManager_OperationFailed(t *testing.T) {
 	assert.Equal(t, time.Duration(0), when)
 
 	// when
-	_, _, err = opManager.OperationFailed(op, errMsg, nil, logrus.New())
+	_, _, err = opManager.OperationFailed(op, errMsg, nil, fixLogger())
 
 	// then
 	assert.Error(t, err)
@@ -78,7 +77,7 @@ func TestUpgradeClusterOperationManager_RetryOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	// then - first call
-	op, when, err := opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, logrus.New())
+	op, when, err := opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, fixLogger())
 
 	// when - first retry
 	assert.True(t, when > 0)
@@ -88,7 +87,7 @@ func TestUpgradeClusterOperationManager_RetryOperation(t *testing.T) {
 	t.Log(op.UpdatedAt.String())
 	op.UpdatedAt = op.UpdatedAt.Add(-retryInterval - time.Second) // simulate wait of first retry
 	t.Log(op.UpdatedAt.String())
-	op, when, err = opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, logrus.New())
+	op, when, err = opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, fixLogger())
 
 	// when - second call => retry
 	assert.True(t, when > 0)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `slog` instead of `logrus` in queues and orchestration steps.

**Related issue(s)**
See also #1469
