### PR TITLE
Remove HA zones for azure lite plan

### DIFF
--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -401,6 +401,9 @@ func AzureLiteSchema(machineTypesDisplay, regionsDisplay map[string]string, mach
 
 	if enableAdditionalWorkerNodePools {
 		properties.AdditionalWorkerNodePools.Items.Properties.HAZones = nil
+		properties.AdditionalWorkerNodePools.Items.ControlsOrder = removeString(properties.AdditionalWorkerNodePools.Items.ControlsOrder, "haZones")
+		properties.AdditionalWorkerNodePools.Items.Required = removeString(properties.AdditionalWorkerNodePools.Items.Required, "haZones")
+
 		properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Default = 2
 		properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Default = 10
 		properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Maximum = 40
@@ -675,4 +678,14 @@ func filter(items *[]interface{}, included map[string]interface{}) interface{} {
 	}
 
 	return output
+}
+
+func removeString(slice []string, str string) []string {
+	result := []string{}
+	for _, v := range slice {
+		if v != str {
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -352,3 +352,25 @@ func readJsonFile(t *testing.T, file string) string {
 
 	return string(jsonFile)
 }
+
+func TestRemoveString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		remove   string
+		expected []string
+	}{
+		{"Remove existing element", []string{"alpha", "beta", "gamma"}, "beta", []string{"alpha", "gamma"}},
+		{"Remove non-existing element", []string{"alpha", "beta", "gamma"}, "delta", []string{"alpha", "beta", "gamma"}},
+		{"Remove from empty slice", []string{}, "alpha", []string{}},
+		{"Remove all occurrences", []string{"alpha", "alpha", "beta"}, "alpha", []string{"beta"}},
+		{"Remove only element", []string{"alpha"}, "alpha", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := removeString(tt.input, tt.remove)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove HA zones form ControlsOrder and Required fields for Azure lite plan schema.

**Related issue(s)**
See also #952
