### PR TITLE
UseLastOperationID - log the value, implement new ListInstancesWithSubaccountStates

### DIFF
--- a/internal/storage/driver/postsql/instance.go
+++ b/internal/storage/driver/postsql/instance.go
@@ -625,7 +625,7 @@ func (s *Instance) ListWithSubaccountState(filter dbmodel.InstanceFilter) ([]int
 	var dtos []dbmodel.InstanceWithSubaccountStateDTO
 	var err error
 	if s.UseLastOperationID {
-		dtos, count, totalCount, err = s.NewReadSession().ListInstancesWithSubaccountStates(filter)
+		dtos, count, totalCount, err = s.NewReadSession().ListInstancesWithSubaccountStatesWithUseLastOperationID(filter)
 	} else {
 		dtos, count, totalCount, err = s.NewReadSession().ListInstancesWithSubaccountStates(filter)
 	}

--- a/internal/storage/driver/postsql/instance.go
+++ b/internal/storage/driver/postsql/instance.go
@@ -621,7 +621,15 @@ func (s *Instance) UpdateInstanceLastOperation(instanceID, operationID string) e
 }
 
 func (s *Instance) ListWithSubaccountState(filter dbmodel.InstanceFilter) ([]internal.InstanceWithSubaccountState, int, int, error) {
-	dtos, count, totalCount, err := s.NewReadSession().ListInstancesWithSubaccountStates(filter)
+	var count, totalCount int
+	var dtos []dbmodel.InstanceWithSubaccountStateDTO
+	var err error
+	if s.UseLastOperationID {
+		dtos, count, totalCount, err = s.NewReadSession().ListInstancesWithSubaccountStates(filter)
+	} else {
+		dtos, count, totalCount, err = s.NewReadSession().ListInstancesWithSubaccountStates(filter)
+	}
+
 	if err != nil {
 		return []internal.InstanceWithSubaccountState{}, 0, 0, err
 	}

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -1113,14 +1113,14 @@ func TestInstanceStorage_ListInstances(t *testing.T) {
 	_ = instanceStorage.UpdateInstanceLastOperation(instance2.InstanceID, operation2_1.ID)
 
 	// when
-	got, _, _, err := instanceStorage.List(dbmodel.InstanceFilter{
+	got, _, _, err := instanceStorage.ListWithSubaccountState(dbmodel.InstanceFilter{
 		States:   []dbmodel.InstanceState{dbmodel.InstanceUpdating},
 		PageSize: 10,
 		Page:     1,
 	})
 	assert.Equal(t, 2, len(got))
 
-	got, _, _, err = instanceStorage.List(dbmodel.InstanceFilter{
+	got, _, _, err = instanceStorage.ListWithSubaccountState(dbmodel.InstanceFilter{
 		States:   []dbmodel.InstanceState{dbmodel.InstanceUpdating},
 		PageSize: 1,
 		Page:     1,
@@ -1128,7 +1128,7 @@ func TestInstanceStorage_ListInstances(t *testing.T) {
 	assert.Equal(t, 1, len(got))
 
 	// when
-	got, _, _, err = instanceStorage.List(dbmodel.InstanceFilter{
+	got, _, _, err = instanceStorage.ListWithSubaccountState(dbmodel.InstanceFilter{
 		States:   []dbmodel.InstanceState{dbmodel.InstanceDeprovisioning},
 		PageSize: 10,
 		Page:     1,

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -48,6 +48,7 @@ type ReadSession interface {
 	ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error)
 	ListInstancesUsingLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error)
 	ListInstancesWithSubaccountStates(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error)
+	ListInstancesWithSubaccountStatesWithUseLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error)
 	ListOperationsByOrchestrationID(orchestrationID string, filter dbmodel.OperationFilter) ([]dbmodel.OperationDTO, int, int, error)
 	ListOperationsInTimeRange(from, to time.Time) ([]dbmodel.OperationDTO, error)
 	GetOperationStatsForOrchestration(orchestrationID string) ([]dbmodel.OperationStatEntry, error)

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -3,6 +3,7 @@ package postsql
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -774,6 +775,8 @@ func (r readSession) GetNumberOfInstancesForGlobalAccountID(globalAccountID stri
 func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error) {
 	var instances []dbmodel.InstanceWithExtendedOperationDTO
 
+	slog.Info("List instances - ListInstancesUsingLastOperationID", "filter", filter)
+
 	// select an instance with a last operation
 	stmt := r.session.Select("o.data", "o.state", "o.type", fmt.Sprintf("%s.*", InstancesTableName)).
 		From(InstancesTableName).
@@ -809,6 +812,8 @@ func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFi
 // deprecated, use ListInstancesUsingLastOperationID
 func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithExtendedOperationDTO, int, int, error) {
 	var instances []dbmodel.InstanceWithExtendedOperationDTO
+
+	slog.Info("List instances - ListInstances", "filter", filter)
 
 	// Base select and order by created at
 	var stmt *dbr.SelectStmt

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -798,6 +798,8 @@ func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFi
 		return nil, -1, -1, fmt.Errorf("while fetching instances: %w", err)
 	}
 
+	slog.Info("Got %d instances", len(instances))
+
 	totalCount, err := r.getInstanceCountByLastOperationID(filter)
 	if err != nil {
 		return nil, -1, -1, err

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -798,7 +798,7 @@ func (r readSession) ListInstancesUsingLastOperationID(filter dbmodel.InstanceFi
 		return nil, -1, -1, fmt.Errorf("while fetching instances: %w", err)
 	}
 
-	slog.Info("Got %d instances", len(instances))
+	slog.Info(fmt.Sprintf("Got %d instances", len(instances)))
 
 	totalCount, err := r.getInstanceCountByLastOperationID(filter)
 	if err != nil {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -865,6 +865,8 @@ func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.Ins
 func (r readSession) ListInstancesWithSubaccountStates(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error) {
 	var instances []dbmodel.InstanceWithSubaccountStateDTO
 
+	slog.Info("Calling ListInstancesWithSubaccountStates")
+
 	// Base select and order by created at
 	var stmt *dbr.SelectStmt
 	// Find and join the last operation for each instance matching the state filter(s).
@@ -880,6 +882,50 @@ func (r readSession) ListInstancesWithSubaccountStates(filter dbmodel.InstanceFi
 		LeftJoin(dbr.I(SubaccountStatesTableName).As("ss"), fmt.Sprintf("%s.sub_account_id = ss.id", InstancesTableName)).
 		Where("o2.created_at IS NULL").
 		Where(fmt.Sprintf("o1.state NOT IN ('%s', '%s')", orchestration.Pending, orchestration.Canceled)).
+		OrderBy(fmt.Sprintf("%s.%s", InstancesTableName, CreatedAtField))
+
+	if len(filter.States) > 0 || filter.Suspended != nil {
+		stateFilters := buildInstanceStateFilters("o1", filter)
+		stmt.Where(stateFilters)
+	}
+
+	// Add pagination
+	if filter.Page > 0 && filter.PageSize > 0 {
+		stmt = stmt.Paginate(uint64(filter.Page), uint64(filter.PageSize))
+	}
+
+	addInstanceFilters(stmt, filter)
+
+	_, err := stmt.Load(&instances)
+	if err != nil {
+		return nil, -1, -1, fmt.Errorf("while fetching instances: %w", err)
+	}
+
+	// getInstanceCount is appropriate for this query because we added only left join without any additional selection/filtering
+	totalCount, err := r.getInstanceCount(filter)
+	if err != nil {
+		return nil, -1, -1, err
+	}
+
+	return instances,
+		len(instances),
+		totalCount,
+		nil
+}
+
+func (r readSession) ListInstancesWithSubaccountStatesWithUseLastOperationID(filter dbmodel.InstanceFilter) ([]dbmodel.InstanceWithSubaccountStateDTO, int, int, error) {
+	var instances []dbmodel.InstanceWithSubaccountStateDTO
+
+	slog.Info("Calling ListInstancesWithSubaccountStatesWithUseLastOperationID")
+
+	// Base select and order by created at
+	var stmt *dbr.SelectStmt
+
+	// select an instance with a last operation
+	stmt = r.session.Select("o.data", "o.state", "o.type", fmt.Sprintf("%s.*", InstancesTableName), "ss.beta_enabled", "ss.used_for_production").
+		From(InstancesTableName).
+		Join(dbr.I(OperationTableName).As("o"), fmt.Sprintf("%s.last_operation_id = o.id", InstancesTableName)).
+		LeftJoin(dbr.I(SubaccountStatesTableName).As("ss"), fmt.Sprintf("%s.sub_account_id = ss.id", InstancesTableName)).
 		OrderBy(fmt.Sprintf("%s.%s", InstancesTableName, CreatedAtField))
 
 	if len(filter.States) > 0 || filter.Suspended != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -32,8 +32,8 @@ const (
 )
 
 func NewFromConfig(cfg Config, evcfg events.Config, cipher postgres.Cipher) (BrokerStorage, *dbr.Connection, error) {
-	slog.Info(fmt.Sprintf("Setting DB connection pool params: connectionMaxLifetime=%s maxIdleConnections=%d maxOpenConnections=%d",
-		cfg.ConnMaxLifetime, cfg.MaxIdleConns, cfg.MaxOpenConns))
+	slog.Info(fmt.Sprintf("Setting DB connection pool params: connectionMaxLifetime=%s maxIdleConnections=%d maxOpenConnections=%d useLastOperationID=%v",
+		cfg.ConnMaxLifetime, cfg.MaxIdleConns, cfg.MaxOpenConns, cfg.UseLastOperationID))
 
 	connection, err := postsql.InitializeDatabase(cfg.ConnectionURL(), connectionRetries)
 	if err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- create ListInstancesWithSubaccountStatesWithUseLastOperationID to replace ListInstancesWithSubaccountStates
- log the UseLastOperationID value

**Related issue(s)**
Related: https://github.com/kyma-project/kyma-environment-broker/issues/1734