### PR TITLE
Populate additionalOIDC field during provisioning and update

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -196,6 +196,8 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 		DefaultGardenerShootPurpose:  "testing",
 		DefaultTrialProvider:         pkg.AWS,
 		EnableShootAndSeedSameRegion: cfg.Provisioner.EnableShootAndSeedSameRegion,
+		UseMainOIDC:                  true,
+		UseAdditionalOIDC:            false,
 	}, map[string]string{"cf-eu10": "europe", "cf-us10": "us"}, cfg.FreemiumProviders, defaultOIDCValues(), cfg.Broker.UseSmallerMachineTypes)
 
 	storageCleanup, db, err := GetStorageForE2ETests()

--- a/cmd/broker/storage_test.go
+++ b/cmd/broker/storage_test.go
@@ -84,5 +84,5 @@ func dbInMemoryForE2ETests() bool {
 	} else {
 		fmt.Println("running e2e test on real postgres database")
 	}
-	return true
+	return v
 }

--- a/cmd/broker/storage_test.go
+++ b/cmd/broker/storage_test.go
@@ -84,5 +84,5 @@ func dbInMemoryForE2ETests() bool {
 	} else {
 		fmt.Println("running e2e test on real postgres database")
 	}
-	return v
+	return true
 }

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -281,6 +281,8 @@ func fixConfig() *Config {
 			CheckRuntimeResourceDeletionStepTimeout: 50 * time.Millisecond,
 			DefaultTrialProvider:                    "AWS",
 			ControlPlaneFailureTolerance:            "zone",
+			UseMainOIDC:                             true,
+			UseAdditionalOIDC:                       false,
 		},
 		Database: storage.Config{
 			SecretKey: dbSecretKey,

--- a/internal/process/input/input.go
+++ b/internal/process/input/input.go
@@ -42,6 +42,8 @@ type Config struct {
 	ClusterUpdateStepTimeout                time.Duration     `envconfig:"default=2h"`
 	CheckRuntimeResourceDeletionStepTimeout time.Duration     `envconfig:"default=1h"`
 	EnableShootAndSeedSameRegion            bool              `envconfig:"default=false"`
+	UseMainOIDC                             bool              `envconfig:"default=true"`
+	UseAdditionalOIDC                       bool              `envconfig:"default=false"`
 }
 
 type RuntimeInput struct {

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -298,13 +298,20 @@ func (s *CreateRuntimeResourceStep) createKubernetesConfiguration(operation inte
 		}
 	}
 
-	return imv1.Kubernetes{
-		Version: ptr.String(s.config.KubernetesVersion),
-		KubeAPIServer: imv1.APIServer{
-			OidcConfig:           oidc,
-			AdditionalOidcConfig: &[]gardener.OIDCConfig{oidc},
-		},
+	kubernetesConfig := imv1.Kubernetes{
+		Version:       ptr.String(s.config.KubernetesVersion),
+		KubeAPIServer: imv1.APIServer{},
 	}
+
+	if s.config.UseMainOIDC {
+		kubernetesConfig.KubeAPIServer.OidcConfig = oidc
+	}
+
+	if s.config.UseAdditionalOIDC {
+		kubernetesConfig.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{oidc}
+	}
+
+	return kubernetesConfig
 }
 
 func (s *CreateRuntimeResourceStep) updateInstance(id string, region string) error {

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -305,6 +305,7 @@ func (s *CreateRuntimeResourceStep) createKubernetesConfiguration(operation inte
 
 	if s.config.UseMainOIDC {
 		kubernetesConfig.KubeAPIServer.OidcConfig = oidc
+		kubernetesConfig.KubeAPIServer.AdditionalOidcConfig = nil
 	}
 
 	if s.config.UseAdditionalOIDC {

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -302,7 +302,7 @@ func (s *CreateRuntimeResourceStep) createKubernetesConfiguration(operation inte
 		Version: ptr.String(s.config.KubernetesVersion),
 		KubeAPIServer: imv1.APIServer{
 			OidcConfig:           oidc,
-			AdditionalOidcConfig: nil,
+			AdditionalOidcConfig: &[]gardener.OIDCConfig{oidc},
 		},
 	}
 }

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -246,7 +246,7 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 	}, &runtime)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOIDCConfig, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
-	assert.Equal(t, expectedOIDCConfig, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)
 }
 
 func TestCreateRuntimeResourceStep_FailureToleranceForTrial(t *testing.T) {

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -62,7 +62,7 @@ var defaultOIDSConfig = pkg.OIDCConfigDTO{
 	UsernamePrefix: "up-default",
 }
 
-func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
+func TestCreateRuntimeResourceStep_onlyMainOIDC_AllCustom(t *testing.T) {
 	// given
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
@@ -85,7 +85,11 @@ func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-custom"),
 	}
-	inputConfig := input.Config{MultiZoneCluster: true}
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: false,
+	}
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
 
@@ -102,6 +106,105 @@ func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
 	}, &runtime)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOIDCConfig, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)
+}
+
+func TestCreateRuntimeResourceStep_MainAndAdditionalOIDC_AllCustom(t *testing.T) {
+	// given
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	memoryStorage := storage.NewMemoryStorage()
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
+		ClientID:       "client-id-custom",
+		GroupsClaim:    "gc-custom",
+		IssuerURL:      "issuer-url-custom",
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  "uc-custom",
+		UsernamePrefix: "up-custom",
+	}
+	assertInsertions(t, memoryStorage, instance, operation)
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-custom"),
+	}
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: true,
+	}
+	cli := getClientForTests(t)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+
+	// when
+	_, repeat, err := step.Run(operation, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, repeat)
+	runtime := imv1.Runtime{}
+	err = cli.Get(context.Background(), client.ObjectKey{
+		Namespace: "kyma-system",
+		Name:      operation.RuntimeID,
+	}, &runtime)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedOIDCConfig, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, expectedOIDCConfig, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+}
+
+func TestCreateRuntimeResourceStep_onlyAdditionalOIDC_AllCustom(t *testing.T) {
+	// given
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	memoryStorage := storage.NewMemoryStorage()
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
+		ClientID:       "client-id-custom",
+		GroupsClaim:    "gc-custom",
+		IssuerURL:      "issuer-url-custom",
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  "uc-custom",
+		UsernamePrefix: "up-custom",
+	}
+	assertInsertions(t, memoryStorage, instance, operation)
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-custom"),
+	}
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       false,
+		UseAdditionalOIDC: true,
+	}
+	cli := getClientForTests(t)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+
+	// when
+	_, repeat, err := step.Run(operation, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, repeat)
+	runtime := imv1.Runtime{}
+	err = cli.Get(context.Background(), client.ObjectKey{
+		Namespace: "kyma-system",
+		Name:      operation.RuntimeID,
+	}, &runtime)
+	assert.NoError(t, err)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.ClientID)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.GroupsClaim)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.IssuerURL)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernameClaim)
+	assert.Nil(t, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernamePrefix)
 	assert.Equal(t, expectedOIDCConfig, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -229,7 +229,11 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-default"),
 	}
-	inputConfig := input.Config{MultiZoneCluster: true}
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: false,
+	}
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
 

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -101,6 +101,14 @@ func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-custom"),
 	}, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-custom"),
+	}, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 
 func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
@@ -140,6 +148,14 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-default"),
 	}, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-default"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-default"),
+	}, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 
 func TestCreateRuntimeResourceStep_FailureToleranceForTrial(t *testing.T) {

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -77,6 +77,14 @@ func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
 		UsernamePrefix: "up-custom",
 	}
 	assertInsertions(t, memoryStorage, instance, operation)
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-custom"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-custom"),
+	}
 	inputConfig := input.Config{MultiZoneCluster: true}
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
@@ -93,22 +101,8 @@ func TestCreateRuntimeResourceStep_OIDC_AllCustom(t *testing.T) {
 		Name:      operation.RuntimeID,
 	}, &runtime)
 	assert.NoError(t, err)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("client-id-custom"),
-		GroupsClaim:    ptr.String("gc-custom"),
-		IssuerURL:      ptr.String("issuer-url-custom"),
-		SigningAlgs:    []string{"sa-custom"},
-		UsernameClaim:  ptr.String("uc-custom"),
-		UsernamePrefix: ptr.String("up-custom"),
-	}, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("client-id-custom"),
-		GroupsClaim:    ptr.String("gc-custom"),
-		IssuerURL:      ptr.String("issuer-url-custom"),
-		SigningAlgs:    []string{"sa-custom"},
-		UsernameClaim:  ptr.String("uc-custom"),
-		UsernamePrefix: ptr.String("up-custom"),
-	}, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+	assert.Equal(t, expectedOIDCConfig, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, expectedOIDCConfig, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 
 func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
@@ -124,6 +118,14 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		UsernameClaim: "uc-custom",
 	}
 	assertInsertions(t, memoryStorage, instance, operation)
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("client-id-custom"),
+		GroupsClaim:    ptr.String("gc-custom"),
+		IssuerURL:      ptr.String("issuer-url-custom"),
+		SigningAlgs:    []string{"sa-default"},
+		UsernameClaim:  ptr.String("uc-custom"),
+		UsernamePrefix: ptr.String("up-default"),
+	}
 	inputConfig := input.Config{MultiZoneCluster: true}
 	cli := getClientForTests(t)
 	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -142,22 +142,8 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		Name:      operation.RuntimeID,
 	}, &runtime)
 	assert.NoError(t, err)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("client-id-custom"),
-		GroupsClaim:    ptr.String("gc-custom"),
-		IssuerURL:      ptr.String("issuer-url-custom"),
-		SigningAlgs:    []string{"sa-default"},
-		UsernameClaim:  ptr.String("uc-custom"),
-		UsernamePrefix: ptr.String("up-default"),
-	}, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("client-id-custom"),
-		GroupsClaim:    ptr.String("gc-custom"),
-		IssuerURL:      ptr.String("issuer-url-custom"),
-		SigningAlgs:    []string{"sa-default"},
-		UsernameClaim:  ptr.String("uc-custom"),
-		UsernamePrefix: ptr.String("up-default"),
-	}, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+	assert.Equal(t, expectedOIDCConfig, runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, expectedOIDCConfig, (*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 
 func TestCreateRuntimeResourceStep_FailureToleranceForTrial(t *testing.T) {

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -89,12 +89,12 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 	}
 
 	if operation.UpdatingParameters.OIDC != nil {
+		if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
+			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{{}}
+		}
 		input := operation.UpdatingParameters.OIDC
 		if len(input.SigningAlgs) > 0 {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs = input.SigningAlgs
-			if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
-				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{{}}
-			}
 			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].SigningAlgs = input.SigningAlgs
 		}
 		if input.ClientID != "" {

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -92,21 +92,30 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 		input := operation.UpdatingParameters.OIDC
 		if len(input.SigningAlgs) > 0 {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs = input.SigningAlgs
+			if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{{}}
+			}
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].SigningAlgs = input.SigningAlgs
 		}
 		if input.ClientID != "" {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.ClientID = &input.ClientID
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].ClientID = &input.ClientID
 		}
 		if input.IssuerURL != "" {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.IssuerURL = &input.IssuerURL
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].IssuerURL = &input.IssuerURL
 		}
 		if input.GroupsClaim != "" {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.GroupsClaim = &input.GroupsClaim
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].GroupsClaim = &input.GroupsClaim
 		}
 		if input.UsernamePrefix != "" {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernamePrefix = &input.UsernamePrefix
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernamePrefix = &input.UsernamePrefix
 		}
 		if input.UsernameClaim != "" {
 			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernameClaim = &input.UsernameClaim
+			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernameClaim = &input.UsernameClaim
 		}
 	}
 

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -89,33 +89,50 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 	}
 
 	if operation.UpdatingParameters.OIDC != nil {
-		if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{{}}
-		}
 		input := operation.UpdatingParameters.OIDC
-		if len(input.SigningAlgs) > 0 {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs = input.SigningAlgs
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].SigningAlgs = input.SigningAlgs
+		if s.config.UseMainOIDC {
+			if len(input.SigningAlgs) > 0 {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs = input.SigningAlgs
+			}
+			if input.ClientID != "" {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.ClientID = &input.ClientID
+			}
+			if input.IssuerURL != "" {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.IssuerURL = &input.IssuerURL
+			}
+			if input.GroupsClaim != "" {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.GroupsClaim = &input.GroupsClaim
+			}
+			if input.UsernamePrefix != "" {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernamePrefix = &input.UsernamePrefix
+			}
+			if input.UsernameClaim != "" {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernameClaim = &input.UsernameClaim
+			}
 		}
-		if input.ClientID != "" {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.ClientID = &input.ClientID
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].ClientID = &input.ClientID
-		}
-		if input.IssuerURL != "" {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.IssuerURL = &input.IssuerURL
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].IssuerURL = &input.IssuerURL
-		}
-		if input.GroupsClaim != "" {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.GroupsClaim = &input.GroupsClaim
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].GroupsClaim = &input.GroupsClaim
-		}
-		if input.UsernamePrefix != "" {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernamePrefix = &input.UsernamePrefix
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernamePrefix = &input.UsernamePrefix
-		}
-		if input.UsernameClaim != "" {
-			runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernameClaim = &input.UsernameClaim
-			(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernameClaim = &input.UsernameClaim
+
+		if s.config.UseAdditionalOIDC {
+			if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
+				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]gardener.OIDCConfig{{}}
+			}
+			if len(input.SigningAlgs) > 0 {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].SigningAlgs = input.SigningAlgs
+			}
+			if input.ClientID != "" {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].ClientID = &input.ClientID
+			}
+			if input.IssuerURL != "" {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].IssuerURL = &input.IssuerURL
+			}
+			if input.GroupsClaim != "" {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].GroupsClaim = &input.GroupsClaim
+			}
+			if input.UsernamePrefix != "" {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernamePrefix = &input.UsernamePrefix
+			}
+			if input.UsernameClaim != "" {
+				(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0].UsernameClaim = &input.UsernameClaim
+			}
 		}
 	}
 

--- a/internal/process/update/update_runtime_step_test.go
+++ b/internal/process/update/update_runtime_step_test.go
@@ -82,6 +82,15 @@ func TestUpdateRuntimeStep_RunUpdateOIDC(t *testing.T) {
 	operation.RuntimeResourceName = "runtime-name"
 	operation.KymaResourceNamespace = "kcp-system"
 
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("clinet-id-oidc"),
+		GroupsClaim:    ptr.String("groups"),
+		IssuerURL:      ptr.String("issuer-url"),
+		SigningAlgs:    []string{"signingAlgs"},
+		UsernameClaim:  ptr.String("sub"),
+		UsernamePrefix: nil,
+	}
+
 	// when
 	_, backoff, err := step.Run(operation, fixLogger())
 
@@ -92,22 +101,8 @@ func TestUpdateRuntimeStep_RunUpdateOIDC(t *testing.T) {
 	var gotRuntime imv1.Runtime
 	err = kcpClient.Get(context.Background(), client.ObjectKey{Name: operation.RuntimeResourceName, Namespace: "kcp-system"}, &gotRuntime)
 	require.NoError(t, err)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("clinet-id-oidc"),
-		GroupsClaim:    ptr.String("groups"),
-		IssuerURL:      ptr.String("issuer-url"),
-		SigningAlgs:    []string{"signingAlgs"},
-		UsernameClaim:  ptr.String("sub"),
-		UsernamePrefix: nil,
-	}, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
-	assert.Equal(t, gardener.OIDCConfig{
-		ClientID:       ptr.String("clinet-id-oidc"),
-		GroupsClaim:    ptr.String("groups"),
-		IssuerURL:      ptr.String("issuer-url"),
-		SigningAlgs:    []string{"signingAlgs"},
-		UsernameClaim:  ptr.String("sub"),
-		UsernamePrefix: nil,
-	}, (*gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+	assert.Equal(t, expectedOIDCConfig, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Equal(t, expectedOIDCConfig, (*gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 
 func fixRuntimeResource(name string, controlledByProvisioner bool) runtime.Object {

--- a/internal/process/update/update_runtime_step_test.go
+++ b/internal/process/update/update_runtime_step_test.go
@@ -81,7 +81,6 @@ func TestUpdateRuntimeStep_RunUpdateOIDC(t *testing.T) {
 	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
 	operation.RuntimeResourceName = "runtime-name"
 	operation.KymaResourceNamespace = "kcp-system"
-
 	expectedOIDCConfig := gardener.OIDCConfig{
 		ClientID:       ptr.String("clinet-id-oidc"),
 		GroupsClaim:    ptr.String("groups"),

--- a/internal/process/update/update_runtime_step_test.go
+++ b/internal/process/update/update_runtime_step_test.go
@@ -72,12 +72,15 @@ func TestUpdateRuntimeStep_RunUpdateMachineType(t *testing.T) {
 
 }
 
-func TestUpdateRuntimeStep_RunUpdateOIDC(t *testing.T) {
+func TestUpdateRuntimeStep_RunUpdateOnlyMainOIDC(t *testing.T) {
 	// given
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource("runtime-name", false)).Build()
-	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{}, false, nil)
+	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: false,
+	}, false, nil)
 	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
 	operation.RuntimeResourceName = "runtime-name"
 	operation.KymaResourceNamespace = "kcp-system"
@@ -101,6 +104,85 @@ func TestUpdateRuntimeStep_RunUpdateOIDC(t *testing.T) {
 	err = kcpClient.Get(context.Background(), client.ObjectKey{Name: operation.RuntimeResourceName, Namespace: "kcp-system"}, &gotRuntime)
 	require.NoError(t, err)
 	assert.Equal(t, expectedOIDCConfig, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)
+}
+
+func TestUpdateRuntimeStep_RunUpdateMainAndAdditionalOIDC(t *testing.T) {
+	// given
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource("runtime-name", false)).Build()
+	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: true,
+	}, false, nil)
+	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
+	operation.RuntimeResourceName = "runtime-name"
+	operation.KymaResourceNamespace = "kcp-system"
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("clinet-id-oidc"),
+		GroupsClaim:    ptr.String("groups"),
+		IssuerURL:      ptr.String("issuer-url"),
+		SigningAlgs:    []string{"signingAlgs"},
+		UsernameClaim:  ptr.String("sub"),
+		UsernamePrefix: nil,
+	}
+
+	// when
+	_, backoff, err := step.Run(operation, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, backoff)
+
+	var gotRuntime imv1.Runtime
+	err = kcpClient.Get(context.Background(), client.ObjectKey{Name: operation.RuntimeResourceName, Namespace: "kcp-system"}, &gotRuntime)
+	require.NoError(t, err)
+	assert.Equal(t, expectedOIDCConfig, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig)
+	assert.NotNil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)
+	assert.Equal(t, expectedOIDCConfig, (*gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
+}
+
+func TestUpdateRuntimeStep_RunUpdateOnlyAdditionalOIDC(t *testing.T) {
+	// given
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource("runtime-name", false)).Build()
+	step := NewUpdateRuntimeStep(nil, kcpClient, 0, input.Config{
+		UseMainOIDC:       false,
+		UseAdditionalOIDC: true,
+	}, false, nil)
+	operation := fixture.FixUpdatingOperation("op-id", "inst-id").Operation
+	operation.RuntimeResourceName = "runtime-name"
+	operation.KymaResourceNamespace = "kcp-system"
+	expectedOIDCConfig := gardener.OIDCConfig{
+		ClientID:       ptr.String("clinet-id-oidc"),
+		GroupsClaim:    ptr.String("groups"),
+		IssuerURL:      ptr.String("issuer-url"),
+		SigningAlgs:    []string{"signingAlgs"},
+		UsernameClaim:  ptr.String("sub"),
+		UsernamePrefix: nil,
+	}
+	var gotRuntime imv1.Runtime
+	err = kcpClient.Get(context.Background(), client.ObjectKey{Name: operation.RuntimeResourceName, Namespace: "kcp-system"}, &gotRuntime)
+	require.NoError(t, err)
+	t.Logf("gotRuntime: %+v", gotRuntime)
+	// when
+	_, backoff, err := step.Run(operation, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, backoff)
+
+	err = kcpClient.Get(context.Background(), client.ObjectKey{Name: operation.RuntimeResourceName, Namespace: "kcp-system"}, &gotRuntime)
+	require.NoError(t, err)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.ClientID)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.GroupsClaim)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.IssuerURL)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.SigningAlgs)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernameClaim)
+	assert.Nil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig.UsernamePrefix)
+	assert.NotNil(t, gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)
 	assert.Equal(t, expectedOIDCConfig, (*gotRuntime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0])
 }
 

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -231,6 +231,10 @@ spec:
               value: "{{ .Values.gardener.controlPlaneFailureTolerance }}"
             - name: APP_PROVISIONER_ENABLE_SHOOT_AND_SEED_SAME_REGION
               value: "{{ .Values.provisioner.gardener.enableShootAndSeedSameRegion }}"
+            - name: APP_PROVISIONER_USE_MAIN_OIDC
+              value: "{{ .Values.provisioner.useMainOIDC }}"
+            - name: APP_PROVISIONER_USE_ADDITIONAL_OIDC
+              value: "{{ .Values.provisioner.useAdditionalOIDC }}"
             - name: APP_DEFAULT_REQUEST_REGION
               value: "{{ .Values.broker.defaultRequestRegion }}"
             - name: APP_UPDATE_PROCESSING_ENABLED

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -214,6 +214,8 @@ provisioner:
 
   gardener:
     enableShootAndSeedSameRegion: "false"
+  useMainOIDC: "true"
+  useAdditionalOIDC: "false"
 
 trialRegionsMapping: |-
   cf-eu10: europe


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Part of the phase 1: migration.  We duplicate the main OIDC to additionalOIDC[0] when the feature flag is enabled.

Changes proposed in this pull request:

- Copy OIDC value to additionalOIDC when enabled
- Add a feature flag that enables/disables writing to the mainOIDC
- Add a feature flag that enables/disables writing to the additionalOIDC
- Add tests that use different feature flags enabled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #423 