### PR TITLE
Assert workers and additional workers on `runtimes` endpoint

### DIFF
--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net/http"
 	"os"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kyma-project/kyma-environment-broker/int
 	"github.com/kyma-project/kyma-environment-broker/internal/provider"
 	"github.com/stretchr/testify/require"
 

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net/http"
 	"os"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kyma-project/kyma-environment-broker/common/hyperscaler"
+
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -1931,4 +1933,34 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 	assert.Len(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers, 2)
 	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-1", "m6i.large", 3, 20, 3)
 	suite.assertAdditionalWorkerIsCreated(t, runtime.Spec.Shoot.Provider, "name-2", "m5.large", 1, 1, 1)
+
+	resp = suite.CallAPI("GET", fmt.Sprintf("runtimes?runtime_config=true&account=%s&subaccount=%s&state=provisioned", "g-account-id", "sub-id"), "")
+	response, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	var runtimes pkg.RuntimesPage
+
+	err = json.Unmarshal(response, &runtimes)
+
+	assert.Len(t, runtimes.Data, 1)
+	assert.NotNil(t, runtimes.Data[0].InstanceID)
+	config := runtimes.Data[0].RuntimeConfig
+	provider, ok, err := unstructured.NestedMap(*config, "spec", "shoot", "provider")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	workers, ok, err := unstructured.NestedSlice(provider, "workers")
+	additionalWorkers, ok, err := unstructured.NestedSlice(provider, "additionalWorkers")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	assert.Len(t, workers, 1)
+	assert.Len(t, additionalWorkers, 2)
+
+	assert.Equal(t, "cpu-worker-0", workers[0].(map[string]interface{})["name"])
+	assert.Equal(t, "name-1", additionalWorkers[0].(map[string]interface{})["name"])
+	assert.Equal(t, "name-2", additionalWorkers[1].(map[string]interface{})["name"])
+
+	assert.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
 }

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1946,7 +1946,11 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 	provider, ok, err := unstructured.NestedMap(*config, "spec", "shoot", "provider")
 	assert.True(t, ok)
 	assert.NoError(t, err)
+
 	workers, ok, err := unstructured.NestedSlice(provider, "workers")
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
 	additionalWorkers, ok, err := unstructured.NestedSlice(provider, "additionalWorkers")
 	assert.True(t, ok)
 	assert.NoError(t, err)

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1943,6 +1943,8 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 
 	assert.Len(t, runtimes.Data, 1)
 	config := runtimes.Data[0].RuntimeConfig
+	assert.NotNil(t, config)
+
 	provider, ok, err := unstructured.NestedMap(*config, "spec", "shoot", "provider")
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -1962,8 +1964,6 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 	assert.Equal(t, "name-1", additionalWorkers[0].(map[string]interface{})["name"])
 	assert.Equal(t, "name-2", additionalWorkers[1].(map[string]interface{})["name"])
 
-	assert.NoError(t, err)
-	assert.NotNil(t, config)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 }

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -12,7 +12,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/kyma-project/kyma-environment-broker/int
 	"github.com/kyma-project/kyma-environment-broker/internal/provider"
 	"github.com/stretchr/testify/require"
 

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -1942,7 +1942,6 @@ func TestProvisioningWithAdditionalWorkerNodePools(t *testing.T) {
 	err = json.Unmarshal(response, &runtimes)
 
 	assert.Len(t, runtimes.Data, 1)
-	assert.NotNil(t, runtimes.Data[0].InstanceID)
 	config := runtimes.Data[0].RuntimeConfig
 	provider, ok, err := unstructured.NestedMap(*config, "spec", "shoot", "provider")
 	assert.True(t, ok)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Assert that workers and additionalWorkers are present in runtime configuration (`runtime_config` parameter) returned by `/runtimes` endpoint

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
