### PR TITLE
Align azure_lite root volume to be the same as other paid plan runtimes

### DIFF
--- a/internal/provider/azure.go
+++ b/internal/provider/azure.go
@@ -126,8 +126,8 @@ func (p *AzureLiteInputProvider) Provide() Values {
 		DefaultMachineType:   machineType,
 		Region:               region,
 		Purpose:              p.Purpose,
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}
 }
 

--- a/internal/provider/azure_provider.go
+++ b/internal/provider/azure_provider.go
@@ -134,8 +134,8 @@ func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
 	}
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
-			DiskType:       ptr.String("Standard_LRS"),
-			VolumeSizeGb:   ptr.Integer(50),
+			DiskType:       ptr.String("StandardSSD_LRS"),
+			VolumeSizeGb:   ptr.Integer(80),
 			MachineType:    machineType,
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",

--- a/internal/provider/azure_test.go
+++ b/internal/provider/azure_test.go
@@ -96,8 +96,8 @@ func TestAzureLiteDefaults(t *testing.T) {
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "eastus",
 		Purpose:              "evaluation",
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}, values)
 }
 
@@ -203,7 +203,7 @@ func TestAzureLiteSpecific(t *testing.T) {
 		DefaultMachineType:   "Standard_D4s_v5",
 		Region:               "uksouth",
 		Purpose:              "evaluation",
-		DiskType:             "Standard_LRS",
-		VolumeSizeGb:         50,
+		DiskType:             "StandardSSD_LRS",
+		VolumeSizeGb:         80,
 	}, values)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

SRE faced recurring node diskpressure problems on azure_lite runtimes recently. These paid runtimes were not migrated to 80 GiB root/data volumes along with the other paid plans. As azure_lite is also a paid plan (unlike free or trial), and the cost difference between the old and the new volume is negligible, however the impact on system stability is high, we would migrate all azure_lite plan runtimes to use 80 GiB root volumes. 



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- https://github.tools.sap/kyma/backlog/issues/6556
- https://github.tools.sap/kyma/backlog/issues/6261