### PR TITLE
Revert "Enable current configuration load (#1595)"

### DIFF
--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -18,8 +18,6 @@ type RootSchema struct {
 	ShowFormView bool `json:"_show_form_view"`
 	// Specifies in what order properties will be displayed on the form
 	ControlsOrder []string `json:"_controlsOrder"`
-	// Specified to true loads current instance configuration into the update instance schema
-	LoadCurrentConfig bool `json:"_load_current_config"`
 }
 
 type ProvisioningProperties struct {
@@ -364,10 +362,9 @@ func NewSchema(properties interface{}, update bool, required []string) *RootSche
 		Type: Type{
 			Type: "object",
 		},
-		Properties:        properties,
-		ShowFormView:      true,
-		Required:          required,
-		LoadCurrentConfig: true,
+		Properties:   properties,
+		ShowFormView: true,
+		Required:     required,
 	}
 
 	if update {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/aws/free-aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/free-aws-schema-additional-params-eu.json
@@ -8,7 +8,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/aws/free-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/free-aws-schema-additional-params.json
@@ -8,7 +8,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/aws/free-aws-schema-eu.json
+++ b/internal/broker/testdata/aws/free-aws-schema-eu.json
@@ -6,7 +6,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "modules": {

--- a/internal/broker/testdata/aws/free-aws-schema.json
+++ b/internal/broker/testdata/aws/free-aws-schema.json
@@ -6,7 +6,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "modules": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-free-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-free-aws-schema-additional-params.json
@@ -4,7 +4,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -11,7 +11,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -11,7 +11,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-trial-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-trial-schema-additional-params.json
@@ -6,7 +6,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/azure-trial-schema.json
+++ b/internal/broker/testdata/azure/azure-trial-schema.json
@@ -4,7 +4,6 @@
     "name",
     "modules"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "modules": {

--- a/internal/broker/testdata/azure/free-azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/free-azure-schema-additional-params-eu.json
@@ -8,7 +8,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/free-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/free-azure-schema-additional-params.json
@@ -8,7 +8,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/free-azure-schema-eu.json
+++ b/internal/broker/testdata/azure/free-azure-schema-eu.json
@@ -6,7 +6,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "modules": {

--- a/internal/broker/testdata/azure/free-azure-schema.json
+++ b/internal/broker/testdata/azure/free-azure-schema.json
@@ -6,7 +6,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "modules": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-trial-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-trial-schema-additional-params.json
@@ -4,7 +4,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/azure/update-free-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-free-azure-schema-additional-params.json
@@ -4,7 +4,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/own-cluster-schema-additional-params.json
+++ b/internal/broker/testdata/own-cluster-schema-additional-params.json
@@ -7,7 +7,6 @@
     "shootDomain",
     "modules"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "kubeconfig": {

--- a/internal/broker/testdata/own-cluster-schema.json
+++ b/internal/broker/testdata/own-cluster-schema.json
@@ -7,7 +7,6 @@
     "shootDomain",
     "modules"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "kubeconfig": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -12,7 +12,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -9,7 +9,6 @@
     "modules",
     "networking"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -7,7 +7,6 @@
     "oidc",
     "administrators"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "administrators": {

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -5,7 +5,6 @@
     "autoScalerMin",
     "autoScalerMax"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "autoScalerMax": {

--- a/internal/broker/testdata/update-own-cluster-schema-additional-params.json
+++ b/internal/broker/testdata/update-own-cluster-schema-additional-params.json
@@ -3,7 +3,6 @@
   "_controlsOrder": [
     "kubeconfig"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "kubeconfig": {

--- a/internal/broker/testdata/update-own-cluster-schema.json
+++ b/internal/broker/testdata/update-own-cluster-schema.json
@@ -3,7 +3,6 @@
   "_controlsOrder": [
     "kubeconfig"
   ],
-  "_load_current_config": true,
   "_show_form_view": true,
   "properties": {
     "kubeconfig": {


### PR DESCRIPTION
This reverts commit 3264bc90ae3f32421f36701407e8ce5fdad4188a, `_load_current_config` loads last applied configuration, not current instance configuration.

**Related issue(s)**
See also #952
