### PR TITLE
Enhance error handling

### DIFF
--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -303,10 +303,12 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 
 	if parameters.AdditionalWorkerNodePools != nil {
 		if !supportsAdditionalWorkerNodePools(details.PlanID) {
-			return ersContext, parameters, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+			message := fmt.Sprintf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+			return ersContext, parameters, apiresponses.NewFailureResponse(fmt.Errorf(message), http.StatusUnprocessableEntity, message)
 		}
 		if !AreNamesUnique(parameters.AdditionalWorkerNodePools) {
-			return ersContext, parameters, fmt.Errorf("names of additional worker node pools must be unique")
+			message := "names of additional worker node pools must be unique"
+			return ersContext, parameters, apiresponses.NewFailureResponse(fmt.Errorf(message), http.StatusUnprocessableEntity, message)
 		}
 		for _, additionalWorkerNodePool := range parameters.AdditionalWorkerNodePools {
 			if err := additionalWorkerNodePool.Validate(); err != nil {

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -266,10 +266,12 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 
 	if params.AdditionalWorkerNodePools != nil {
 		if !supportsAdditionalWorkerNodePools(details.PlanID) {
-			return domain.UpdateServiceSpec{}, fmt.Errorf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+			message := fmt.Sprintf("additional worker node pools are not supported for plan ID: %s", details.PlanID)
+			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf(message), http.StatusBadRequest, message)
 		}
 		if !AreNamesUnique(params.AdditionalWorkerNodePools) {
-			return domain.UpdateServiceSpec{}, fmt.Errorf("names of additional worker node pools must be unique")
+			message := "names of additional worker node pools must be unique"
+			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf(message), http.StatusBadRequest, message)
 		}
 		for _, additionalWorkerNodePool := range params.AdditionalWorkerNodePools {
 			if err := additionalWorkerNodePool.Validate(); err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- return `apiresponses.NewFailureResponse` instead of Go's standard library error.

**Related issue(s)**
See also #952
