### PR TITLE
ERS stats query using `last_operation_id`

### DIFF
--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -58,7 +58,7 @@ func FixERSContext(id string) internal.ERSContext {
 		tenantID     = fmt.Sprintf("Tenant-%s", id)
 		subAccountId = fmt.Sprintf("SA-%s", id)
 		userID       = fmt.Sprintf("User-%s", id)
-		licenseType  = ""
+		licenseType  = "SAPDEV"
 	)
 
 	return internal.ERSContext{

--- a/internal/storage/driver/postsql/instance.go
+++ b/internal/storage/driver/postsql/instance.go
@@ -457,7 +457,15 @@ func (s *Instance) GetActiveInstanceStats() (internal.InstanceStats, error) {
 }
 
 func (s *Instance) GetERSContextStats() (internal.ERSContextStats, error) {
-	entries, err := s.NewReadSession().GetERSContextStats()
+	var err error
+	var entries []dbmodel.InstanceERSContextStatsEntry
+
+	//TODO remove conditional after migration
+	if s.UseLastOperationID {
+		entries, err = s.NewReadSession().GetERSContextStatsUsingLastOperationID()
+	} else {
+		entries, err = s.NewReadSession().GetERSContextStats()
+	}
 	if err != nil {
 		return internal.ERSContextStats{}, err
 	}

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -164,6 +164,72 @@ func TestInstance(t *testing.T) {
 		assert.Equal(t, 0, numberOfInstancesB)
 	})
 
+	t.Run("Should fetch ERS context statistics", func(t *testing.T) {
+		storageCleanup, brokerStorage, err := GetStorageForDatabaseTests()
+		require.NoError(t, err)
+		require.NotNil(t, brokerStorage)
+		defer func() {
+			err := storageCleanup()
+			assert.NoError(t, err)
+		}()
+
+		// populate database with samples
+		fixInstances := []internal.Instance{
+			*fixInstance(instanceData{val: "A1", globalAccountID: "A", subAccountID: "sub-01"}),
+			*fixInstance(instanceData{val: "A2", globalAccountID: "A", subAccountID: "sub-02", deletedAt: time.Time{}}),
+			*fixInstance(instanceData{val: "A3", globalAccountID: "A", subAccountID: "sub-02"}),
+			*fixInstance(instanceData{val: "C1", globalAccountID: "C", subAccountID: "sub-01"}),
+			*fixInstance(instanceData{val: "C2", globalAccountID: "C", deletedAt: time.Now()}), // deleted - should not be counted
+			*fixInstance(instanceData{val: "B1", globalAccountID: "B", deletedAt: time.Now()}), // deleted - should not be counted
+		}
+
+		for _, i := range fixInstances {
+			err = brokerStorage.Instances().Insert(i)
+			require.NoError(t, err)
+		}
+
+		op1 := fixture.FixProvisioningOperation("op1", "A1")
+
+		op2 := fixture.FixProvisioningOperation("op2", "A2")
+		op2.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		op3 := fixture.FixSuspensionOperationAsOperation("op3", "A3")
+
+		// simulating update with different license type, since query is based on created_at date we need to adjust creation times
+		// provisioning precedes update
+		op4 := fixture.FixProvisioningOperation("op4", "C1")
+		op4.CreatedAt = time.Date(2025, 2, 19, 11, 0, 0, 0, time.UTC)
+		op5 := fixture.FixUpdatingOperation("op5", "C1").Operation
+		op5.CreatedAt = time.Date(2025, 2, 19, 12, 0, 0, 0, time.UTC)
+		op5.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		op6 := fixture.FixProvisioningOperation("op6", "C2") // this instance is deleted, should not be counted
+
+		// simulating update with different license type, since query is based on created_at date we need to adjust creation times
+		// but the instance is already deleted
+		op7 := fixture.FixProvisioningOperation("op7", "B1")
+		op7.CreatedAt = time.Date(2025, 2, 19, 11, 0, 0, 0, time.UTC)
+		op8 := fixture.FixUpdatingOperation("op8", "B1").Operation
+		op8.CreatedAt = time.Date(2025, 2, 19, 12, 0, 0, 0, time.UTC)
+		op8.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		fixOperations := []internal.Operation{op1, op2, op3, op4, op5, op6, op7, op8}
+
+		for _, i := range fixOperations {
+			err = brokerStorage.Operations().InsertOperation(i)
+			require.NoError(t, err)
+		}
+
+		// when
+		stats, err := brokerStorage.Instances().GetERSContextStats()
+		require.NoError(t, err)
+
+		t.Logf("%+v", stats)
+
+		// then
+		assert.Equal(t, internal.ERSContextStats{LicenseType: map[string]int{"SAPDEV": 2, "SAPOTHER": 2}}, stats)
+	})
+
 	t.Run("Should get distinct subaccounts from active instances", func(t *testing.T) {
 		storageCleanup, brokerStorage, err := GetStorageForDatabaseTests()
 		require.NoError(t, err)

--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -1264,6 +1264,74 @@ func TestInstance_UsingLastOperationID(t *testing.T) {
 		assert.Equal(t, 0, numberOfInstancesB)
 	})
 
+	t.Run("Should fetch ERS context statistics", func(t *testing.T) {
+		storageCleanup, brokerStorage, err := storage.GetStorageForTest(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, brokerStorage)
+		defer func() {
+			err := storageCleanup()
+			assert.NoError(t, err)
+		}()
+
+		// populate database with samples
+		fixInstances := []internal.Instance{
+			*fixInstance(instanceData{val: "A1", globalAccountID: "A", subAccountID: "sub-01"}),
+			*fixInstance(instanceData{val: "A2", globalAccountID: "A", subAccountID: "sub-02", deletedAt: time.Time{}}),
+			*fixInstance(instanceData{val: "A3", globalAccountID: "A", subAccountID: "sub-02"}),
+			*fixInstance(instanceData{val: "C1", globalAccountID: "C", subAccountID: "sub-01"}),
+			*fixInstance(instanceData{val: "C2", globalAccountID: "C", deletedAt: time.Now()}), // deleted - should not be counted
+			*fixInstance(instanceData{val: "B1", globalAccountID: "B", deletedAt: time.Now()}), // deleted - should not be counted
+		}
+
+		for _, i := range fixInstances {
+			err = brokerStorage.Instances().Insert(i)
+			require.NoError(t, err)
+		}
+
+		op1 := fixture.FixProvisioningOperation("op1", "A1")
+
+		op2 := fixture.FixProvisioningOperation("op2", "A2")
+		op2.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		op3 := fixture.FixSuspensionOperationAsOperation("op3", "A3")
+
+		// simulating update with different license type, since query is based on created_at date we need to adjust creation times
+		// provisioning precedes update
+		op4 := fixture.FixProvisioningOperation("op4", "C1")
+		op4.CreatedAt = time.Date(2025, 2, 19, 11, 0, 0, 0, time.UTC)
+		op5 := fixture.FixUpdatingOperation("op5", "C1").Operation
+		op5.CreatedAt = time.Date(2025, 2, 19, 12, 0, 0, 0, time.UTC)
+		op5.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		op6 := fixture.FixProvisioningOperation("op6", "C2") // this instance is deleted, should not be counted
+
+		// simulating update with different license type, since query is based on created_at date we need to adjust creation times
+		// but the instance is already deleted
+		op7 := fixture.FixProvisioningOperation("op7", "B1")
+		op7.CreatedAt = time.Date(2025, 2, 19, 11, 0, 0, 0, time.UTC)
+		op8 := fixture.FixUpdatingOperation("op8", "B1").Operation
+		op8.CreatedAt = time.Date(2025, 2, 19, 12, 0, 0, 0, time.UTC)
+		op8.ProvisioningParameters.ErsContext.LicenseType = ptr.String("SAPOTHER")
+
+		fixOperations := []internal.Operation{op1, op2, op3, op4, op5, op6, op7, op8}
+
+		for _, i := range fixOperations {
+			err = brokerStorage.Operations().InsertOperation(i)
+			require.NoError(t, err)
+			err = brokerStorage.Instances().UpdateInstanceLastOperation(i.InstanceID, i.ID)
+			require.NoError(t, err)
+		}
+
+		// when
+		stats, err := brokerStorage.Instances().GetERSContextStats()
+		require.NoError(t, err)
+
+		t.Logf("%+v", stats)
+
+		// then
+		assert.Equal(t, internal.ERSContextStats{LicenseType: map[string]int{"SAPDEV": 2, "SAPOTHER": 2}}, stats)
+	})
+
 	t.Run("Should get distinct subaccounts from active instances", func(t *testing.T) {
 		storageCleanup, brokerStorage, err := storage.GetStorageForTest(cfg)
 		require.NoError(t, err)

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -42,6 +42,7 @@ type ReadSession interface {
 	GetActiveInstanceStatsUsingLastOperationID() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error)
 	GetSubaccountsInstanceStatsUsingLastOperationID() ([]dbmodel.InstanceBySubAccountIDStatEntry, error)
 	GetERSContextStats() ([]dbmodel.InstanceERSContextStatsEntry, error)
+	GetERSContextStatsUsingLastOperationID() ([]dbmodel.InstanceERSContextStatsEntry, error)
 	GetNumberOfInstancesForGlobalAccountID(globalAccountID string) (int, error)
 	GetRuntimeStateByOperationID(operationID string) (dbmodel.RuntimeStateDTO, dberr.Error)
 	ListRuntimeStateByRuntimeID(runtimeID string) ([]dbmodel.RuntimeStateDTO, dberr.Error)

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -807,7 +807,7 @@ func (r readSession) GetERSContextStatsUsingLastOperationID() ([]dbmodel.Instanc
 	var rows []dbmodel.InstanceERSContextStatsEntry
 	// group existing instances by license_Type from the last operation
 	_, err := r.session.SelectBySql(`
-SELECT count(*), (o.provisioning_parameters -> 'ers_context' -> 'license_type')::VARCHAR AS license_type
+SELECT count(*) as total, (o.provisioning_parameters -> 'ers_context' -> 'license_type')::VARCHAR AS license_type
 FROM instances i
          INNER JOIN operations o ON i.last_operation_id = o.id
 WHERE i.deleted_at = '0001-01-01T00:00:00.000Z'

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -803,6 +803,18 @@ GROUP BY license_type;
 	return rows, err
 }
 
+func (r readSession) GetERSContextStatsUsingLastOperationID() ([]dbmodel.InstanceERSContextStatsEntry, error) {
+	var rows []dbmodel.InstanceERSContextStatsEntry
+	// group existing instances by license_Type from the last operation
+	_, err := r.session.SelectBySql(`
+SELECT count(*), (o.provisioning_parameters -> 'ers_context' -> 'license_type')::VARCHAR AS license_type
+FROM instances i
+         INNER JOIN operations o ON i.last_operation_id = o.id
+WHERE i.deleted_at = '0001-01-01T00:00:00.000Z'
+GROUP BY license_type;`).Load(&rows)
+	return rows, err
+}
+
 func (r readSession) GetNumberOfInstancesForGlobalAccountID(globalAccountID string) (int, error) {
 	var res struct {
 		Total int


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Old query has become inefficient and runs approx. 5s on PROD due to the cases of instances with thousands of operations.

Changes proposed in this pull request:

- ERS stats (licenses) query using `last_operation_id` field (on feature flag)
- test cases for old and new query 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#1734 