### PR TITLE
Corrected Logger Initialization

### DIFF
--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -108,32 +108,32 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 				}
 
 				id := key.(string)
-				log = log.With("operationID", id)
-				log.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
+				workerLogger := log.With("operationID", id)
+				workerLogger.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
 				q.updateWorkerTime(id, workerNameId, log)
 
 				defer func() {
 					if err := recover(); err != nil {
-						log.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
+						workerLogger.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					q.removeTimeIfInWarnMargin(id, workerNameId, log)
 					queue.Done(key)
-					log.Info("queue done processing")
+					workerLogger.Info("queue done processing")
 				}()
 
 				when, err := process(id)
 				if err == nil && when != 0 {
-					log.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
+					workerLogger.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
 					afterDuration := time.Duration(int64(when) / q.speedFactor)
 					queue.AddAfter(key, afterDuration)
 					return false
 				}
 				if err != nil {
-					log.Error(fmt.Sprintf("Error from process: %v", err))
+					workerLogger.Error(fmt.Sprintf("Error from process: %v", err))
 				}
 
 				queue.Forget(key)
-				log.Info(fmt.Sprintf("item for %s has been processed, no retry, element forgotten", id))
+				workerLogger.Info(fmt.Sprintf("item for %s has been processed, no retry, element forgotten", id))
 
 				return false
 			}()

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -110,7 +110,7 @@ func (q *Queue) worker(queue workqueue.RateLimitingInterface, process func(key s
 				id := key.(string)
 				workerLogger := log.With("operationID", id)
 				workerLogger.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
-				q.updateWorkerTime(id, workerNameId, log)
+				q.updateWorkerTime(id, workerNameId, workerLogger)
 
 				defer func() {
 					if err := recover(); err != nil {

--- a/internal/process/queue_test.go
+++ b/internal/process/queue_test.go
@@ -57,13 +57,15 @@ func TestWorkerLogging(t *testing.T) {
 		require.True(t, strings.Contains(stringLogs, "msg=\"starting worker with id 0\" queueName=test workerId=0"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"item processId2 will be added to the queue test after duration of 0, queue length is 1\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"added item processId to the queue test, queue length is 2\" queueName=test"))
+
 		require.True(t, strings.Contains(stringLogs, "msg=\"updating worker time, processing item processId2, queue length is 1\" queueName=test workerId=0 operationID=processId2"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"updating worker time, processing item processId, queue length is 0\" queueName=test workerId=0 operationID=processId"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"shutting down the queue, queue length is 0\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"queue speed factor set to 1\" queueName=test"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"worker routine - starting\" queueName=test workerId=0"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"worker done\" queueName=test workerId=0"))
-		require.True(t, strings.Contains(stringLogs, "msg=\"shutting down\" queueName=test workerId=0 operationID=processId"))
+
+		require.True(t, strings.Contains(stringLogs, "msg=\"shutting down\" queueName=test workerId=0"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"item for processId has been processed, no retry, element forgotten\" queueName=test workerId=0 operationID=processId"))
 		require.True(t, strings.Contains(stringLogs, "msg=\"about to process item processId, queue length is 0\" queueName=test workerId=0 operationID=processId"))
 	})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The way that logger was initializad with `operationID` made it produce logs like the following where the `operationID` log is duplicated: 

```
time=2025-02-17T10:24:24.869+01:00 level=INFO msg="queue done processing" queueName=test workerId=0 operationID=processId2 operationID=processId
```

Changes proposed in this pull request:

- corrected logger initialization,
- tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
