### PR TITLE
Instances table contains last operation id to speed up listinstances …

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -567,8 +567,7 @@ func (s *BrokerSuiteTest) DecodeErrorResponse(resp *http.Response) apiresponses.
 
 func (s *BrokerSuiteTest) ReadResponse(resp *http.Response) []byte {
 	m, err := io.ReadAll(resp.Body)
-	msg := string(m)
-	s.Log(msg)
+	s.Log(string(m))
 	require.NoError(s.t, err)
 	return m
 }

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -567,7 +567,8 @@ func (s *BrokerSuiteTest) DecodeErrorResponse(resp *http.Response) apiresponses.
 
 func (s *BrokerSuiteTest) ReadResponse(resp *http.Response) []byte {
 	m, err := io.ReadAll(resp.Body)
-	s.Log(string(m))
+	msg := string(m)
+	s.Log(msg)
 	require.NoError(s.t, err)
 	return m
 }

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -5,13 +5,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-project/kyma-environment-broker/internal/provider"
-	"github.com/stretchr/testify/require"
 	"io"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/provider"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/google/uuid"
 	"github.com/pivotal-cf/brokerapi/v8/domain"

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -5,15 +5,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/kyma-project/kyma-environment-broker/internal/provider"
+	"github.com/stretchr/testify/require"
 	"io"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"net/http"
 	"os"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/provider"
-	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
 	"github.com/pivotal-cf/brokerapi/v8/domain"

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -231,6 +231,12 @@ func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, de
 		return domain.ProvisionedServiceSpec{}, fmt.Errorf("cannot save instance")
 	}
 
+	err = b.instanceStorage.UpdateInstanceLastOperation(instanceID, operationID)
+	if err != nil {
+		logger.Error(fmt.Sprintf("cannot save instance in storage: %s", err))
+		return domain.ProvisionedServiceSpec{}, fmt.Errorf("cannot save instance")
+	}
+
 	logger.Info("Adding operation to provisioning queue")
 	b.queue.Add(operation.ID)
 

--- a/internal/process/deprovisioning/init.go
+++ b/internal/process/deprovisioning/init.go
@@ -65,6 +65,12 @@ func (s *InitStep) Run(operation internal.Operation, log *slog.Logger) (internal
 		return operation, time.Second, nil
 	}
 
+	log.Info("Setting lastOperation ID in the instance")
+	err = s.instanceStorage.UpdateInstanceLastOperation(operation.InstanceID, operation.ID)
+	if err != nil {
+		return s.operationManager.RetryOperation(operation, "error while updating last operation ID", err, 5*time.Second, 1*time.Minute, log)
+	}
+
 	log.Info("Setting state 'in progress' and refreshing instance details")
 	opr, delay, err := s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
 		op.State = domain.InProgress

--- a/internal/process/provisioning/start_step.go
+++ b/internal/process/provisioning/start_step.go
@@ -69,9 +69,16 @@ func (s *StartStep) Run(operation internal.Operation, log *slog.Logger) (interna
 	}
 	lastOp, err := s.operationStorage.GetLastOperation(operation.InstanceID)
 	if err != nil && !dberr.IsNotFound(err) {
-		log.Warn(fmt.Sprintf("Failed to get last operation for ERSContext: %s", err.Error()))
+		log.Warn(fmt.Sprintf("Failed to get last operation: %s", err.Error()))
 		return operation, time.Minute, nil
 	}
+
+	log.Info("Setting lastOperation ID in the instance")
+	err = s.instanceStorage.UpdateInstanceLastOperation(operation.InstanceID, operation.ID)
+	if err != nil {
+		return s.operationManager.RetryOperation(operation, "error while updating last operation ID", err, 5*time.Second, 1*time.Minute, log)
+	}
+
 	log.Info("Setting the operation to 'InProgress'")
 	newOp, retry, _ := s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
 		if lastOp != nil {

--- a/internal/process/update/initialisation_step.go
+++ b/internal/process/update/initialisation_step.go
@@ -87,7 +87,14 @@ func (s *InitialisationStep) Run(operation internal.Operation, log *slog.Logger)
 			log.Error("unable to update the operation (move to 'in progress'), retrying")
 			return operation, delay, nil
 		}
+
 		operation = op
+	}
+
+	log.Info("updating last operation id in the instance")
+	err = s.instanceStorage.UpdateInstanceLastOperation(operation.InstanceID, operation.ID)
+	if err != nil {
+		return s.operationManager.RetryOperation(operation, "error while updating last operation ID", err, 5*time.Second, 1*time.Minute, log)
 	}
 
 	if lastOp.Type == internal.OperationTypeDeprovision {

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -23,6 +23,9 @@ type Config struct {
 	MaxOpenConns    int           `envconfig:"default=8"`
 	MaxIdleConns    int           `envconfig:"default=2"`
 	ConnMaxLifetime time.Duration `envconfig:"default=30m"`
+
+	// feature flags
+	UseLastOperationID bool `envconfig:"default=false"`
 }
 
 func (cfg *Config) ConnectionURL() string {

--- a/internal/storage/driver/memory/instance.go
+++ b/internal/storage/driver/memory/instance.go
@@ -55,6 +55,10 @@ func (s *instances) ListWithoutDecryption(dbmodel.InstanceFilter) ([]internal.In
 	return nil, 0, 0, errors.New("not implemented")
 }
 
+func (s *instances) UpdateInstanceLastOperation(instanceID, operationID string) error {
+	return nil
+}
+
 func (s *instances) FindAllJoinedWithOperations(prct ...predicate.Predicate) ([]internal.InstanceWithOperation, error) {
 	var instances []internal.InstanceWithOperation
 

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -2,11 +2,12 @@ package postsql_test
 
 import (
 	"fmt"
-	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"math/rand"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 
@@ -1072,44 +1073,44 @@ func TestInstanceStorage_ListInstances(t *testing.T) {
 
 	// first instance, one provisioning, one update
 	instance0 := fixInstance(instanceData{val: "inst1"})
-	instanceStorage.Insert(*instance0)
+	_ = instanceStorage.Insert(*instance0)
 	operation0_0 := fixProvisionOperation(instance0.InstanceID)
 	operation0_1 := fixture.FixUpdatingOperation("op0_1", instance0.InstanceID).Operation
 	operation0_1.State = domain.InProgress
 
-	operationStorage.InsertOperation(operation0_0)
-	operationStorage.InsertOperation(operation0_1)
-	instanceStorage.UpdateInstanceLastOperation(instance0.InstanceID, operation0_1.ID)
+	_ = operationStorage.InsertOperation(operation0_0)
+	_ = operationStorage.InsertOperation(operation0_1)
+	_ = instanceStorage.UpdateInstanceLastOperation(instance0.InstanceID, operation0_1.ID)
 
 	// second instance, one provisioning, 1 update
 	instance1 := fixInstance(instanceData{val: fmt.Sprintf("inst2")})
-	instanceStorage.Insert(*instance1)
+	_ = instanceStorage.Insert(*instance1)
 
 	operation1_0 := fixProvisionOperation(instance1.InstanceID)
 
-	operationStorage.InsertOperation(operation1_0)
+	_ = operationStorage.InsertOperation(operation1_0)
 
 	op := fixture.FixUpdatingOperation(fmt.Sprintf("op1__%s", instance1.InstanceID), instance1.InstanceID).Operation
 	op.CreatedAt = time.Now().Add(-3 * time.Second)
 	op.State = domain.Succeeded
-	operationStorage.InsertOperation(op)
+	_ = operationStorage.InsertOperation(op)
 
 	operation1_1 := fixture.FixUpdatingOperation("op1_1", instance1.InstanceID).Operation
 	operation1_1.State = domain.InProgress
-	operationStorage.InsertOperation(operation1_1)
-	instanceStorage.UpdateInstanceLastOperation(instance1.InstanceID, operation1_1.ID)
+	_ = operationStorage.InsertOperation(operation1_1)
+	_ = instanceStorage.UpdateInstanceLastOperation(instance1.InstanceID, operation1_1.ID)
 
 	// third instance, one provisioning, one deprovisioning
 	instance2 := fixInstance(instanceData{val: "inst3"})
-	instanceStorage.Insert(*instance2)
+	_ = instanceStorage.Insert(*instance2)
 
 	operation2_0 := fixProvisionOperation(instance2.InstanceID)
 	operation2_1 := fixDeprovisionOperation(instance2.InstanceID).Operation
 	operation2_1.State = domain.InProgress
 
-	operationStorage.InsertOperation(operation2_0)
-	operationStorage.InsertOperation(operation2_1)
-	instanceStorage.UpdateInstanceLastOperation(instance2.InstanceID, operation2_1.ID)
+	_ = operationStorage.InsertOperation(operation2_0)
+	_ = operationStorage.InsertOperation(operation2_1)
+	_ = instanceStorage.UpdateInstanceLastOperation(instance2.InstanceID, operation2_1.ID)
 
 	// when
 	got, _, _, err := instanceStorage.List(dbmodel.InstanceFilter{

--- a/internal/storage/ext.go
+++ b/internal/storage/ext.go
@@ -31,6 +31,8 @@ type Instances interface {
 	ListDeletedInstanceIDs(int) ([]string, error)
 
 	DeletedInstancesStatistics() (internal.DeletedStats, error)
+
+	UpdateInstanceLastOperation(instanceID, operationID string) error
 }
 
 type InstancesArchived interface {

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -25,6 +25,7 @@ type ReadSession interface {
 	FindAllInstancesForSubAccounts(subAccountslist []string) ([]dbmodel.InstanceDTO, dberr.Error)
 	GetInstanceByID(instanceID string) (dbmodel.InstanceDTO, dberr.Error)
 	GetLastOperation(instanceID string, types []internal.OperationType) (dbmodel.OperationDTO, dberr.Error)
+	GetLastOperationByLastOperationID(instanceID string, types []internal.OperationType) (dbmodel.OperationDTO, dberr.Error)
 	GetOperationByID(opID string) (dbmodel.OperationDTO, dberr.Error)
 	GetNotFinishedOperationsByType(operationType internal.OperationType) ([]dbmodel.OperationDTO, dberr.Error)
 	CountNotFinishedOperationsByInstanceID(instanceID string) (int, dberr.Error)

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -45,6 +45,7 @@ type ReadSession interface {
 	GetOrchestrationByID(oID string) (dbmodel.OrchestrationDTO, dberr.Error)
 	ListOrchestrations(filter dbmodel.OrchestrationFilter) ([]dbmodel.OrchestrationDTO, int, int, error)
 	ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error)
+	ListInstancesUsingLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error)
 	ListInstancesWithSubaccountStates(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error)
 	ListOperationsByOrchestrationID(orchestrationID string, filter dbmodel.OperationFilter) ([]dbmodel.OperationDTO, int, int, error)
 	ListOperationsInTimeRange(from, to time.Time) ([]dbmodel.OperationDTO, error)
@@ -89,6 +90,7 @@ type WriteSession interface {
 	InsertBinding(binding dbmodel.BindingDTO) dberr.Error
 	UpdateBinding(binding dbmodel.BindingDTO) dberr.Error
 	DeleteBinding(instanceID, bindingID string) dberr.Error
+	UpdateInstanceLastOperation(instanceID, operationID string) error
 }
 
 type Transaction interface {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -795,7 +795,7 @@ func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFi
 		return nil, -1, -1, fmt.Errorf("while fetching instances: %w", err)
 	}
 
-	totalCount, err := r.getInstanceCountByLastOpoerationID(filter)
+	totalCount, err := r.getInstanceCountByLastOperationID(filter)
 	if err != nil {
 		return nil, -1, -1, err
 	}

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -918,7 +918,7 @@ func (r readSession) ListEvents(filter events.EventFilter) ([]events.EventDTO, e
 	return events, err
 }
 
-func (r readSession) getInstanceCountByLastOpoerationID(filter dbmodel.InstanceFilter) (int, error) {
+func (r readSession) getInstanceCountByLastOperationID(filter dbmodel.InstanceFilter) (int, error) {
 	var res struct {
 		Total int
 	}

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -222,6 +222,25 @@ func (r readSession) GetLastOperation(instanceID string, types []internal.Operat
 	return operation, nil
 }
 
+func (r readSession) GetLastOperationByLastOperationID(instanceID string, types []internal.OperationType) (dbmodel.OperationDTO, dberr.Error) {
+	inst := dbr.Eq("instance_id", instanceID)
+	state := dbr.Neq("state", []string{orchestration.Pending, orchestration.Canceled})
+	condition := dbr.And(inst, state)
+	if len(types) > 0 {
+		condition = dbr.And(condition, dbr.Expr("type IN ?", types))
+	}
+	operation, err := r.getLastOperation(condition)
+	if err != nil {
+		switch {
+		case dberr.IsNotFound(err):
+			return dbmodel.OperationDTO{}, dberr.NotFound("for instance ID: %s %s", instanceID, err)
+		default:
+			return dbmodel.OperationDTO{}, err
+		}
+	}
+	return operation, nil
+}
+
 func (r readSession) GetOperationByInstanceID(instanceId string) (dbmodel.OperationDTO, dberr.Error) {
 	condition := dbr.Eq("instance_id", instanceId)
 	operation, err := r.getOperation(condition)
@@ -752,6 +771,42 @@ func (r readSession) GetNumberOfInstancesForGlobalAccountID(globalAccountID stri
 	return res.Total, err
 }
 
+func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error) {
+	var instances []dbmodel.InstanceWithExtendedOperationDTO
+
+	// select an instance with a last operation
+	stmt := r.session.Select("o.data", "o.state", "o.type", fmt.Sprintf("%s.*", InstancesTableName)).
+		From(InstancesTableName).
+		Join(dbr.I(OperationTableName).As("o"), fmt.Sprintf("%s.last_operation_id = o.id", InstancesTableName)).
+		OrderBy(fmt.Sprintf("%s.%s", InstancesTableName, CreatedAtField))
+
+	if len(filter.States) > 0 || filter.Suspended != nil {
+		stateFilters := buildInstanceStateFilters("o", filter)
+		stmt.Where(stateFilters)
+	}
+
+	// Add pagination
+	if filter.Page > 0 && filter.PageSize > 0 {
+		stmt = stmt.Paginate(uint64(filter.Page), uint64(filter.PageSize))
+	}
+
+	_, err := stmt.Load(&instances)
+	if err != nil {
+		return nil, -1, -1, fmt.Errorf("while fetching instances: %w", err)
+	}
+
+	totalCount, err := r.getInstanceCountByLastOpoerationID(filter)
+	if err != nil {
+		return nil, -1, -1, err
+	}
+
+	return instances,
+		len(instances),
+		totalCount,
+		nil
+}
+
+// deprecated, use ListInstancesUsingLastOperationID
 func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error) {
 	var instances []dbmodel.InstanceWithExtendedOperationDTO
 
@@ -799,6 +854,7 @@ func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.Ins
 		nil
 }
 
+// todo: refactor after migration to ListInstancesUsingLastOperationID
 func (r readSession) ListInstancesWithSubaccountStates(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error) {
 	var instances []dbmodel.InstanceWithSubaccountStateDTO
 
@@ -860,6 +916,27 @@ func (r readSession) ListEvents(filter events.EventFilter) ([]events.EventDTO, e
 	stmt.OrderBy("created_at")
 	_, err := stmt.Load(&events)
 	return events, err
+}
+
+func (r readSession) getInstanceCountByLastOpoerationID(filter dbmodel.InstanceFilter) (int, error) {
+	var res struct {
+		Total int
+	}
+	var stmt *dbr.SelectStmt
+	stmt = r.session.
+		Select("count(*) as total").
+		From(InstancesTableName).
+		Join(dbr.I(OperationTableName).As("o"), fmt.Sprintf("%s.last_operation_id = o.id", InstancesTableName))
+
+	if len(filter.States) > 0 || filter.Suspended != nil {
+		stateFilters := buildInstanceStateFilters("o1", filter)
+		stmt.Where(stateFilters)
+	}
+
+	addInstanceFilters(stmt, filter)
+	err := stmt.LoadOne(&res)
+
+	return res.Total, err
 }
 
 func (r readSession) getInstanceCount(filter dbmodel.InstanceFilter) (int, error) {

--- a/internal/storage/postsql/write.go
+++ b/internal/storage/postsql/write.go
@@ -21,6 +21,18 @@ type writeSession struct {
 	transaction *dbr.Tx
 }
 
+func (ws writeSession) UpdateInstanceLastOperation(instanceID, operationID string) error {
+	_, err := ws.update(InstancesTableName).
+		Set("last_operation_id", operationID).
+		Where(dbr.Eq("instance_id", instanceID)).
+		Exec()
+
+	if err != nil {
+		return dberr.Internal("Failed to update instance with last operation id: %s", err)
+	}
+	return nil
+}
+
 func (ws writeSession) DeleteBinding(instanceID, bindingID string) dberr.Error {
 	_, err := ws.deleteFrom(BindingsTableName).
 		Where(dbr.Eq("id", bindingID)).

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -48,7 +48,7 @@ func NewFromConfig(cfg Config, evcfg events.Config, cipher postgres.Cipher) (Bro
 
 	operation := postgres.NewOperation(fact, cipher)
 	return storage{
-		instance:          postgres.NewInstance(fact, operation, cipher),
+		instance:          postgres.NewInstance(fact, operation, cipher, cfg.UseLastOperationID),
 		operation:         operation,
 		orchestrations:    postgres.NewOrchestrations(fact),
 		runtimeStates:     postgres.NewRuntimeStates(fact, cipher),

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -46,7 +46,7 @@ func NewFromConfig(cfg Config, evcfg events.Config, cipher postgres.Cipher) (Bro
 
 	fact := postsql.NewFactory(connection)
 
-	operation := postgres.NewOperation(fact, cipher)
+	operation := postgres.NewOperation(fact, cipher, cfg.UseLastOperationID)
 	return storage{
 		instance:          postgres.NewInstance(fact, operation, cipher, cfg.UseLastOperationID),
 		operation:         operation,

--- a/resources/keb/migrations/202502121600_add_lastoperationid.down.sql
+++ b/resources/keb/migrations/202502121600_add_lastoperationid.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE instances
+    DROP COLUMN last_operation_id;

--- a/resources/keb/migrations/202502121600_add_lastoperationid.up.sql
+++ b/resources/keb/migrations/202502121600_add_lastoperationid.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE instances
+    ADD COLUMN last_operation_id varchar(255) DEFAULT '';

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -155,6 +155,8 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.edp.secretName }}"
                   key: secret
+            - name: APP_DATABASE_USE_LAST_OPERATION_ID
+              value: "{{ .Values.useLastOperationID }}"
             - name: APP_DATABASE_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -492,3 +492,5 @@ regionsSupportingMachine: |-
     - europe-west3
     - asia-south1
     - us-central1
+
+useLastOperationID: false


### PR DESCRIPTION
…query

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- introduce last_operation_id in the instances table to speed up the list instances query
- the ListInstances storage method can use new way of listing instances (depends on a feature flag)

**Related issue(s)**
Related: https://github.com/kyma-project/kyma-environment-broker/issues/1734