### PR TITLE
Additional worker node pools schema on Preview

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -97,10 +97,11 @@ type ProvisioningParametersDTO struct {
 	ShootName   string `json:"shootName,omitempty"`
 	ShootDomain string `json:"shootDomain,omitempty"`
 
-	OIDC                   *OIDCConfigDTO `json:"oidc,omitempty"`
-	Networking             *NetworkingDTO `json:"networking,omitempty"`
-	Modules                *ModulesDTO    `json:"modules,omitempty"`
-	ShootAndSeedSameRegion *bool          `json:"shootAndSeedSameRegion,omitempty"`
+	OIDC                      *OIDCConfigDTO             `json:"oidc,omitempty"`
+	Networking                *NetworkingDTO             `json:"networking,omitempty"`
+	Modules                   *ModulesDTO                `json:"modules,omitempty"`
+	ShootAndSeedSameRegion    *bool                      `json:"shootAndSeedSameRegion,omitempty"`
+	AdditionalWorkerNodePools []AdditionalWorkerNodePool `json:"additionalWorkerNodePools,omitempty"`
 }
 
 type AutoScalerParameters struct {
@@ -385,4 +386,18 @@ type ModuleDTO struct {
 	Name                 string               `json:"name,omitempty" yaml:"name,omitempty"`
 	Channel              Channel              `json:"channel,omitempty" yaml:"channel,omitempty"`
 	CustomResourcePolicy CustomResourcePolicy `json:"customResourcePolicy,omitempty" yaml:"customResourcePolicy,omitempty"`
+}
+
+type AdditionalWorkerNodePool struct {
+	Name          string `json:"name"`
+	MachineType   string `json:"machineType"`
+	AutoScalerMin int    `json:"autoScalerMin"`
+	AutoScalerMax int    `json:"autoScalerMax"`
+}
+
+func (a AdditionalWorkerNodePool) Validate() error {
+	if a.AutoScalerMin > a.AutoScalerMax {
+		return fmt.Errorf("AutoScalerMax %v should be larger than AutoScalerMin %v for %s worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
+	}
+	return nil
 }

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -301,6 +301,17 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 		}
 	}
 
+	if parameters.AdditionalWorkerNodePools != nil {
+		if !supportsAdditionalWorkers(details.PlanID) {
+			return ersContext, parameters, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+		}
+		for _, additionalWorkerNodePool := range parameters.AdditionalWorkerNodePools {
+			if err := additionalWorkerNodePool.Validate(); err != nil {
+				return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
+			}
+		}
+	}
+
 	planValidator, err := b.validator(&details, provider, ctx)
 	if err != nil {
 		return ersContext, parameters, fmt.Errorf("while creating plan validator: %w", err)
@@ -387,6 +398,18 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 func isEuRestrictedAccess(ctx context.Context) bool {
 	platformRegion, _ := middleware.RegionFromContext(ctx)
 	return euaccess.IsEURestrictedAccess(platformRegion)
+}
+
+func supportsAdditionalWorkers(planID string) bool {
+	var supportedPlans = []string{
+		PreviewPlanID,
+	}
+	for _, supportedPlan := range supportedPlans {
+		if planID == supportedPlan {
+			return true
+		}
+	}
+	return false
 }
 
 // Rudimentary kubeconfig validation

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -302,7 +302,7 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 	}
 
 	if parameters.AdditionalWorkerNodePools != nil {
-		if !supportsAdditionalWorkers(details.PlanID) {
+		if !supportsAdditionalWorkerNodePools(details.PlanID) {
 			return ersContext, parameters, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
 		}
 		for _, additionalWorkerNodePool := range parameters.AdditionalWorkerNodePools {
@@ -400,7 +400,7 @@ func isEuRestrictedAccess(ctx context.Context) bool {
 	return euaccess.IsEURestrictedAccess(platformRegion)
 }
 
-func supportsAdditionalWorkers(planID string) bool {
+func supportsAdditionalWorkerNodePools(planID string) bool {
 	var supportedPlans = []string{
 		PreviewPlanID,
 	}

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1493,6 +1493,198 @@ func TestProvision_Provision(t *testing.T) {
 	})
 }
 
+func TestAdditionalWorkerNodePools(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		additionalWorkerNodePools string
+		expectedError             bool
+	}{
+		"Valid additional worker node pools": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             false,
+		},
+		"Empty additional worker node pools": {
+			additionalWorkerNodePools: `[]`,
+			expectedError:             false,
+		},
+		"Empty name": {
+			additionalWorkerNodePools: `[{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing name": {
+			additionalWorkerNodePools: `[{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Empty machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMin": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMin smaller than 3": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 2, "autoScalerMax": 300}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMax bigger than 300": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMin bigger than autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
+
+			memoryStorage := storage.NewMemoryStorage()
+
+			queue := &automock.Queue{}
+			queue.On("Add", mock.AnythingOfType("string"))
+
+			factoryBuilder := &automock.PlanValidator{}
+			factoryBuilder.On("IsPlanSupport", broker.PreviewPlanID).Return(true)
+
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+			// #create provisioner endpoint
+			provisionEndpoint := broker.NewProvision(
+				broker.Config{
+					EnablePlans:              []string{"preview"},
+					URL:                      brokerURL,
+					OnlySingleTrialPerGA:     true,
+					EnableKubeconfigURLLabel: true,
+				},
+				gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+				memoryStorage.Operations(),
+				memoryStorage.Instances(),
+				memoryStorage.InstancesArchived(),
+				queue,
+				factoryBuilder,
+				broker.PlansConfig{},
+				planDefaults,
+				log,
+				dashboardConfig,
+				kcBuilder,
+				whitelist.Set{},
+				&broker.OneForAllConvergedCloudRegionsProvider{},
+			)
+
+			// when
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+				ServiceID:     serviceID,
+				PlanID:        broker.PreviewPlanID,
+				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", tc.additionalWorkerNodePools)),
+				RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
+			}, true)
+			t.Logf("%+v\n", *provisionEndpoint)
+
+			// then
+			assert.Equal(t, tc.expectedError, err != nil)
+		})
+	}
+}
+
+func TestAdditionalWorkerNodePoolsForUnsupportedPlans(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		planID string
+	}{
+		"Trial": {
+			planID: broker.TrialPlanID,
+		},
+		"Free": {
+			planID: broker.FreemiumPlanID,
+		},
+		"Azure": {
+			planID: broker.AzurePlanID,
+		},
+		"Azure lite": {
+			planID: broker.AzureLitePlanID,
+		},
+		"AWS": {
+			planID: broker.AWSPlanID,
+		},
+		"GCP": {
+			planID: broker.GCPPlanID,
+		},
+		"SAP converged cloud": {
+			planID: broker.SapConvergedCloudPlanID,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
+
+			memoryStorage := storage.NewMemoryStorage()
+
+			queue := &automock.Queue{}
+			queue.On("Add", mock.AnythingOfType("string"))
+
+			factoryBuilder := &automock.PlanValidator{}
+			factoryBuilder.On("IsPlanSupport", tc.planID).Return(true)
+
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+			// #create provisioner endpoint
+			provisionEndpoint := broker.NewProvision(
+				broker.Config{
+					EnablePlans:              []string{"trial", "free", "azure", "azure_lite", "aws", "gcp", "sap-converged-cloud"},
+					URL:                      brokerURL,
+					OnlySingleTrialPerGA:     true,
+					EnableKubeconfigURLLabel: true,
+				},
+				gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+				memoryStorage.Operations(),
+				memoryStorage.Instances(),
+				memoryStorage.InstancesArchived(),
+				queue,
+				factoryBuilder,
+				broker.PlansConfig{},
+				planDefaults,
+				log,
+				dashboardConfig,
+				kcBuilder,
+				whitelist.Set{},
+				&broker.OneForAllConvergedCloudRegionsProvider{},
+			)
+
+			additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
+
+			// when
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+				ServiceID:     serviceID,
+				PlanID:        tc.planID,
+				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),
+				RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "Test@Test.pl")),
+			}, true)
+			t.Logf("%+v\n", *provisionEndpoint)
+
+			// then
+			assert.EqualError(t, err, fmt.Sprintf("additional worker node pools are not supported for plan ID: %s", tc.planID))
+		})
+	}
+}
+
 func TestNetworkingValidation(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		givenNetworking string

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1586,7 +1586,7 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 			)
 
 			// when
-			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-eu10"), instanceID, domain.ProvisionDetails{
 				ServiceID:     serviceID,
 				PlanID:        broker.PreviewPlanID,
 				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", tc.additionalWorkerNodePools)),
@@ -1671,7 +1671,7 @@ func TestAdditionalWorkerNodePoolsForUnsupportedPlans(t *testing.T) {
 			additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
 
 			// when
-			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-sa30"), instanceID, domain.ProvisionDetails{
+			_, err := provisionEndpoint.Provision(fixRequestContext(t, "cf-eu10"), instanceID, domain.ProvisionDetails{
 				ServiceID:     serviceID,
 				PlanID:        tc.planID,
 				RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s","additionalWorkerNodePools": %s }`, clusterName, "eu-central-1", additionalWorkerNodePools)),

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -263,6 +263,18 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		logger.Error(fmt.Sprintf("invalid autoscaler parameters: %s", err.Error()))
 		return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 	}
+
+	if params.AdditionalWorkerNodePools != nil {
+		if !supportsAdditionalWorkers(details.PlanID) {
+			return domain.UpdateServiceSpec{}, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+		}
+		for _, additionalWorkerNodePool := range params.AdditionalWorkerNodePools {
+			if err := additionalWorkerNodePool.Validate(); err != nil {
+				return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
+			}
+		}
+	}
+
 	err = b.operationStorage.InsertOperation(operation)
 	if err != nil {
 		return domain.UpdateServiceSpec{}, err
@@ -287,6 +299,14 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	if params.MachineType != nil && *params.MachineType != "" {
 		instance.Parameters.Parameters.MachineType = params.MachineType
 	}
+
+	if supportsAdditionalWorkers(details.PlanID) && params.AdditionalWorkerNodePools != nil {
+		newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools))
+		newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools...)
+		instance.Parameters.Parameters.AdditionalWorkerNodePools = newAdditionalWorkerNodePools
+		updateStorage = append(updateStorage, "Additional Worker Node Pools")
+	}
+
 	if len(updateStorage) > 0 {
 		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 			instance, err = b.instanceStorage.Update(*instance)

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -265,7 +265,7 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	}
 
 	if params.AdditionalWorkerNodePools != nil {
-		if !supportsAdditionalWorkers(details.PlanID) {
+		if !supportsAdditionalWorkerNodePools(details.PlanID) {
 			return domain.UpdateServiceSpec{}, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
 		}
 		for _, additionalWorkerNodePool := range params.AdditionalWorkerNodePools {
@@ -300,7 +300,7 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		instance.Parameters.Parameters.MachineType = params.MachineType
 	}
 
-	if supportsAdditionalWorkers(details.PlanID) && params.AdditionalWorkerNodePools != nil {
+	if supportsAdditionalWorkerNodePools(details.PlanID) && params.AdditionalWorkerNodePools != nil {
 		newAdditionalWorkerNodePools := make([]pkg.AdditionalWorkerNodePool, 0, len(params.AdditionalWorkerNodePools))
 		newAdditionalWorkerNodePools = append(newAdditionalWorkerNodePools, params.AdditionalWorkerNodePools...)
 		instance.Parameters.Parameters.AdditionalWorkerNodePools = newAdditionalWorkerNodePools

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -593,6 +593,156 @@ func TestUpdateEndpoint_UpdateParameters(t *testing.T) {
 	})
 }
 
+func TestUpdateAdditionalWorkerNodePools(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		additionalWorkerNodePools string
+		expectedError             bool
+	}{
+		"Valid additional worker node pools": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             false,
+		},
+		"Empty additional worker node pools": {
+			additionalWorkerNodePools: `[]`,
+			expectedError:             false,
+		},
+		"Empty name": {
+			additionalWorkerNodePools: `[{"name": "", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing name": {
+			additionalWorkerNodePools: `[{"machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Empty machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing machine type": {
+			additionalWorkerNodePools: `[{"name": "name-1", "autoScalerMin": 3, "autoScalerMax": 20}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMin": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+		"Missing autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMin smaller than 3": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 2, "autoScalerMax": 300}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMax bigger than 300": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 301}]`,
+			expectedError:             true,
+		},
+		"AutoScalerMin bigger than autoScalerMax": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 20, "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			instance := fixture.FixInstance(instanceID)
+			instance.ServicePlanID = PreviewPlanID
+			st := storage.NewMemoryStorage()
+			err := st.Instances().Insert(instance)
+			require.NoError(t, err)
+			err = st.Operations().InsertProvisioningOperation(fixProvisioningOperation("provisioning01"))
+			require.NoError(t, err)
+
+			handler := &handler{}
+			q := &automock.Queue{}
+			q.On("Add", mock.AnythingOfType("string"))
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			svc := NewUpdate(Config{}, st.Instances(), st.RuntimeStates(), st.Operations(), handler, true, true, false, q, PlansConfig{},
+				planDefaults, fixLogger(), dashboardConfig, kcBuilder, &OneForAllConvergedCloudRegionsProvider{}, fakeKcpK8sClient)
+
+			// when
+			_, err = svc.Update(context.Background(), instanceID, domain.UpdateDetails{
+				ServiceID:       "",
+				PlanID:          PreviewPlanID,
+				RawParameters:   json.RawMessage("{\"additionalWorkerNodePools\":" + tc.additionalWorkerNodePools + "}"),
+				PreviousValues:  domain.PreviousValues{},
+				RawContext:      json.RawMessage("{\"globalaccount_id\":\"globalaccount_id_1\", \"active\":true}"),
+				MaintenanceInfo: nil,
+			}, true)
+
+			// then
+			assert.Equal(t, tc.expectedError, err != nil)
+		})
+	}
+}
+
+func TestUpdateAdditionalWorkerNodePoolsForUnsupportedPlans(t *testing.T) {
+	for tn, tc := range map[string]struct {
+		planID string
+	}{
+		"Trial": {
+			planID: TrialPlanID,
+		},
+		"Free": {
+			planID: FreemiumPlanID,
+		},
+		"Azure": {
+			planID: AzurePlanID,
+		},
+		"Azure lite": {
+			planID: AzureLitePlanID,
+		},
+		"AWS": {
+			planID: AWSPlanID,
+		},
+		"GCP": {
+			planID: GCPPlanID,
+		},
+		"SAP converged cloud": {
+			planID: SapConvergedCloudPlanID,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// given
+			instance := fixture.FixInstance(instanceID)
+			instance.ServicePlanID = tc.planID
+			st := storage.NewMemoryStorage()
+			err := st.Instances().Insert(instance)
+			require.NoError(t, err)
+			err = st.Operations().InsertProvisioningOperation(fixProvisioningOperation("provisioning01"))
+			require.NoError(t, err)
+
+			handler := &handler{}
+			q := &automock.Queue{}
+			q.On("Add", mock.AnythingOfType("string"))
+			planDefaults := func(planID string, platformProvider pkg.CloudProvider, provider *pkg.CloudProvider) (*gqlschema.ClusterConfigInput, error) {
+				return &gqlschema.ClusterConfigInput{}, nil
+			}
+			kcBuilder := &kcMock.KcBuilder{}
+			svc := NewUpdate(Config{}, st.Instances(), st.RuntimeStates(), st.Operations(), handler, true, true, false, q, PlansConfig{},
+				planDefaults, fixLogger(), dashboardConfig, kcBuilder, &OneForAllConvergedCloudRegionsProvider{}, fakeKcpK8sClient)
+
+			additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
+
+			// when
+			_, err = svc.Update(context.Background(), instanceID, domain.UpdateDetails{
+				ServiceID:       "",
+				PlanID:          tc.planID,
+				RawParameters:   json.RawMessage("{\"additionalWorkerNodePools\":" + additionalWorkerNodePools + "}"),
+				PreviousValues:  domain.PreviousValues{},
+				RawContext:      json.RawMessage("{\"globalaccount_id\":\"globalaccount_id_1\", \"active\":true}"),
+				MaintenanceInfo: nil,
+			}, true)
+
+			// then
+			assert.EqualError(t, err, fmt.Sprintf("additional worker node pools are not supported for plan ID: %s", tc.planID))
+		})
+	}
+}
+
 func TestUpdateEndpoint_UpdateWithEnabledDashboard(t *testing.T) {
 	// given
 	instance := internal.Instance{

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -374,7 +374,7 @@ func SapConvergedCloudSchema(machineTypesDisplay, regionsDisplay map[string]stri
 func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.Networking = NewNetworkingSchema()
-	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes, update)
+	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false, true)
 }
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -374,6 +374,7 @@ func SapConvergedCloudSchema(machineTypesDisplay, regionsDisplay map[string]stri
 func PreviewSchema(machineTypesDisplay, regionsDisplay map[string]string, machineTypes []string, additionalParams, update bool, euAccessRestricted bool) *map[string]interface{} {
 	properties := NewProvisioningProperties(machineTypesDisplay, regionsDisplay, machineTypes, AWSRegions(euAccessRestricted), update)
 	properties.Networking = NewNetworkingSchema()
+	properties.AdditionalWorkerNodePools = NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay, machineTypes, update)
 	return createSchemaWithProperties(properties, additionalParams, update, requiredSchemaProperties(), false, false, true)
 }
 

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -435,8 +435,8 @@ func AdministratorsProperty() *Type {
 	}
 }
 
-func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, machineTypes []string, update bool) *AdditionalWorkerNodePoolsType {
-	additionalWorkerNodePoolsType := AdditionalWorkerNodePoolsType{
+func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, machineTypes []string) *AdditionalWorkerNodePoolsType {
+	return &AdditionalWorkerNodePoolsType{
 		Type: Type{
 			Type:        "array",
 			UniqueItems: true,
@@ -478,10 +478,4 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 			},
 		},
 	}
-
-	if update {
-		additionalWorkerNodePoolsType.Items.Properties.Name.ReadOnly = true
-	}
-
-	return &additionalWorkerNodePoolsType
 }

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -35,12 +35,13 @@ type ProvisioningProperties struct {
 }
 
 type UpdateProperties struct {
-	Kubeconfig     *Type     `json:"kubeconfig,omitempty"`
-	AutoScalerMin  *Type     `json:"autoScalerMin,omitempty"`
-	AutoScalerMax  *Type     `json:"autoScalerMax,omitempty"`
-	OIDC           *OIDCType `json:"oidc,omitempty"`
-	Administrators *Type     `json:"administrators,omitempty"`
-	MachineType    *Type     `json:"machineType,omitempty"`
+	Kubeconfig                *Type                          `json:"kubeconfig,omitempty"`
+	AutoScalerMin             *Type                          `json:"autoScalerMin,omitempty"`
+	AutoScalerMax             *Type                          `json:"autoScalerMax,omitempty"`
+	OIDC                      *OIDCType                      `json:"oidc,omitempty"`
+	Administrators            *Type                          `json:"administrators,omitempty"`
+	MachineType               *Type                          `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools *AdditionalWorkerNodePoolsType `json:"additionalWorkerNodePools,omitempty"`
 }
 
 func (up *UpdateProperties) IncludeAdditional() {
@@ -147,6 +148,25 @@ type ModulesCustomListItemsProperties struct {
 	Name                 Type `json:"name,omitempty"`
 	Channel              Type `json:"channel,omitempty"`
 	CustomResourcePolicy Type `json:"customResourcePolicy,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsType struct {
+	Type
+	Items AdditionalWorkerNodePoolsItems `json:"items,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsItems struct {
+	Type
+	ControlsOrder []string                                 `json:"_controlsOrder,omitempty"`
+	Required      []string                                 `json:"required,omitempty"`
+	Properties    AdditionalWorkerNodePoolsItemsProperties `json:"properties,omitempty"`
+}
+
+type AdditionalWorkerNodePoolsItemsProperties struct {
+	Name          Type `json:"name,omitempty"`
+	AutoScalerMin Type `json:"autoScalerMin,omitempty"`
+	AutoScalerMax Type `json:"autoScalerMax,omitempty"`
+	MachineType   Type `json:"machineType,omitempty"`
 }
 
 func NewModulesSchema() *Modules {
@@ -300,6 +320,7 @@ func NewProvisioningProperties(machineTypesDisplay, regionsDisplay map[string]st
 				Type:            "string",
 				Enum:            ToInterfaceSlice(machineTypes),
 				EnumDisplayName: machineTypesDisplay,
+				Description:     "Specifies the type of the virtual machine.",
 			},
 		},
 		Name: NameProperty(),
@@ -392,7 +413,7 @@ func unmarshalOrPanic(from, to interface{}) interface{} {
 }
 
 func DefaultControlsOrder() []string {
-	return []string{"name", "kubeconfig", "shootName", "shootDomain", "region", "shootAndSeedSameRegion", "machineType", "autoScalerMin", "autoScalerMax", "zonesCount", "modules", "networking", "oidc", "administrators"}
+	return []string{"name", "kubeconfig", "shootName", "shootDomain", "region", "shootAndSeedSameRegion", "machineType", "autoScalerMin", "autoScalerMax", "zonesCount", "additionalWorkerNodePools", "modules", "networking", "oidc", "administrators"}
 }
 
 func ToInterfaceSlice(input []string) []interface{} {
@@ -412,4 +433,55 @@ func AdministratorsProperty() *Type {
 			Type: "string",
 		},
 	}
+}
+
+func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, machineTypes []string, update bool) *AdditionalWorkerNodePoolsType {
+	additionalWorkerNodePoolsType := AdditionalWorkerNodePoolsType{
+		Type: Type{
+			Type:        "array",
+			UniqueItems: true,
+			Description: "Specifies the list of additional worker node pools."},
+		Items: AdditionalWorkerNodePoolsItems{
+			ControlsOrder: []string{"name", "machineType", "autoScalerMin", "autoScalerMax"},
+			Required:      []string{"name", "machineType", "autoScalerMin", "autoScalerMax"},
+			Type: Type{
+				Type: "object",
+			},
+			Properties: AdditionalWorkerNodePoolsItemsProperties{
+				Name: Type{
+					Type:      "string",
+					MinLength: 1,
+					// Allows for all alphanumeric characters and '-'
+					Pattern:     "^[a-zA-Z0-9-]*$",
+					Description: "Specifies the unique name of the additional worker node pool.",
+				},
+				MachineType: Type{
+					Type:            "string",
+					MinLength:       1,
+					Enum:            ToInterfaceSlice(machineTypes),
+					EnumDisplayName: machineTypesDisplay,
+					Description:     "Specifies the type of the virtual machine.",
+				},
+				AutoScalerMin: Type{
+					Type:        "integer",
+					Minimum:     3,
+					Default:     3,
+					Description: "Specifies the minimum number of virtual machines to create.",
+				},
+				AutoScalerMax: Type{
+					Type:        "integer",
+					Minimum:     3,
+					Maximum:     300,
+					Default:     20,
+					Description: "Specifies the maximum number of virtual machines to create.",
+				},
+			},
+		},
+	}
+
+	if update {
+		additionalWorkerNodePoolsType.Items.Properties.Name.ReadOnly = true
+	}
+
+	return &additionalWorkerNodePoolsType
 }

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -52,6 +52,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -52,6 +52,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -41,6 +41,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -41,6 +41,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -45,6 +45,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -35,6 +35,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -39,6 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -41,6 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -39,6 +39,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -41,6 +41,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -29,6 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -30,6 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -29,6 +29,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -30,6 +30,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -51,6 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -51,6 +51,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -40,6 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -40,6 +40,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -33,6 +33,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -34,6 +34,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -23,6 +23,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D4s_v5",
         "Standard_D4_v3"

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -24,6 +24,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -44,6 +44,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -34,6 +34,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -45,6 +45,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -45,6 +45,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -34,6 +34,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -34,6 +34,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -38,6 +38,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -28,6 +28,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -46,6 +46,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -35,6 +35,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -39,6 +39,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -29,6 +29,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
+      "description": "Specifies the type of the virtual machine.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/dto.go
+++ b/internal/dto.go
@@ -52,9 +52,10 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 type UpdatingParametersDTO struct {
 	pkg.AutoScalerParameters `json:",inline"`
 
-	OIDC                  *pkg.OIDCConfigDTO `json:"oidc,omitempty"`
-	RuntimeAdministrators []string           `json:"administrators,omitempty"`
-	MachineType           *string            `json:"machineType,omitempty"`
+	OIDC                      *pkg.OIDCConfigDTO             `json:"oidc,omitempty"`
+	RuntimeAdministrators     []string                       `json:"administrators,omitempty"`
+	MachineType               *string                        `json:"machineType,omitempty"`
+	AdditionalWorkerNodePools []pkg.AdditionalWorkerNodePool `json:"additionalWorkerNodePools,omitempty"`
 }
 
 func (u UpdatingParametersDTO) UpdateAutoScaler(p *pkg.ProvisioningParametersDTO) bool {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- extend schema with machine type description,
- extend schema with `additionalWorkerNodePools` on `preview` plan,
- handle `additionalWorkerNodePools` in create and update endpoints.

**Related issue(s)**
See also #952
