### PR TITLE
Logging Worker Execution Times Only if Limit Exceeded

### DIFF
--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -1,7 +1,6 @@
 package process
 
 import (
-	"bytes"
 	"fmt"
 	"log/slog"
 	"runtime/debug"

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -115,6 +115,7 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 
 				defer func() {
 					if err := recover(); err != nil {
+						q.removeTimeIfInWarnMargin(id, workerNameId, log)
 						log.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					queue.Done(key)
@@ -170,16 +171,6 @@ func (q *Queue) removeTimeIfInWarnMargin(key string, workerNameId string, log *s
 
 func (q *Queue) logWorkersSummary() {
 	healthCheckLog := q.log.With("summary", q.name)
-	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("health - queue length %d", q.queue.Len()))
-
-	for name, lastTime := range q.workerExecutionTimes {
-		timeSinceLastExecution := time.Since(lastTime)
-
-		buffer.WriteString(fmt.Sprintf(", [worker %s, last execution time: %s, since last execution: %s]", name, lastTime, timeSinceLastExecution))
-	}
-
-	healthCheckLog.Info(buffer.String())
 
 	for name, lastTime := range q.workerExecutionTimes {
 		timeSinceLastExecution := time.Since(lastTime)

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -114,9 +114,9 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 
 				defer func() {
 					if err := recover(); err != nil {
-						q.removeTimeIfInWarnMargin(id, workerNameId, log)
 						log.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
+					q.removeTimeIfInWarnMargin(id, workerNameId, log)
 					queue.Done(key)
 					log.Info("queue done processing")
 				}()
@@ -126,14 +126,12 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 					log.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
 					afterDuration := time.Duration(int64(when) / q.speedFactor)
 					queue.AddAfter(key, afterDuration)
-					q.removeTimeIfInWarnMargin(id, workerNameId, log)
 					return false
 				}
 				if err != nil {
 					log.Error(fmt.Sprintf("Error from process: %v", err))
 				}
 
-				q.removeTimeIfInWarnMargin(id, workerNameId, log)
 				queue.Forget(key)
 				log.Info(fmt.Sprintf("item for %s has been processed, no retry, element forgotten", id))
 

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -23,7 +23,7 @@ type Queue struct {
 	log                     *slog.Logger
 	name                    string
 	workerExecutionTimes    map[string]time.Time
-	workerLastKeys		    map[string]string
+	workerLastKeys          map[string]string
 	warnAfterTime           time.Duration
 	healthCheckIntervalTime time.Duration
 
@@ -40,7 +40,7 @@ func NewQueue(executor Executor, log *slog.Logger, name string, warnAfterTime, h
 		speedFactor:             1,
 		name:                    name,
 		workerExecutionTimes:    make(map[string]time.Time),
-		workerLastKeys:   		 make(map[string]string),
+		workerLastKeys:          make(map[string]string),
 		warnAfterTime:           warnAfterTime,
 		healthCheckIntervalTime: healthCheckIntervalTime,
 	}
@@ -155,7 +155,7 @@ func (q *Queue) removeTimeIfInWarnMargin(key string, workerNameId string, log *s
 
 	if !ok {
 		log.Warn(fmt.Sprintf("worker %s has no start time", workerNameId))
-		return		
+		return
 	}
 
 	processingTime := time.Since(processingStart)
@@ -164,8 +164,8 @@ func (q *Queue) removeTimeIfInWarnMargin(key string, workerNameId string, log *s
 		log.Info(fmt.Sprintf("worker %s exceeded allowed limit of %s since last execution while processing %s", workerNameId, q.warnAfterTime, key))
 	}
 
-	delete(q.workerExecutionTimes, workerNameId)	
-	delete(q.workerLastKeys, workerNameId)	
+	delete(q.workerExecutionTimes, workerNameId)
+	delete(q.workerLastKeys, workerNameId)
 }
 
 func (q *Queue) logWorkersSummary() {

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -23,6 +23,7 @@ type Queue struct {
 	log                     *slog.Logger
 	name                    string
 	workerExecutionTimes    map[string]time.Time
+	workerLastKeys		    map[string]string
 	warnAfterTime           time.Duration
 	healthCheckIntervalTime time.Duration
 
@@ -39,6 +40,7 @@ func NewQueue(executor Executor, log *slog.Logger, name string, warnAfterTime, h
 		speedFactor:             1,
 		name:                    name,
 		workerExecutionTimes:    make(map[string]time.Time),
+		workerLastKeys:   		 make(map[string]string),
 		warnAfterTime:           warnAfterTime,
 		healthCheckIntervalTime: healthCheckIntervalTime,
 	}
@@ -95,7 +97,7 @@ func (q *Queue) createWorker(queue workqueue.RateLimitingInterface, process func
 	}()
 }
 
-func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key string) (time.Duration, error), log *slog.Logger, nameId string) func() {
+func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key string) (time.Duration, error), log *slog.Logger, workerNameId string) func() {
 	return func() {
 		exit := false
 		for !exit {
@@ -109,7 +111,7 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 				id := key.(string)
 				log = log.With("operationID", id)
 				log.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
-				q.logAndUpdateWorkerTimes(key.(string), nameId, log)
+				q.updateWorkerTime(id, workerNameId, log)
 
 				defer func() {
 					if err := recover(); err != nil {
@@ -124,12 +126,14 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 					log.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
 					afterDuration := time.Duration(int64(when) / q.speedFactor)
 					queue.AddAfter(key, afterDuration)
+					q.removeTimeIfInWarnMargin(id, workerNameId, log)
 					return false
 				}
 				if err != nil {
 					log.Error(fmt.Sprintf("Error from process: %v", err))
 				}
 
+				q.removeTimeIfInWarnMargin(id, workerNameId, log)
 				queue.Forget(key)
 				log.Info(fmt.Sprintf("item for %s has been processed, no retry, element forgotten", id))
 
@@ -139,16 +143,29 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 	}
 }
 
-func (q *Queue) logAndUpdateWorkerTimes(key string, name string, log *slog.Logger) {
-	// log time
-	now := time.Now()
-	lastTime, ok := q.workerExecutionTimes[name]
-	if ok {
-		log.Info(fmt.Sprintf("execution - worker %s last execution time %s, executed after %s", name, lastTime, now.Sub(lastTime)))
-	}
-	q.workerExecutionTimes[name] = now
+func (q *Queue) updateWorkerTime(key string, workerNameId string, log *slog.Logger) {
+	q.workerExecutionTimes[workerNameId] = time.Now()
+	q.workerLastKeys[workerNameId] = key
+	log.Info(fmt.Sprintf("updating worker time, processing item %s, queue length is %d", key, q.queue.Len()))
+}
 
-	log.Info(fmt.Sprintf("processing item %s, queue length is %d", key, q.queue.Len()))
+func (q *Queue) removeTimeIfInWarnMargin(key string, workerNameId string, log *slog.Logger) {
+
+	processingStart, ok := q.workerExecutionTimes[workerNameId]
+
+	if !ok {
+		log.Warn(fmt.Sprintf("worker %s has no start time", workerNameId))
+		return		
+	}
+
+	processingTime := time.Since(processingStart)
+
+	if processingTime > q.warnAfterTime {
+		log.Info(fmt.Sprintf("worker %s exceeded allowed limit of %s since last execution while processing %s", workerNameId, q.warnAfterTime, key))
+	}
+
+	delete(q.workerExecutionTimes, workerNameId)	
+	delete(q.workerLastKeys, workerNameId)	
 }
 
 func (q *Queue) logWorkersSummary() {
@@ -166,8 +183,13 @@ func (q *Queue) logWorkersSummary() {
 
 	for name, lastTime := range q.workerExecutionTimes {
 		timeSinceLastExecution := time.Since(lastTime)
+		lastItemKey, ok := q.workerLastKeys[name]
+		if !ok {
+			lastItemKey = "'already removed'"
+		}
+
 		if timeSinceLastExecution > q.warnAfterTime {
-			healthCheckLog.Info(fmt.Sprintf("worker %s exceeded allowed limit of %s since last execution, its last execution is %s, time since last execution %s", name, q.warnAfterTime, lastTime, timeSinceLastExecution))
+			healthCheckLog.Info(fmt.Sprintf("worker %s exceeded allowed limit of %s since last execution, its last execution is %s, time since last execution %s, while processing item %s", name, q.warnAfterTime, lastTime, timeSinceLastExecution, lastItemKey))
 		}
 	}
 }

--- a/internal/process/queue_test.go
+++ b/internal/process/queue_test.go
@@ -57,8 +57,8 @@ func TestWorkerLogging(t *testing.T) {
 		require.True(t, strings.Contains(stringLogs, "msg=\"starting worker with id 0\" queueName=test workerId=0"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"item processId2 will be added to the queue test after duration of 0, queue length is 1\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"added item processId to the queue test, queue length is 2\" queueName=test"))
-		require.True(t, strings.Contains(stringLogs, "msg=\"processing item processId2, queue length is 1\" queueName=test workerId=0 operationID=processId2"))
-		require.True(t, strings.Contains(stringLogs, "msg=\"processing item processId, queue length is 0\" queueName=test workerId=0 operationID=processId"))
+		require.True(t, strings.Contains(stringLogs, "msg=\"updating worker time, processing item processId2, queue length is 1\" queueName=test workerId=0 operationID=processId2"))
+		require.True(t, strings.Contains(stringLogs, "msg=\"updating worker time, processing item processId, queue length is 0\" queueName=test workerId=0 operationID=processId"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"shutting down the queue, queue length is 0\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"queue speed factor set to 1\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"worker routine - starting\" queueName=test workerId=0"))
@@ -66,8 +66,6 @@ func TestWorkerLogging(t *testing.T) {
 		require.True(t, strings.Contains(stringLogs, "msg=\"shutting down\" queueName=test workerId=0 operationID=processId"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"item for processId has been processed, no retry, element forgotten\" queueName=test workerId=0 operationID=processId"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"about to process item processId, queue length is 0\" queueName=test workerId=0 operationID=processId"))
-		require.True(t, strings.Contains(stringLogs, "msg=\"execution - worker test-0 last execution time"))
-		require.True(t, strings.Contains(stringLogs, "executed after"))
 	})
 
 }


### PR DESCRIPTION
Removing execution time for given worker in removeTimeIfInWarnMargin function to track only workers that exceed allowed margin time. Added additional workerLastKeys map to keep worker keys for logging in worker summary go routine.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

* Removing execution time for given worker in removeTimeIfInWarnMargin function to track only workers that exceed allowed margin time.
* Added additional workerLastKeys map to keep worker keys for logging in worker summary go routine.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#1473
