### PR TITLE
Fix worker pool update params in last operation

### DIFF
--- a/internal/model.go
+++ b/internal/model.go
@@ -472,6 +472,10 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 		op.ProvisioningParameters.Parameters.MachineType = updatingParams.MachineType
 	}
 
+	if updatingParams.AdditionalWorkerNodePools != nil {
+		op.ProvisioningParameters.Parameters.AdditionalWorkerNodePools = updatingParams.AdditionalWorkerNodePools
+	}
+
 	return op
 }
 

--- a/internal/model.go
+++ b/internal/model.go
@@ -472,7 +472,7 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 		op.ProvisioningParameters.Parameters.MachineType = updatingParams.MachineType
 	}
 
-	if updatingParams.AdditionalWorkerNodePools != nil {
+	if len(updatingParams.AdditionalWorkerNodePools) != 0 {
 		op.ProvisioningParameters.Parameters.AdditionalWorkerNodePools = updatingParams.AdditionalWorkerNodePools
 	}
 

--- a/internal/model.go
+++ b/internal/model.go
@@ -472,7 +472,7 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 		op.ProvisioningParameters.Parameters.MachineType = updatingParams.MachineType
 	}
 
-	if len(updatingParams.AdditionalWorkerNodePools) != 0 {
+	if updatingParams.AdditionalWorkerNodePools != nil {
 		op.ProvisioningParameters.Parameters.AdditionalWorkerNodePools = updatingParams.AdditionalWorkerNodePools
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Incoming `AdditionalWorkerNodePools` params were not saved to the latest operation during update operation.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
