### PR TITLE
Fix -H using full path instead only of branch name in promote workflow

### DIFF
--- a/.github/workflows/promote-keb-to-dev.yaml
+++ b/.github/workflows/promote-keb-to-dev.yaml
@@ -120,4 +120,4 @@ jobs:
               echo "PR already exists, no need to create new one"
               exit 0
           fi
-          gh pr create -B chart/keb-sap -H https://${{ vars.GH_TOOLS_HOST }}/kyma/${{ vars.MP_CHARTS_REPO_NAME }}:${BRANCH_NAME} -R https://${{ vars.GH_TOOLS_HOST }}/kyma/${{ vars.MP_CHARTS_REPO_NAME }}/ --title "Bump keb to ${TAG}" --fill --body "${{env.KEB_RELEASES_URL }}/${TAG}"
+          gh pr create -B chart/keb-sap -H ${BRANCH_NAME} -R https://${{ vars.GH_TOOLS_HOST }}/kyma/${{ vars.MP_CHARTS_REPO_NAME }}/ --title "Bump keb to ${TAG}" --fill --body "${{env.KEB_RELEASES_URL }}/${TAG}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- only branch name should be used in -H

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
