### PR TITLE
Refresh updateAt operation field to measure timeout

### DIFF
--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -118,6 +118,7 @@ func (om *OperationManager) RetryOperationOnce(operation internal.Operation, err
 }
 
 // UpdateOperation updates a given operation and handles conflict situation
+// The DB update call must be done even if there is no any change in the operation - this is required to update the operation's `UpdatedAt` field.
 func (om *OperationManager) UpdateOperation(operation internal.Operation, update func(operation *internal.Operation), log *slog.Logger) (internal.Operation, time.Duration, error) {
 	update(&operation)
 	op, err := om.storage.UpdateOperation(operation)
@@ -129,6 +130,7 @@ func (om *OperationManager) UpdateOperation(operation internal.Operation, update
 				log.Error(fmt.Sprintf("while getting operation: %v", err))
 				return operation, 1 * time.Minute, err
 			}
+			// do not optimize the flow by skipping the update call - it's required to update the `UpdatedAt` field
 			op.Merge(&operation)
 			update(op)
 			op, err = om.storage.UpdateOperation(*op)

--- a/internal/process/provisioning/check_runtime_step.go
+++ b/internal/process/provisioning/check_runtime_step.go
@@ -77,7 +77,10 @@ func (s *CheckRuntimeStep) checkRuntimeStatus(operation internal.Operation, log 
 
 	switch status.State {
 	case gqlschema.OperationStateSucceeded:
-		return operation, 0, nil
+		// A dummy update to refresh updatedAt field in the operation
+		// This field is used by RetryOperation in next steps.
+		return s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+		}, log)
 	case gqlschema.OperationStateInProgress:
 		return operation, 20 * time.Second, nil
 	case gqlschema.OperationStatePending:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- Check runtime resource step is repeated for a long time but it wasn't updating the operation - so the next step cannot calculate timeout.
- This PR adds a dummy update to have proper updatedAt value

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
