### PR TITLE
 Additional Worker Node Pools on Preview

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
 	"github.com/kyma-project/kyma-environment-broker/internal/customresources"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
@@ -1275,4 +1277,17 @@ func createResource(t *testing.T, gvk schema.GroupVersionKind, k8sClient client.
 	object.SetName(name)
 	err := k8sClient.Create(context.TODO(), object)
 	assert.NoError(t, err)
+}
+
+func (s *BrokerSuiteTest) assertAdditionalWorkerIsCreated(t *testing.T, provider imv1.Provider, name, machineType string, autoScalerMin, autoScalerMax int) {
+	var worker *v1beta1.Worker
+	//for _, additionalWorker := range provider.AdditionalWorkers {
+	//	if additionalWorker.Name == name {
+	//		worker = &additionalWorker
+	//	}
+	//}
+	require.NotNil(t, worker)
+	assert.Equal(t, machineType, worker.Machine.Type)
+	assert.Equal(t, int32(autoScalerMin), worker.Minimum)
+	assert.Equal(t, int32(autoScalerMax), worker.Maximum)
 }

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1902,20 +1902,22 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 					"parameters": {
 						"name": "testing-cluster",
 						"region": "eu-central-1",
-						"additionalWorkerNodePools": [
-							{
-								"name": "name-1",
-								"machineType": "m6i.large",
-								"autoScalerMin": 1,
-								"autoScalerMax": 10
-							},
-							{
-								"name": "name-2",
-								"machineType": "m5.large",
-								"autoScalerMin": 0,
-								"autoScalerMax": 0
-							}
-						]
+						"additionalWorkerNodePools": {
+							"list": [
+								{
+									"name": "name-1",
+									"machineType": "m6i.large",
+									"autoScalerMin": 1,
+									"autoScalerMax": 10
+								},
+								{
+									"name": "name-2",
+									"machineType": "m5.large",
+									"autoScalerMin": 0,
+									"autoScalerMax": 0
+								}
+							]
+						}
 					}
 		}`)
 

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1877,3 +1877,55 @@ func TestProvisioning_Modules(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }
+
+func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
+	//given
+	cfg := fixConfig()
+	cfg.Broker.KimConfig.Enabled = true
+	cfg.Broker.KimConfig.Plans = []string{"preview"}
+	cfg.Broker.KimConfig.KimOnlyPlans = []string{"preview"}
+
+	suite := NewBrokerSuiteTestWithConfig(t, cfg)
+	defer suite.TearDown()
+	iid := uuid.New().String()
+
+	// when
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu21/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+					"plan_id": "5cb3d976-b85c-42ea-a636-79cadda109a9",
+					"context": {
+						"globalaccount_id": "g-account-id",
+						"subaccount_id": "sub-id",
+						"user_id": "john.smith@email.com"
+					},
+					"parameters": {
+						"name": "testing-cluster",
+						"region": "eu-central-1",
+						"additionalWorkerNodePools": [
+							{
+								"name": "name-1",
+								"machineType": "m6i.large",
+								"autoScalerMin": 1,
+								"autoScalerMax": 10
+							},
+							{
+								"name": "name-2",
+								"machineType": "m5.large",
+								"autoScalerMin": 0,
+								"autoScalerMax": 0
+							}
+						]
+					}
+		}`)
+
+	opID := suite.DecodeOperationID(resp)
+	suite.processKIMOnlyProvisioningByOperationID(opID)
+
+	// then
+	suite.WaitForOperationState(opID, domain.Succeeded)
+	runtime := suite.GetRuntimeResourceByInstanceID(iid)
+	//assert.Len(t, runtime.Spec.Shoot.Provider.AdditionalWorkers, 2)
+	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 1, 10)
+	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
+}

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1907,14 +1907,14 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 								{
 									"name": "name-1",
 									"machineType": "m6i.large",
-									"autoScalerMin": 1,
-									"autoScalerMax": 10
+									"autoScalerMin": 3,
+									"autoScalerMax": 20
 								},
 								{
 									"name": "name-2",
 									"machineType": "m5.large",
-									"autoScalerMin": 0,
-									"autoScalerMax": 0
+									"autoScalerMin": 4,
+									"autoScalerMax": 21
 								}
 							]
 						}
@@ -1928,6 +1928,6 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 	suite.WaitForOperationState(opID, domain.Succeeded)
 	runtime := suite.GetRuntimeResourceByInstanceID(iid)
 	//assert.Len(t, runtime.Spec.Shoot.Provider.AdditionalWorkers, 2)
-	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 1, 10)
-	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
+	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 3, 20)
+	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 4, 21)
 }

--- a/cmd/broker/update.go
+++ b/cmd/broker/update.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
-
 	"github.com/kyma-project/kyma-environment-broker/internal/event"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/process/input"
+	"github.com/kyma-project/kyma-environment-broker/internal/process/steps"
 	"github.com/kyma-project/kyma-environment-broker/internal/process/update"
+	"github.com/kyma-project/kyma-environment-broker/internal/provider"
 	"github.com/kyma-project/kyma-environment-broker/internal/provisioner"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,6 +18,11 @@ import (
 func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManager, workersAmount int, db storage.BrokerStorage, inputFactory input.CreatorForPlan,
 	provisionerClient provisioner.Client, publisher event.Publisher,
 	cfg Config, k8sClientProvider K8sClientProvider, cli client.Client, logs *slog.Logger) *process.Queue {
+
+	trialRegionsMapping, err := provider.ReadPlatformRegionMappingFromFile(cfg.TrialRegionMappingFilePath)
+	if err != nil {
+		fatalOnError(err, logs)
+	}
 
 	manager.DefineStages([]string{"cluster", "btp-operator", "btp-operator-check", "check", "runtime_resource", "check_runtime_resource"})
 	updateSteps := []struct {
@@ -42,7 +47,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManage
 		},
 		{
 			stage:     "runtime_resource",
-			step:      update.NewUpdateRuntimeStep(db.Operations(), cli, cfg.UpdateRuntimeResourceDelay),
+			step:      update.NewUpdateRuntimeStep(db.Operations(), cli, cfg.UpdateRuntimeResourceDelay, cfg.Provisioner, cfg.Broker.UseSmallerMachineTypes, trialRegionsMapping),
 			condition: update.SkipForOwnClusterPlan,
 		},
 		{

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -2568,14 +2568,14 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 									{
 										"name": "name-1",
 										"machineType": "m6i.large",
-										"autoScalerMin": 1,
-										"autoScalerMax": 10
+										"autoScalerMin": 3,
+										"autoScalerMax": 20
 									},
 									{
 										"name": "name-2",
 										"machineType": "m5.large",
-										"autoScalerMin": 0,
-										"autoScalerMax": 0
+										"autoScalerMin": 4,
+										"autoScalerMax": 21
 									}
 								]
 							}
@@ -2588,8 +2588,8 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 		suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
 		runtime := suite.GetRuntimeResourceByInstanceID(iid)
 		//assert.Len(t, runtime.Spec.Shoot.Provider.AdditionalWorkers, 2)
-		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 1, 10)
-		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
+		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 3, 20)
+		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 4, 21)
 	})
 
 	t.Run("should replace additional worker node pools", func(t *testing.T) {
@@ -2615,8 +2615,8 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 									{
 										"name": "name-1",
 										"machineType": "m6i.large",
-										"autoScalerMin": 1,
-										"autoScalerMax": 10
+										"autoScalerMin": 3,
+										"autoScalerMax": 20
 									}
 								]
 							}
@@ -2642,8 +2642,8 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 									{
 										"name": "name-2",
 										"machineType": "m5.large",
-										"autoScalerMin": 0,
-										"autoScalerMax": 0
+										"autoScalerMin": 4,
+										"autoScalerMax": 21
 									}
 								]
 							}
@@ -2656,7 +2656,7 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 		suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
 		runtime := suite.GetRuntimeResourceByInstanceID(iid)
 		//assert.Len(t, runtime.Spec.Shoot.Provider.AdditionalWorkers, 1)
-		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
+		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 4, 21)
 	})
 
 	t.Run("should remove additional worker node pools when list is empty", func(t *testing.T) {
@@ -2682,14 +2682,14 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 									{
 										"name": "name-1",
 										"machineType": "m6i.large",
-										"autoScalerMin": 1,
-										"autoScalerMax": 10
+										"autoScalerMin": 3,
+										"autoScalerMax": 20
 									},
 									{
 										"name": "name-2",
 										"machineType": "m5.large",
-										"autoScalerMin": 0,
-										"autoScalerMax": 0
+										"autoScalerMin": 4,
+										"autoScalerMax": 21
 									}
 								]
 							}

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -2610,14 +2610,16 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 						"parameters": {
 							"name": "testing-cluster",
 							"region": "eu-central-1",
-							"additionalWorkerNodePools": [
-								{
-									"name": "name-1",
-									"machineType": "m6i.large",
-									"autoScalerMin": 1,
-									"autoScalerMax": 10
-								}
-							]
+							"additionalWorkerNodePools": {
+								"list": [
+									{
+										"name": "name-1",
+										"machineType": "m6i.large",
+										"autoScalerMin": 1,
+										"autoScalerMax": 10
+									}
+								]
+							}
 						}
    			}`)
 		opID := suite.DecodeOperationID(resp)
@@ -2657,7 +2659,7 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
 	})
 
-	t.Run("should not change additional worker node pools when list is empty", func(t *testing.T) {
+	t.Run("should remove additional worker node pools when list is empty", func(t *testing.T) {
 		// given
 		suite := NewBrokerSuiteTest(t)
 		defer suite.TearDown()
@@ -2675,20 +2677,22 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 						"parameters": {
 							"name": "testing-cluster",
 							"region": "eu-central-1",
-							"additionalWorkerNodePools": [
-								{
-									"name": "name-1",
-									"machineType": "m6i.large",
-									"autoScalerMin": 1,
-									"autoScalerMax": 10
-								},
-								{
-									"name": "name-2",
-									"machineType": "m5.large",
-									"autoScalerMin": 0,
-									"autoScalerMax": 0
-								}
-							]
+							"additionalWorkerNodePools": {
+								"list": [
+									{
+										"name": "name-1",
+										"machineType": "m6i.large",
+										"autoScalerMin": 1,
+										"autoScalerMax": 10
+									},
+									{
+										"name": "name-2",
+										"machineType": "m5.large",
+										"autoScalerMin": 0,
+										"autoScalerMax": 0
+									}
+								]
+							}
 						}
    			}`)
 		opID := suite.DecodeOperationID(resp)
@@ -2708,71 +2712,6 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 						"parameters": {
 							"additionalWorkerNodePools": {
 								"list": []
-							}
-						}
-   			}`)
-		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
-		upgradeOperationID := suite.DecodeOperationID(resp)
-
-		// then
-		suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
-		runtime := suite.GetRuntimeResourceByInstanceID(iid)
-		//assert.Len(t, runtime.Spec.Shoot.Provider.AdditionalWorkers, 2)
-		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 1, 10)
-		suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 0, 0)
-	})
-
-	t.Run("should remove additional worker node pools", func(t *testing.T) {
-		// given
-		suite := NewBrokerSuiteTest(t)
-		defer suite.TearDown()
-		iid := uuid.New().String()
-
-		resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
-			`{
-				   		"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
-				   		"plan_id": "5cb3d976-b85c-42ea-a636-79cadda109a9",
-				   		"context": {
-					   		"globalaccount_id": "g-account-id",
-					   		"subaccount_id": "sub-id",
-					   		"user_id": "john.smith@email.com"
-				   		},
-						"parameters": {
-							"name": "testing-cluster",
-							"region": "eu-central-1",
-							"additionalWorkerNodePools": [
-								{
-									"name": "name-1",
-									"machineType": "m6i.large",
-									"autoScalerMin": 1,
-									"autoScalerMax": 10
-								},
-								{
-									"name": "name-2",
-									"machineType": "m5.large",
-									"autoScalerMin": 0,
-									"autoScalerMax": 0
-								}
-							]
-						}
-   			}`)
-		opID := suite.DecodeOperationID(resp)
-		suite.waitForRuntimeAndMakeItReady(opID)
-		suite.WaitForOperationState(opID, domain.Succeeded)
-
-		// when
-		// OSB update:
-		resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", iid),
-			`{
-       					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
-       					"plan_id": "5cb3d976-b85c-42ea-a636-79cadda109a9",
-       					"context": {
-           					"globalaccount_id": "g-account-id",
-           					"user_id": "john.smith@email.com"
-       					},
-						"parameters": {
-							"additionalWorkerNodePools": {
-								"remove": true
 							}
 						}
    			}`)

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -389,8 +389,15 @@ type ModuleDTO struct {
 }
 
 type AdditionalWorkerNodePool struct {
-	AutoScalerParameters `json:",inline"`
+	Name          string `json:"name"`
+	MachineType   string `json:"machineType"`
+	AutoScalerMin int    `json:"autoScalerMin"`
+	AutoScalerMax int    `json:"autoScalerMax"`
+}
 
-	Name        string  `json:"name"`
-	MachineType *string `json:"machineType,omitempty"`
+func (a AdditionalWorkerNodePool) Validate() error {
+	if a.AutoScalerMin > a.AutoScalerMax {
+		return fmt.Errorf("AutoScalerMax %v should be larger than AutoScalerMin %v for %s worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
+	}
+	return nil
 }

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -388,6 +388,25 @@ type ModuleDTO struct {
 	CustomResourcePolicy CustomResourcePolicy `json:"customResourcePolicy,omitempty" yaml:"customResourcePolicy,omitempty"`
 }
 
+type AdditionalWorkerNodePools struct {
+	List   []AdditionalWorkerNodePool `json:"list"`
+	Remove bool                       `json:"remove"`
+}
+
+func (a AdditionalWorkerNodePools) Validate() error {
+	if a.Remove && len(a.List) > 0 {
+		return fmt.Errorf("cannot remove additional worker node pools while the list is not empty")
+	}
+
+	for _, additionalWorkerNodePool := range a.List {
+		if err := additionalWorkerNodePool.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 type AdditionalWorkerNodePool struct {
 	Name          string `json:"name"`
 	MachineType   string `json:"machineType"`

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -101,7 +101,7 @@ type ProvisioningParametersDTO struct {
 	Networking                *NetworkingDTO             `json:"networking,omitempty"`
 	Modules                   *ModulesDTO                `json:"modules,omitempty"`
 	ShootAndSeedSameRegion    *bool                      `json:"shootAndSeedSameRegion,omitempty"`
-	AdditionalWorkerNodePools []AdditionalWorkerNodePool `json:"additionalWorkerNodePools,omitempty"`
+	AdditionalWorkerNodePools *AdditionalWorkerNodePools `json:"additionalWorkerNodePools,omitempty"`
 }
 
 type AutoScalerParameters struct {
@@ -389,15 +389,24 @@ type ModuleDTO struct {
 }
 
 type AdditionalWorkerNodePools struct {
-	List   []AdditionalWorkerNodePool `json:"list"`
-	Remove bool                       `json:"remove"`
+	List             []AdditionalWorkerNodePool `json:"list"`
+	SkipModification *bool                      `json:"skipModification,omitempty"`
 }
 
-func (a AdditionalWorkerNodePools) Validate() error {
-	if a.Remove && len(a.List) > 0 {
-		return fmt.Errorf("cannot remove additional worker node pools while the list is not empty")
+func (a *AdditionalWorkerNodePools) IsProvided() bool {
+	if a == nil {
+		return false
 	}
+	if a.SkipModification != nil && *a.SkipModification {
+		return false
+	}
+	if a.List == nil {
+		return false
+	}
+	return true
+}
 
+func (a *AdditionalWorkerNodePools) Validate() error {
 	for _, additionalWorkerNodePool := range a.List {
 		if err := additionalWorkerNodePool.Validate(); err != nil {
 			return err

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -97,10 +97,11 @@ type ProvisioningParametersDTO struct {
 	ShootName   string `json:"shootName,omitempty"`
 	ShootDomain string `json:"shootDomain,omitempty"`
 
-	OIDC                   *OIDCConfigDTO `json:"oidc,omitempty"`
-	Networking             *NetworkingDTO `json:"networking,omitempty"`
-	Modules                *ModulesDTO    `json:"modules,omitempty"`
-	ShootAndSeedSameRegion *bool          `json:"shootAndSeedSameRegion,omitempty"`
+	OIDC                      *OIDCConfigDTO             `json:"oidc,omitempty"`
+	Networking                *NetworkingDTO             `json:"networking,omitempty"`
+	Modules                   *ModulesDTO                `json:"modules,omitempty"`
+	ShootAndSeedSameRegion    *bool                      `json:"shootAndSeedSameRegion,omitempty"`
+	AdditionalWorkerNodePools []AdditionalWorkerNodePool `json:"additionalWorkerNodePools,omitempty"`
 }
 
 type AutoScalerParameters struct {
@@ -385,4 +386,11 @@ type ModuleDTO struct {
 	Name                 string               `json:"name,omitempty" yaml:"name,omitempty"`
 	Channel              Channel              `json:"channel,omitempty" yaml:"channel,omitempty"`
 	CustomResourcePolicy CustomResourcePolicy `json:"customResourcePolicy,omitempty" yaml:"customResourcePolicy,omitempty"`
+}
+
+type AdditionalWorkerNodePool struct {
+	AutoScalerParameters `json:",inline"`
+
+	Name        string  `json:"name"`
+	MachineType *string `json:"machineType,omitempty"`
 }

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -295,6 +295,15 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 	if err := parameters.AutoScalerParameters.Validate(autoscalerMin, autoscalerMax); err != nil {
 		return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
 	}
+
+	if IsPreviewPlan(details.PlanID) {
+		for _, workerNodePool := range parameters.AdditionalWorkerNodePools {
+			if err := workerNodePool.AutoScalerParameters.Validate(autoscalerMin, autoscalerMax); err != nil {
+				return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
+			}
+		}
+	}
+
 	if parameters.OIDC.IsProvided() {
 		if err := parameters.OIDC.Validate(); err != nil {
 			return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -298,7 +298,7 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 
 	if IsPreviewPlan(details.PlanID) {
 		for _, workerNodePool := range parameters.AdditionalWorkerNodePools {
-			if err := workerNodePool.AutoScalerParameters.Validate(autoscalerMin, autoscalerMax); err != nil {
+			if err := workerNodePool.Validate(); err != nil {
 				return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
 			}
 		}

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -296,11 +296,9 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 		return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
 	}
 
-	if IsPreviewPlan(details.PlanID) {
-		for _, workerNodePool := range parameters.AdditionalWorkerNodePools {
-			if err := workerNodePool.Validate(); err != nil {
-				return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
-			}
+	if IsPreviewPlan(details.PlanID) && parameters.AdditionalWorkerNodePools.IsProvided() {
+		if err := parameters.AdditionalWorkerNodePools.Validate(); err != nil {
+			return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
 		}
 	}
 

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1491,165 +1491,109 @@ func TestProvision_Provision(t *testing.T) {
 		// then
 		require.EqualError(t, err, "while validating input parameters: region: region must be one of the following: \"me-central2\"")
 	})
+}
 
-	t.Run("Should pass with additional worker node pools", func(t *testing.T) {
-		// given
-		memoryStorage := storage.NewMemoryStorage()
+func TestAdditionalWorkerNodePools(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		additionalWorkerNodePools string
+		expectedError             bool
+	}{
+		"Valid additional worker node pools": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]`,
+			expectedError:             false,
+		},
+		"Empty additional worker node pools": {
+			additionalWorkerNodePools: "[]",
+			expectedError:             false,
+		},
+		"Empty name": {
+			additionalWorkerNodePools: `[{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing name": {
+			additionalWorkerNodePools: `[{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Empty machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMin": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMax bigger than 300": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMin bigger than autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
 
-		queue := &automock.Queue{}
-		queue.On("Add", mock.AnythingOfType("string"))
+			memoryStorage := storage.NewMemoryStorage()
 
-		factoryBuilder := &automock.PlanValidator{}
-		factoryBuilder.On("IsPlanSupport", broker.PreviewPlanID).Return(true)
+			queue := &automock.Queue{}
+			queue.On("Add", mock.AnythingOfType("string"))
 
-		planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
-			return &gqlschema.ClusterConfigInput{}, nil
-		}
-		kcBuilder := &kcMock.KcBuilder{}
-		kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
-		// #create provisioner endpoint
-		provisionEndpoint := broker.NewProvision(
-			broker.Config{
-				EnablePlans:              []string{"preview"},
-				URL:                      brokerURL,
-				OnlySingleTrialPerGA:     true,
-				EnableKubeconfigURLLabel: true,
-			},
-			gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
-			memoryStorage.Operations(),
-			memoryStorage.Instances(),
-			memoryStorage.InstancesArchived(),
-			queue,
-			factoryBuilder,
-			broker.PlansConfig{},
-			planDefaults,
-			log,
-			dashboardConfig,
-			kcBuilder,
-			whitelist.Set{},
-			&broker.OneForAllConvergedCloudRegionsProvider{},
-		)
+			factoryBuilder := &automock.PlanValidator{}
+			factoryBuilder.On("IsPlanSupport", broker.PreviewPlanID).Return(true)
 
-		additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+			// #create provisioner endpoint
+			provisionEndpoint := broker.NewProvision(
+				broker.Config{
+					EnablePlans:              []string{"preview"},
+					URL:                      brokerURL,
+					OnlySingleTrialPerGA:     true,
+					EnableKubeconfigURLLabel: true,
+				},
+				gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+				memoryStorage.Operations(),
+				memoryStorage.Instances(),
+				memoryStorage.InstancesArchived(),
+				queue,
+				factoryBuilder,
+				broker.PlansConfig{},
+				planDefaults,
+				log,
+				dashboardConfig,
+				kcBuilder,
+				whitelist.Set{},
+				&broker.OneForAllConvergedCloudRegionsProvider{},
+			)
 
-		// when
-		_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
-			ServiceID:     serviceID,
-			PlanID:        broker.PreviewPlanID,
-			RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),
-			RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
-		}, true)
-		t.Logf("%+v\n", *provisionEndpoint)
+			// when
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+				ServiceID:     serviceID,
+				PlanID:        broker.PreviewPlanID,
+				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", tc.additionalWorkerNodePools)),
+				RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
+			}, true)
+			t.Logf("%+v\n", *provisionEndpoint)
 
-		// then
-		require.NoError(t, err)
-	})
-
-	t.Run("Should pass with empty additional worker node pools", func(t *testing.T) {
-		// given
-		memoryStorage := storage.NewMemoryStorage()
-
-		queue := &automock.Queue{}
-		queue.On("Add", mock.AnythingOfType("string"))
-
-		factoryBuilder := &automock.PlanValidator{}
-		factoryBuilder.On("IsPlanSupport", broker.PreviewPlanID).Return(true)
-
-		planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
-			return &gqlschema.ClusterConfigInput{}, nil
-		}
-		kcBuilder := &kcMock.KcBuilder{}
-		kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
-		// #create provisioner endpoint
-		provisionEndpoint := broker.NewProvision(
-			broker.Config{
-				EnablePlans:              []string{"preview"},
-				URL:                      brokerURL,
-				OnlySingleTrialPerGA:     true,
-				EnableKubeconfigURLLabel: true,
-			},
-			gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
-			memoryStorage.Operations(),
-			memoryStorage.Instances(),
-			memoryStorage.InstancesArchived(),
-			queue,
-			factoryBuilder,
-			broker.PlansConfig{},
-			planDefaults,
-			log,
-			dashboardConfig,
-			kcBuilder,
-			whitelist.Set{},
-			&broker.OneForAllConvergedCloudRegionsProvider{},
-		)
-
-		additionalWorkerNodePools := "[]"
-
-		// when
-		_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
-			ServiceID:     serviceID,
-			PlanID:        broker.PreviewPlanID,
-			RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),
-			RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
-		}, true)
-		t.Logf("%+v\n", *provisionEndpoint)
-
-		// then
-		require.NoError(t, err)
-	})
-
-	t.Run("Should fail for autoScalerMin bigger than autoScalerMax", func(t *testing.T) {
-		// given
-		memoryStorage := storage.NewMemoryStorage()
-
-		queue := &automock.Queue{}
-		queue.On("Add", mock.AnythingOfType("string"))
-
-		factoryBuilder := &automock.PlanValidator{}
-		factoryBuilder.On("IsPlanSupport", broker.PreviewPlanID).Return(true)
-
-		planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
-			return &gqlschema.ClusterConfigInput{}, nil
-		}
-		kcBuilder := &kcMock.KcBuilder{}
-		kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
-		// #create provisioner endpoint
-		provisionEndpoint := broker.NewProvision(
-			broker.Config{
-				EnablePlans:              []string{"preview"},
-				URL:                      brokerURL,
-				OnlySingleTrialPerGA:     true,
-				EnableKubeconfigURLLabel: true,
-			},
-			gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
-			memoryStorage.Operations(),
-			memoryStorage.Instances(),
-			memoryStorage.InstancesArchived(),
-			queue,
-			factoryBuilder,
-			broker.PlansConfig{},
-			planDefaults,
-			log,
-			dashboardConfig,
-			kcBuilder,
-			whitelist.Set{},
-			&broker.OneForAllConvergedCloudRegionsProvider{},
-		)
-
-		additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
-
-		// when
-		_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
-			ServiceID:     serviceID,
-			PlanID:        broker.PreviewPlanID,
-			RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),
-			RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
-		}, true)
-		t.Logf("%+v\n", *provisionEndpoint)
-
-		// then
-		require.EqualError(t, err, "AutoScalerMax 3 should be larger than AutoScalerMin 20. User provided values min:20, max:3; plan defaults min:0, max:0")
-	})
+			// then
+			assert.Equal(t, tc.expectedError, err != nil)
+		})
+	}
 }
 
 func TestNetworkingValidation(t *testing.T) {

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1624,6 +1624,91 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 	}
 }
 
+func TestAdditionalWorkerNodePoolsForUnsupportedPlans(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		planID string
+	}{
+		"Trial": {
+			planID: broker.TrialPlanID,
+		},
+		"Free": {
+			planID: broker.FreemiumPlanID,
+		},
+		"Azure": {
+			planID: broker.AzurePlanID,
+		},
+		"Azure lite": {
+			planID: broker.AzureLitePlanID,
+		},
+		"AWS": {
+			planID: broker.AWSPlanID,
+		},
+		"GCP": {
+			planID: broker.GCPPlanID,
+		},
+		"SAP converged cloud": {
+			planID: broker.SapConvergedCloudPlanID,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
+
+			memoryStorage := storage.NewMemoryStorage()
+
+			queue := &automock.Queue{}
+			queue.On("Add", mock.AnythingOfType("string"))
+
+			factoryBuilder := &automock.PlanValidator{}
+			factoryBuilder.On("IsPlanSupport", tc.planID).Return(true)
+
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+			// #create provisioner endpoint
+			provisionEndpoint := broker.NewProvision(
+				broker.Config{
+					EnablePlans:              []string{"trial", "free", "azure", "azure_lite", "aws", "gcp", "sap-converged-cloud"},
+					URL:                      brokerURL,
+					OnlySingleTrialPerGA:     true,
+					EnableKubeconfigURLLabel: true,
+				},
+				gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+				memoryStorage.Operations(),
+				memoryStorage.Instances(),
+				memoryStorage.InstancesArchived(),
+				queue,
+				factoryBuilder,
+				broker.PlansConfig{},
+				planDefaults,
+				log,
+				dashboardConfig,
+				kcBuilder,
+				whitelist.Set{},
+				&broker.OneForAllConvergedCloudRegionsProvider{},
+			)
+
+			additionalWorkerNodePools := `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`
+
+			// when
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+				ServiceID:     serviceID,
+				PlanID:        tc.planID,
+				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),
+				RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
+			}, true)
+			t.Logf("%+v\n", *provisionEndpoint)
+
+			// then
+			assert.EqualError(t, err, fmt.Sprintf("additional worker node pools are not supported for plan ID: %s", tc.planID))
+		})
+	}
+}
+
 func TestNetworkingValidation(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		givenNetworking string

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1499,7 +1499,7 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 		expectedError             bool
 	}{
 		"Valid additional worker node pools": {
-			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             false,
 		},
 		"Empty additional worker node pools": {
@@ -1552,6 +1552,10 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 		},
 		"Missing autoScalerMax": {
 			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]}`,
+			expectedError:             true,
+		},
+		"AutoScalerMin smaller than 3": {
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 2, "autoScalerMax": 300}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMax bigger than 300": {

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1499,43 +1499,67 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 		expectedError             bool
 	}{
 		"Valid additional worker node pools": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
 			expectedError:             false,
 		},
 		"Empty additional worker node pools": {
-			additionalWorkerNodePools: "[]",
+			additionalWorkerNodePools: `{"list": []}`,
 			expectedError:             false,
 		},
+		"Sip set to false": {
+			additionalWorkerNodePools: `{"skipModification": false}`,
+			expectedError:             false,
+		},
+		"SkipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true}`,
+			expectedError:             false,
+		},
+		"Valid additional worker node pools and skipModification set to false": {
+			additionalWorkerNodePools: `{"skipModification": false, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			expectedError:             true,
+		},
+		"Valid additional worker node pools and skipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			expectedError:             true,
+		},
+		"Empty additional worker node pools and skipModification set to false": {
+			additionalWorkerNodePools: `{"skipModification": false, "list": []}`,
+			expectedError:             true,
+		},
+		"Empty additional worker node pools and skipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true, "list": []}`,
+			expectedError:             true,
+		},
 		"Empty name": {
-			additionalWorkerNodePools: `[{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing name": {
-			additionalWorkerNodePools: `[{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Empty machine type": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing machine type": {
-			additionalWorkerNodePools: `[{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing autoScalerMin": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]}`,
 			expectedError:             true,
 		},
 		"Missing autoScalerMax": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMax bigger than 300": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMin bigger than autoScalerMax": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]}`,
 			expectedError:             true,
 		},
 	} {

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -266,7 +266,7 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 
 	if IsPreviewPlan(details.PlanID) {
 		for _, workerNodePool := range params.AdditionalWorkerNodePools {
-			if err := workerNodePool.AutoScalerParameters.Validate(autoscalerMin, autoscalerMax); err != nil {
+			if err := workerNodePool.Validate(); err != nil {
 				return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 			}
 		}

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -264,7 +264,7 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 	}
 
-	if IsPreviewPlan(details.PlanID) {
+	if IsPreviewPlan(details.PlanID) && params.AdditionalWorkerNodePools.IsProvided() {
 		if err := params.AdditionalWorkerNodePools.Validate(); err != nil {
 			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 		}
@@ -295,16 +295,9 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		instance.Parameters.Parameters.MachineType = params.MachineType
 	}
 
-	if IsPreviewPlan(details.PlanID) {
-		if len(params.AdditionalWorkerNodePools.List) > 0 {
-			newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools.List))
-			newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools.List...)
-			instance.Parameters.Parameters.AdditionalWorkerNodePools = newAdditionalWorkerNodePools
-			updateStorage = append(updateStorage, "Additional Worker Node Pools")
-		} else if params.AdditionalWorkerNodePools.Remove {
-			instance.Parameters.Parameters.AdditionalWorkerNodePools = []pkg.AdditionalWorkerNodePool{}
-			updateStorage = append(updateStorage, "Additional Worker Node Pools")
-		}
+	if IsPreviewPlan(details.PlanID) && params.AdditionalWorkerNodePools.IsProvided() {
+		instance.Parameters.Parameters.AdditionalWorkerNodePools = params.AdditionalWorkerNodePools
+		updateStorage = append(updateStorage, "Additional Worker Node Pools")
 	}
 
 	if len(updateStorage) > 0 {

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -264,7 +264,10 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 	}
 
-	if IsPreviewPlan(details.PlanID) && params.AdditionalWorkerNodePools.IsProvided() {
+	if params.AdditionalWorkerNodePools.IsProvided() {
+		if !supportsAdditionalWorkers(details.PlanID) {
+			return domain.UpdateServiceSpec{}, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+		}
 		if err := params.AdditionalWorkerNodePools.Validate(); err != nil {
 			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 		}

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -265,10 +265,8 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	}
 
 	if IsPreviewPlan(details.PlanID) {
-		for _, workerNodePool := range params.AdditionalWorkerNodePools {
-			if err := workerNodePool.Validate(); err != nil {
-				return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
-			}
+		if err := params.AdditionalWorkerNodePools.Validate(); err != nil {
+			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 		}
 	}
 
@@ -298,10 +296,13 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	}
 
 	if IsPreviewPlan(details.PlanID) {
-		if params.AdditionalWorkerNodePools != nil {
-			newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools))
-			newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools...)
+		if len(params.AdditionalWorkerNodePools.List) > 0 {
+			newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools.List))
+			newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools.List...)
 			instance.Parameters.Parameters.AdditionalWorkerNodePools = newAdditionalWorkerNodePools
+			updateStorage = append(updateStorage, "Additional Worker Node Pools")
+		} else if params.AdditionalWorkerNodePools.Remove {
+			instance.Parameters.Parameters.AdditionalWorkerNodePools = []pkg.AdditionalWorkerNodePool{}
 			updateStorage = append(updateStorage, "Additional Worker Node Pools")
 		}
 	}

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -298,7 +298,6 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	}
 
 	if IsPreviewPlan(details.PlanID) {
-		// if the list is empty remove additional worker node pools
 		if params.AdditionalWorkerNodePools != nil {
 			newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools))
 			newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools...)

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -593,49 +593,73 @@ func TestUpdateEndpoint_UpdateParameters(t *testing.T) {
 	})
 }
 
-func TestAdditionalWorkerNodePools(t *testing.T) {
+func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		additionalWorkerNodePools string
 		expectedError             bool
 	}{
 		"Valid additional worker node pools": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
 			expectedError:             false,
 		},
 		"Empty additional worker node pools": {
-			additionalWorkerNodePools: "[]",
+			additionalWorkerNodePools: `{"list": []}`,
 			expectedError:             false,
 		},
+		"Remove set to false": {
+			additionalWorkerNodePools: `{"remove": false}`,
+			expectedError:             false,
+		},
+		"Remove set to true": {
+			additionalWorkerNodePools: `{"remove": true}`,
+			expectedError:             false,
+		},
+		"Valid additional worker node pools and remove set to false": {
+			additionalWorkerNodePools: `{"remove": false, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			expectedError:             true,
+		},
+		"Valid additional worker node pools and remove set to true": {
+			additionalWorkerNodePools: `{"remove": true, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			expectedError:             true,
+		},
+		"Empty additional worker node pools and remove set to false": {
+			additionalWorkerNodePools: `{"remove": false, "list": []}`,
+			expectedError:             true,
+		},
+		"Empty additional worker node pools and remove set to true": {
+			additionalWorkerNodePools: `{"remove": true, "list": []}`,
+			expectedError:             true,
+		},
 		"Empty name": {
-			additionalWorkerNodePools: `[{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing name": {
-			additionalWorkerNodePools: `[{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Empty machine type": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing machine type": {
-			additionalWorkerNodePools: `[{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             true,
 		},
 		"Missing autoScalerMin": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]}`,
 			expectedError:             true,
 		},
 		"Missing autoScalerMax": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMax bigger than 300": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMin bigger than autoScalerMax": {
-			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]}`,
 			expectedError:             true,
 		},
 	} {

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -599,7 +599,7 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 		expectedError             bool
 	}{
 		"Valid additional worker node pools": {
-			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]}`,
 			expectedError:             false,
 		},
 		"Empty additional worker node pools": {
@@ -652,6 +652,10 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 		},
 		"Missing autoScalerMax": {
 			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]}`,
+			expectedError:             true,
+		},
+		"AutoScalerMin smaller than 3": {
+			additionalWorkerNodePools: `{"list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 2, "autoScalerMax": 300}]}`,
 			expectedError:             true,
 		},
 		"AutoScalerMax bigger than 300": {

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -606,28 +606,28 @@ func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
 			additionalWorkerNodePools: `{"list": []}`,
 			expectedError:             false,
 		},
-		"Remove set to false": {
-			additionalWorkerNodePools: `{"remove": false}`,
+		"SkipModification set to false": {
+			additionalWorkerNodePools: `{"skipModification": false}`,
 			expectedError:             false,
 		},
-		"Remove set to true": {
-			additionalWorkerNodePools: `{"remove": true}`,
+		"SkipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true}`,
 			expectedError:             false,
 		},
-		"Valid additional worker node pools and remove set to false": {
-			additionalWorkerNodePools: `{"remove": false, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+		"Valid additional worker node pools and skipModification set to false": {
+			additionalWorkerNodePools: `{"skipModification": false, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
 			expectedError:             true,
 		},
-		"Valid additional worker node pools and remove set to true": {
-			additionalWorkerNodePools: `{"remove": true, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
+		"Valid additional worker node pools and skipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true, "list": [{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 0, "autoScalerMax": 0}]}`,
 			expectedError:             true,
 		},
-		"Empty additional worker node pools and remove set to false": {
-			additionalWorkerNodePools: `{"remove": false, "list": []}`,
+		"Empty additional worker node pools and skipModification set to false": {
+			additionalWorkerNodePools: `{"skipModification": false, "list": []}`,
 			expectedError:             true,
 		},
-		"Empty additional worker node pools and remove set to true": {
-			additionalWorkerNodePools: `{"remove": true, "list": []}`,
+		"Empty additional worker node pools and skipModification set to true": {
+			additionalWorkerNodePools: `{"skipModification": true, "list": []}`,
 			expectedError:             true,
 		},
 		"Empty name": {

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -368,7 +368,12 @@ func SapConvergedCloudSchema(machineTypesDisplay, regionsDisplay map[string]stri
 func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.Networking = NewNetworkingSchema()
-	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
+	if update {
+		properties.UpdateProperties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
+	} else {
+		additionalWorkerNodePoolsList := NewAdditionalWorkerNodePoolsList(machineTypesDisplay, machineTypes)
+		properties.AdditionalWorkerNodePools = &additionalWorkerNodePoolsList
+	}
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false)
 }
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -547,7 +547,7 @@ func Plans(plans PlansConfig, provider pkg.CloudProvider, includeAdditionalParam
 		FreemiumPlanID:   defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, azureRegionsDisplay, includeAdditionalParamsInSchema, true, euAccessRestricted)),
 		TrialPlanID:      defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
 		OwnClusterPlanID: defaultServicePlan(OwnClusterPlanID, OwnClusterPlanName, plans, ownClusterSchema, OwnClusterSchema(true)),
-		PreviewPlanID:    defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, previewCatalogSchema, AWSSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted, false)),
+		PreviewPlanID:    defaultServicePlan(PreviewPlanID, PreviewPlanName, plans, previewCatalogSchema, PreviewSchema(awsMachinesDisplay, awsRegionsDisplay, awsMachineNames, includeAdditionalParamsInSchema, true, euAccessRestricted)),
 	}
 
 	if len(sapConvergedCloudRegions) != 0 {

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -368,6 +368,7 @@ func SapConvergedCloudSchema(machineTypesDisplay, regionsDisplay map[string]stri
 func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.Networking = NewNetworkingSchema()
+	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false)
 }
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -368,12 +368,7 @@ func SapConvergedCloudSchema(machineTypesDisplay, regionsDisplay map[string]stri
 func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.Networking = NewNetworkingSchema()
-	if update {
-		properties.UpdateProperties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
-	} else {
-		additionalWorkerNodePoolsList := NewAdditionalWorkerNodePoolsList(machineTypesDisplay, machineTypes)
-		properties.AdditionalWorkerNodePools = &additionalWorkerNodePoolsList
-	}
+	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false)
 }
 

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -318,7 +318,7 @@ func NewProvisioningProperties(machineTypesDisplay, regionsDisplay map[string]st
 				Type:            "string",
 				Enum:            ToInterfaceSlice(machineTypes),
 				EnumDisplayName: machineTypesDisplay,
-				Description:     "Specifies the type of the machine.",
+				Description:     "Specifies the type of the virtual machine.",
 			},
 		},
 		Name: NameProperty(),
@@ -452,7 +452,7 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					MinLength:       1,
 					Enum:            ToInterfaceSlice(machineTypes),
 					EnumDisplayName: machineTypesDisplay,
-					Description:     "Specifies the type of the machine.",
+					Description:     "Specifies the type of the virtual machine.",
 				},
 				AutoScalerMin: Type{
 					Type:        "integer",

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -495,8 +495,10 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 							},
 							Properties: AdditionalWorkerNodePoolsListItemsProperties{
 								Name: Type{
-									Type:        "string",
-									MinLength:   1,
+									Type:      "string",
+									MinLength: 1,
+									// Allows for all alphanumeric characters and '-'
+									Pattern:     "^[a-zA-Z0-9-]*$",
 									Description: "Specifies the unique name of the additional worker node pool.",
 								},
 								MachineType: Type{

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -508,13 +508,15 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 								},
 								AutoScalerMin: Type{
 									Type:        "integer",
-									Minimum:     0,
+									Minimum:     3,
+									Default:     3,
 									Description: "Specifies the minimum number of virtual machines to create.",
 								},
 								AutoScalerMax: Type{
 									Type:        "integer",
-									Minimum:     0,
+									Minimum:     3,
 									Maximum:     300,
+									Default:     20,
 									Description: "Specifies the maximum number of virtual machines to create.",
 								},
 							},

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -33,12 +33,13 @@ type ProvisioningProperties struct {
 }
 
 type UpdateProperties struct {
-	Kubeconfig     *Type     `json:"kubeconfig,omitempty"`
-	AutoScalerMin  *Type     `json:"autoScalerMin,omitempty"`
-	AutoScalerMax  *Type     `json:"autoScalerMax,omitempty"`
-	OIDC           *OIDCType `json:"oidc,omitempty"`
-	Administrators *Type     `json:"administrators,omitempty"`
-	MachineType    *Type     `json:"machineType,omitempty"`
+	Kubeconfig                *Type                          `json:"kubeconfig,omitempty"`
+	AutoScalerMin             *Type                          `json:"autoScalerMin,omitempty"`
+	AutoScalerMax             *Type                          `json:"autoScalerMax,omitempty"`
+	OIDC                      *OIDCType                      `json:"oidc,omitempty"`
+	Administrators            *Type                          `json:"administrators,omitempty"`
+	MachineType               *Type                          `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools *AdditionalWorkerNodePoolsType `json:"additionalWorkerNodePools,omitempty"`
 }
 
 func (up *UpdateProperties) IncludeAdditional() {
@@ -145,6 +146,25 @@ type ModulesCustomListItemsProperties struct {
 	Name                 Type `json:"name,omitempty"`
 	Channel              Type `json:"channel,omitempty"`
 	CustomResourcePolicy Type `json:"customResourcePolicy,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsType struct {
+	Type
+	Items AdditionalWorkerNodePoolsItems `json:"items,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsItems struct {
+	Type
+	ControlsOrder []string                                 `json:"_controlsOrder,omitempty"`
+	Required      []string                                 `json:"required"`
+	Properties    AdditionalWorkerNodePoolsItemsProperties `json:"properties,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsItemsProperties struct {
+	Name          Type `json:"name,omitempty"`
+	AutoScalerMin Type `json:"autoScalerMin,omitempty"`
+	AutoScalerMax Type `json:"autoScalerMax,omitempty"`
+	MachineType   Type `json:"machineType,omitempty"`
 }
 
 func NewModulesSchema() *Modules {
@@ -298,6 +318,7 @@ func NewProvisioningProperties(machineTypesDisplay, regionsDisplay map[string]st
 				Type:            "string",
 				Enum:            ToInterfaceSlice(machineTypes),
 				EnumDisplayName: machineTypesDisplay,
+				Description:     "Specifies the type of the machine.",
 			},
 		},
 		Name: NameProperty(),
@@ -386,7 +407,7 @@ func unmarshalOrPanic(from, to interface{}) interface{} {
 }
 
 func DefaultControlsOrder() []string {
-	return []string{"name", "kubeconfig", "shootName", "shootDomain", "region", "shootAndSeedSameRegion", "machineType", "autoScalerMin", "autoScalerMax", "zonesCount", "modules", "networking", "oidc", "administrators"}
+	return []string{"name", "kubeconfig", "shootName", "shootDomain", "region", "shootAndSeedSameRegion", "machineType", "autoScalerMin", "autoScalerMax", "additionalWorkerNodePools", "zonesCount", "modules", "networking", "oidc", "administrators"}
 }
 
 func ToInterfaceSlice(input []string) []interface{} {
@@ -404,6 +425,47 @@ func AdministratorsProperty() *Type {
 		Description: "Specifies the list of runtime administrators",
 		Items: &Type{
 			Type: "string",
+		},
+	}
+}
+
+func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, machineTypes []string) *AdditionalWorkerNodePoolsType {
+	return &AdditionalWorkerNodePoolsType{
+		Type: Type{
+			Type:        "array",
+			UniqueItems: true,
+			Description: "Specifies the list of additional worker node pools."},
+		Items: AdditionalWorkerNodePoolsItems{
+			ControlsOrder: []string{"name", "machineType", "autoScalerMin", "autoScalerMax"},
+			Required:      []string{"name", "machineType", "autoScalerMin", "autoScalerMax"},
+			Type: Type{
+				Type: "object",
+			},
+			Properties: AdditionalWorkerNodePoolsItemsProperties{
+				Name: Type{
+					Type:        "string",
+					MinLength:   1,
+					Description: "Specifies the unique name of the additional worker node pool.",
+				},
+				MachineType: Type{
+					Type:            "string",
+					MinLength:       1,
+					Enum:            ToInterfaceSlice(machineTypes),
+					EnumDisplayName: machineTypesDisplay,
+					Description:     "Specifies the type of the machine.",
+				},
+				AutoScalerMin: Type{
+					Type:        "integer",
+					Minimum:     0,
+					Description: "Specifies the minimum number of virtual machines to create.",
+				},
+				AutoScalerMax: Type{
+					Type:        "integer",
+					Minimum:     0,
+					Maximum:     300,
+					Description: "Specifies the maximum number of virtual machines to create.",
+				},
+			},
 		},
 	}
 }

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -50,6 +50,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -50,7 +50,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -50,6 +50,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -50,7 +50,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -39,7 +39,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -39,6 +39,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -39,7 +39,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -39,6 +39,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -43,6 +43,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -43,7 +43,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -33,6 +33,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -33,7 +33,7 @@
         "m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -39,6 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -39,7 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -41,6 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -41,7 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -39,6 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -39,7 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -41,6 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -41,7 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -29,7 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -29,6 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -30,6 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -30,7 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -29,7 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -29,6 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -30,6 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -30,7 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -51,7 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -51,6 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -51,7 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -51,6 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -40,6 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -40,7 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -40,6 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -40,7 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -33,7 +33,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -33,6 +33,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -34,6 +34,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -34,7 +34,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -23,6 +23,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -23,7 +23,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -24,7 +24,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -24,6 +24,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -44,6 +44,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -44,7 +44,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -34,7 +34,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -34,6 +34,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -44,6 +44,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -44,7 +44,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -44,6 +44,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -44,7 +44,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -33,7 +33,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -33,6 +33,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -33,7 +33,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -33,6 +33,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -37,6 +37,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -37,7 +37,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -27,7 +27,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -27,6 +27,7 @@
         "n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
         "n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -46,6 +46,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -46,7 +46,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -35,6 +35,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -35,7 +35,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -39,7 +39,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -39,6 +39,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -29,6 +29,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -29,7 +29,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the machine.",
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/dto.go
+++ b/internal/dto.go
@@ -52,9 +52,10 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 type UpdatingParametersDTO struct {
 	pkg.AutoScalerParameters `json:",inline"`
 
-	OIDC                  *pkg.OIDCConfigDTO `json:"oidc,omitempty"`
-	RuntimeAdministrators []string           `json:"administrators,omitempty"`
-	MachineType           *string            `json:"machineType,omitempty"`
+	OIDC                      *pkg.OIDCConfigDTO             `json:"oidc,omitempty"`
+	RuntimeAdministrators     []string                       `json:"administrators,omitempty"`
+	MachineType               *string                        `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools []pkg.AdditionalWorkerNodePool `json:"additionalWorkerNodePools"`
 }
 
 func (u UpdatingParametersDTO) UpdateAutoScaler(p *pkg.ProvisioningParametersDTO) bool {

--- a/internal/dto.go
+++ b/internal/dto.go
@@ -52,10 +52,10 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 type UpdatingParametersDTO struct {
 	pkg.AutoScalerParameters `json:",inline"`
 
-	OIDC                      *pkg.OIDCConfigDTO             `json:"oidc,omitempty"`
-	RuntimeAdministrators     []string                       `json:"administrators,omitempty"`
-	MachineType               *string                        `json:"machineType,omitempty"`
-	AdditionalWorkerNodePools []pkg.AdditionalWorkerNodePool `json:"additionalWorkerNodePools"`
+	OIDC                      *pkg.OIDCConfigDTO            `json:"oidc,omitempty"`
+	RuntimeAdministrators     []string                      `json:"administrators,omitempty"`
+	MachineType               *string                       `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools pkg.AdditionalWorkerNodePools `json:"additionalWorkerNodePools"`
 }
 
 func (u UpdatingParametersDTO) UpdateAutoScaler(p *pkg.ProvisioningParametersDTO) bool {

--- a/internal/dto.go
+++ b/internal/dto.go
@@ -52,10 +52,10 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 type UpdatingParametersDTO struct {
 	pkg.AutoScalerParameters `json:",inline"`
 
-	OIDC                      *pkg.OIDCConfigDTO            `json:"oidc,omitempty"`
-	RuntimeAdministrators     []string                      `json:"administrators,omitempty"`
-	MachineType               *string                       `json:"machineType,omitempty"`
-	AdditionalWorkerNodePools pkg.AdditionalWorkerNodePools `json:"additionalWorkerNodePools"`
+	OIDC                      *pkg.OIDCConfigDTO             `json:"oidc,omitempty"`
+	RuntimeAdministrators     []string                       `json:"administrators,omitempty"`
+	MachineType               *string                        `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools *pkg.AdditionalWorkerNodePools `json:"additionalWorkerNodePools,omitempty"`
 }
 
 func (u UpdatingParametersDTO) UpdateAutoScaler(p *pkg.ProvisioningParametersDTO) bool {

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -250,11 +250,11 @@ func (s *CreateRuntimeResourceStep) createShootProvider(operation *internal.Oper
 		}
 	}
 
-	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID && len(operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools) > 0 {
+	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID && operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.IsProvided() {
 		additionalWorkerNodePoolsMaxSurge := intstr.FromInt32(int32(values.ZonesCount))
 		additionalWorkerNodePoolsMaxUnavailable := intstr.FromInt32(int32(0))
-		workers := make([]gardener.Worker, 0, len(operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools))
-		for _, additionalWorkerNodePool := range operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools {
+		workers := make([]gardener.Worker, 0, len(operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.List))
+		for _, additionalWorkerNodePool := range operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.List {
 			worker := gardener.Worker{
 				Name: additionalWorkerNodePool.Name,
 				Machine: gardener.Machine{

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -250,7 +250,7 @@ func (s *CreateRuntimeResourceStep) createShootProvider(operation *internal.Oper
 		}
 	}
 
-	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID && operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.IsProvided() {
+	if operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.IsProvided() {
 		additionalWorkerNodePoolsMaxSurge := intstr.FromInt32(int32(values.ZonesCount))
 		additionalWorkerNodePoolsMaxUnavailable := intstr.FromInt32(int32(0))
 		workers := make([]gardener.Worker, 0, len(operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools.List))

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -10,7 +10,6 @@ import (
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal"
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/process/input"
@@ -70,7 +69,7 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 	maxUnavailable := intstr.FromInt32(int32(provisioning.DefaultIfParamNotSet(runtime.Spec.Shoot.Provider.Workers[0].MaxUnavailable.IntValue(), operation.UpdatingParameters.MaxUnavailable)))
 	runtime.Spec.Shoot.Provider.Workers[0].MaxUnavailable = &maxUnavailable
 
-	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID && operation.UpdatingParameters.AdditionalWorkerNodePools.IsProvided() {
+	if operation.UpdatingParameters.AdditionalWorkerNodePools.IsProvided() {
 		values, err := provider.GetPlanSpecificValues(&operation, s.config.MultiZoneCluster, s.config.DefaultTrialProvider, s.useSmallerMachineTypes, s.trialPlatformRegionMapping, s.config.DefaultGardenerShootPurpose)
 		if err != nil {
 			return s.operationManager.OperationFailed(operation, fmt.Sprintf("while calculating plan specific values: %s", err), err, log)

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -70,44 +70,40 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 	maxUnavailable := intstr.FromInt32(int32(provisioning.DefaultIfParamNotSet(runtime.Spec.Shoot.Provider.Workers[0].MaxUnavailable.IntValue(), operation.UpdatingParameters.MaxUnavailable)))
 	runtime.Spec.Shoot.Provider.Workers[0].MaxUnavailable = &maxUnavailable
 
-	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID {
-		if len(operation.UpdatingParameters.AdditionalWorkerNodePools.List) > 0 {
-			values, err := provider.GetPlanSpecificValues(&operation, s.config.MultiZoneCluster, s.config.DefaultTrialProvider, s.useSmallerMachineTypes, s.trialPlatformRegionMapping, s.config.DefaultGardenerShootPurpose)
-			if err != nil {
-				return s.operationManager.OperationFailed(operation, fmt.Sprintf("while calculating plan specific values: %s", err), err, log)
-			}
-			additionalWorkerNodePoolsMaxSurge := intstr.FromInt32(int32(values.ZonesCount))
-			additionalWorkerNodePoolsMaxUnavailable := intstr.FromInt32(int32(0))
-			workers := make([]gardener.Worker, 0, len(operation.UpdatingParameters.AdditionalWorkerNodePools.List))
-			for _, additionalWorkerNodePool := range operation.UpdatingParameters.AdditionalWorkerNodePools.List {
-				worker := gardener.Worker{
-					Name: additionalWorkerNodePool.Name,
-					Machine: gardener.Machine{
-						Type: additionalWorkerNodePool.MachineType,
-						Image: &gardener.ShootMachineImage{
-							Name:    s.config.MachineImage,
-							Version: &s.config.MachineImageVersion,
-						},
-					},
-					Maximum:        int32(additionalWorkerNodePool.AutoScalerMax),
-					Minimum:        int32(additionalWorkerNodePool.AutoScalerMin),
-					MaxSurge:       &additionalWorkerNodePoolsMaxSurge,
-					MaxUnavailable: &additionalWorkerNodePoolsMaxUnavailable,
-					Zones:          values.Zones,
-				}
-				if values.ProviderType != "openstack" {
-					volumeSize := strconv.Itoa(values.VolumeSizeGb)
-					worker.Volume = &gardener.Volume{
-						Type:       ptr.String(values.DiskType),
-						VolumeSize: fmt.Sprintf("%sGi", volumeSize),
-					}
-				}
-				workers = append(workers, worker)
-			}
-			//runtime.Spec.Shoot.Provider.AdditionalWorkers = workers
-		} else if operation.UpdatingParameters.AdditionalWorkerNodePools.Remove {
-			//runtime.Spec.Shoot.Provider.AdditionalWorkers = []gardener.Worker{}
+	if operation.ProvisioningParameters.PlanID == broker.PreviewPlanID && operation.UpdatingParameters.AdditionalWorkerNodePools.IsProvided() {
+		values, err := provider.GetPlanSpecificValues(&operation, s.config.MultiZoneCluster, s.config.DefaultTrialProvider, s.useSmallerMachineTypes, s.trialPlatformRegionMapping, s.config.DefaultGardenerShootPurpose)
+		if err != nil {
+			return s.operationManager.OperationFailed(operation, fmt.Sprintf("while calculating plan specific values: %s", err), err, log)
 		}
+		additionalWorkerNodePoolsMaxSurge := intstr.FromInt32(int32(values.ZonesCount))
+		additionalWorkerNodePoolsMaxUnavailable := intstr.FromInt32(int32(0))
+		workers := make([]gardener.Worker, 0, len(operation.UpdatingParameters.AdditionalWorkerNodePools.List))
+		for _, additionalWorkerNodePool := range operation.UpdatingParameters.AdditionalWorkerNodePools.List {
+			worker := gardener.Worker{
+				Name: additionalWorkerNodePool.Name,
+				Machine: gardener.Machine{
+					Type: additionalWorkerNodePool.MachineType,
+					Image: &gardener.ShootMachineImage{
+						Name:    s.config.MachineImage,
+						Version: &s.config.MachineImageVersion,
+					},
+				},
+				Maximum:        int32(additionalWorkerNodePool.AutoScalerMax),
+				Minimum:        int32(additionalWorkerNodePool.AutoScalerMin),
+				MaxSurge:       &additionalWorkerNodePoolsMaxSurge,
+				MaxUnavailable: &additionalWorkerNodePoolsMaxUnavailable,
+				Zones:          values.Zones,
+			}
+			if values.ProviderType != "openstack" {
+				volumeSize := strconv.Itoa(values.VolumeSizeGb)
+				worker.Volume = &gardener.Volume{
+					Type:       ptr.String(values.DiskType),
+					VolumeSize: fmt.Sprintf("%sGi", volumeSize),
+				}
+			}
+			workers = append(workers, worker)
+		}
+		//runtime.Spec.Shoot.Provider.AdditionalWorkers = workers
 	}
 
 	if operation.UpdatingParameters.OIDC != nil {

--- a/internal/process/update/update_runtime_step_test.go
+++ b/internal/process/update/update_runtime_step_test.go
@@ -15,6 +15,7 @@ import (
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/kyma-environment-broker/internal/process/input"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +31,7 @@ func TestUpdateRuntimeStep_NoRuntime(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	kcpClient := fake.NewClientBuilder().Build()
-	step := NewUpdateRuntimeStep(nil, kcpClient, 0)
+	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{}, false, nil)
 	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
 	operation.RuntimeResourceName = "runtime-name"
 	operation.KymaResourceNamespace = "kyma-ns"
@@ -48,7 +49,7 @@ func TestUpdateRuntimeStep_RunUpdateMachineType(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource("runtime-name", false)).Build()
-	step := NewUpdateRuntimeStep(nil, kcpClient, 0)
+	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{}, false, nil)
 	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
 	operation.RuntimeResourceName = "runtime-name"
 	operation.KymaResourceNamespace = "kcp-system"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- extend schema with machine type description,
- extend schema with `additionalWorkerNodePools` on `preview` plan,
- handle `additionalWorkerNodePools` in create and update endpoints,
- update runtime resource with additional `additionalWorkers`.

**Related issue(s)**
See also #952
