### PR TITLE
Timeouts in EDP and deprovisioning steps using `RetryOperations` helper function

### DIFF
--- a/internal/process/deprovisioning/edp_deregistration.go
+++ b/internal/process/deprovisioning/edp_deregistration.go
@@ -107,9 +107,10 @@ func (s *EDPDeregistrationStep) handleError(operation internal.Operation, err er
 	}
 
 	errMsg := fmt.Sprintf("Step %s failed. EDP data have not been deleted.", s.Name())
-	operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), errMsg, log)
+	operation, repeat, err := s.operationManager.MarkStepAsExecutedButNotCompleted(operation, s.Name(), errMsg, log)
 	if repeat != 0 {
-		return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), "marking step as not completed failed", edpRetryInterval, edpRetryTimeout, log, err)
+		// caveat: this retry is guarded by the staged manager timeout for entire operation - and it could fail the operation eventually
+		return operation, repeat, err
 	}
 
 	log.Error(fmt.Sprintf("%s: %s", msg, err))

--- a/internal/process/deprovisioning/edp_deregistration.go
+++ b/internal/process/deprovisioning/edp_deregistration.go
@@ -109,7 +109,7 @@ func (s *EDPDeregistrationStep) handleError(operation internal.Operation, err er
 	errMsg := fmt.Sprintf("Step %s failed. EDP data have not been deleted.", s.Name())
 	operation, repeat, err := s.operationManager.MarkStepAsExecutedButNotCompleted(operation, s.Name(), errMsg, log)
 	if repeat != 0 {
-		// caveat: this retry is guarded by the staged manager timeout for entire operation - and it could fail the operation eventually
+		// CAVEAT: this retry is guarded by the staged manager timeout for entire operation - and it could fail the operation eventually
 		return operation, repeat, err
 	}
 

--- a/internal/process/deprovisioning/init.go
+++ b/internal/process/deprovisioning/init.go
@@ -22,6 +22,13 @@ type InitStep struct {
 	instanceStorage  storage.Instances
 }
 
+const (
+	opRetryInterval = 1 * time.Minute
+	opRetryTimeout  = 120 * time.Minute
+	dbRetryInterval = 10 * time.Second
+	dbRetryTimeout  = 1 * time.Minute
+)
+
 func NewInitStep(operations storage.Operations, instances storage.Instances, operationTimeout time.Duration) *InitStep {
 	step := &InitStep{
 		operationTimeout: operationTimeout,
@@ -48,11 +55,11 @@ func (s *InitStep) Run(operation internal.Operation, log *slog.Logger) (internal
 	// Check concurrent operation
 	lastOp, err := s.operationStorage.GetLastOperation(operation.InstanceID)
 	if err != nil {
-		return operation, time.Minute, nil
+		return s.operationManager.RetryOperation(operation, "getting last operation", err, dbRetryInterval, dbRetryTimeout, log)
 	}
 	if !lastOp.IsFinished() {
 		log.Info(fmt.Sprintf("waiting for %s operation (%s) to be finished", lastOp.Type, lastOp.ID))
-		return operation, time.Minute, nil
+		return s.operationManager.RetryOperation(operation, "waiting for operation to be finished", err, opRetryInterval, opRetryTimeout, log)
 	}
 
 	// read the instance details (it could happen that created deprovisioning operation has outdated one)
@@ -62,13 +69,13 @@ func (s *InitStep) Run(operation internal.Operation, log *slog.Logger) (internal
 			log.Warn("the instance already deprovisioned")
 			return s.operationManager.OperationFailed(operation, "the instance was already deprovisioned", err, log)
 		}
-		return operation, time.Second, nil
+		return s.operationManager.RetryOperation(operation, "getting instance by ID", err, dbRetryInterval, dbRetryTimeout, log)
 	}
 
 	log.Info("Setting lastOperation ID in the instance")
 	err = s.instanceStorage.UpdateInstanceLastOperation(operation.InstanceID, operation.ID)
 	if err != nil {
-		return s.operationManager.RetryOperation(operation, "error while updating last operation ID", err, 5*time.Second, 1*time.Minute, log)
+		return s.operationManager.RetryOperation(operation, "error while updating last operation ID", err, dbRetryInterval, dbRetryTimeout, log)
 	}
 
 	log.Info("Setting state 'in progress' and refreshing instance details")
@@ -79,7 +86,7 @@ func (s *InitStep) Run(operation internal.Operation, log *slog.Logger) (internal
 	}, log)
 	if delay != 0 {
 		log.Error("unable to update the operation (move to 'in progress'), retrying")
-		return operation, delay, nil
+		return s.operationManager.RetryOperation(operation, "unable to update the operation", err, dbRetryInterval, dbRetryTimeout, log)
 	}
 
 	return opr, 0, nil

--- a/internal/process/deprovisioning/release_subscription_step.go
+++ b/internal/process/deprovisioning/release_subscription_step.go
@@ -45,7 +45,7 @@ func (s ReleaseSubscriptionStep) Run(operation internal.Operation, log *slog.Log
 		instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 		if err != nil {
 			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - get the instance data for instanceID [%s]: %s", operation.InstanceID, err.Error())
-			operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), msg, log)
+			operation, repeat, err := s.operationManager.MarkStepAsExecutedButNotCompleted(operation, s.Name(), msg, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}
@@ -60,7 +60,7 @@ func (s ReleaseSubscriptionStep) Run(operation internal.Operation, log *slog.Log
 		hypType, err := hyperscaler.HypTypeFromCloudProviderWithRegion(instance.Provider, &instance.ProviderRegion, &operation.ProvisioningParameters.PlatformRegion)
 		if err != nil {
 			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - determine the type of hyperscaler to use for planID [%s]: %s", planID, err.Error())
-			operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), msg, log)
+			operation, repeat, err := s.operationManager.MarkStepAsExecutedButNotCompleted(operation, s.Name(), msg, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}

--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -96,7 +96,7 @@ func (om *OperationManager) OperationCanceled(operation internal.Operation, desc
 
 // RetryOperation checks if operation should be retried or if it's the status should be marked as failed
 func (om *OperationManager) RetryOperation(operation internal.Operation, errorMessage string, err error, retryInterval time.Duration, maxTime time.Duration, log *slog.Logger) (internal.Operation, time.Duration, error) {
-	log.Info(fmt.Sprintf("Retry Operation was triggered with message: %s", errorMessage))
+	log.Info(fmt.Sprintf("Retry Operation was called with message: %s", errorMessage))
 	log.Info(fmt.Sprintf("Retrying for %s in %s steps", maxTime.String(), retryInterval.String()))
 
 	om.storeTimestampIfMissing(operation.ID)
@@ -104,12 +104,12 @@ func (om *OperationManager) RetryOperation(operation internal.Operation, errorMe
 		return operation, retryInterval, nil
 	}
 
-	log.Error(fmt.Sprintf("Aborting after %s of failing retries", maxTime.String()))
+	log.Error(fmt.Sprintf("Failing operation after %s of failing retries", maxTime.String()))
 	op, retry, err := om.OperationFailed(operation, errorMessage, err, log)
 	if err == nil {
-		err = fmt.Errorf("Too many retries")
+		err = fmt.Errorf("too many retries")
 	} else {
-		err = fmt.Errorf("Failed to set status for operation after too many retries: %v", err)
+		err = fmt.Errorf("failed to set status `Failed` for operation after too many retries: %v", err)
 	}
 	return op, retry, err
 }

--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -136,11 +136,11 @@ func (om *OperationManager) RetryOperationWithoutFail(operation internal.Operati
 		return op, repeat, err
 	}
 
-	op.EventErrorf(fmt.Errorf(description), "step %s failed retries: operation continues", stepName)
+	op.EventErrorf(fmt.Errorf(description), "step %s failed all retries: operation continues", stepName)
 	if opErr != nil {
-		log.Error(fmt.Sprintf("omitting after %s of failing retries, last error: %s", maxTime.String(), opErr.Error()))
+		log.Error(fmt.Sprintf("quiting step after %s of failing retries, last error: %s", maxTime.String(), opErr.Error()))
 	} else {
-		log.Error(fmt.Sprintf("omitting after %s of failing retries", maxTime.String()))
+		log.Error(fmt.Sprintf("quiting step after %s of failing retries", maxTime.String()))
 	}
 	return op, 0, nil
 }

--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -180,7 +180,7 @@ func (om *OperationManager) UpdateOperation(operation internal.Operation, update
 	return *op, 0, nil
 }
 
-func (om *OperationManager) MarkStepAsExcutedButNotCompleted(operation internal.Operation, stepName string, msg string, log *slog.Logger) (internal.Operation, time.Duration, error) {
+func (om *OperationManager) MarkStepAsExecutedButNotCompleted(operation internal.Operation, stepName string, msg string, log *slog.Logger) (internal.Operation, time.Duration, error) {
 	op, repeat, err := om.UpdateOperation(operation, func(operation *internal.Operation) {
 		operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, stepName)
 	}, log)

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -176,6 +176,6 @@ func (s *EDPRegistrationStep) handleConflict(operation internal.Operation, log *
 	}
 
 	log.Info("Retrying...")
-	// CAVEAT this retry operation is guarded by operation timeout at staged manager level, and it fails eventually after timeout
+	// CAVEAT this retry operation is guarded by operation timeout at staged manager level, and could fail the operation eventually
 	return operation, time.Second, nil
 }

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -106,7 +106,11 @@ func (s *EDPRegistrationStep) handleError(operation internal.Operation, err erro
 
 	if kebError.IsTemporaryError(err) {
 		log.Warn(fmt.Sprintf("request to EDP failed: %s. Retry...", err))
-		return s.operationManager.RetryOperation(operation, "request to EDP failed", err, edpRetryInterval, edpRetryTimeout, log)
+		if s.config.Required {
+			return s.operationManager.RetryOperation(operation, "request to EDP failed", err, edpRetryInterval, edpRetryTimeout, log)
+		} else {
+			return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), "request to EDP failed", edpRetryInterval, edpRetryTimeout, log, err)
+		}
 	}
 
 	if !s.config.Required {

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -176,5 +176,6 @@ func (s *EDPRegistrationStep) handleConflict(operation internal.Operation, log *
 	}
 
 	log.Info("Retrying...")
+	// this retry operation is guarded by operation timeout at staged manager level
 	return operation, time.Second, nil
 }

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -103,17 +103,19 @@ func (s *EDPRegistrationStep) Run(operation internal.Operation, log *slog.Logger
 
 func (s *EDPRegistrationStep) handleError(operation internal.Operation, err error, log *slog.Logger, msg string) (internal.Operation, time.Duration, error) {
 	log.Warn(fmt.Sprintf("%s: %s", msg, err))
-	if s.config.Required {
-		if kebError.IsTemporaryError(err) {
-			log.Warn(fmt.Sprintf("request to EDP failed: %s. Retry...", err))
+
+	if kebError.IsTemporaryError(err) {
+		log.Warn(fmt.Sprintf("request to EDP failed: %s. Retry...", err))
+		if s.config.Required {
 			return s.operationManager.RetryOperation(operation, "request to EDP failed", err, edpRetryInterval, edpRetryTimeout, log)
-		}
-		return s.operationManager.OperationFailed(operation, msg, err, log)
-	} else {
-		if kebError.IsTemporaryError(err) {
-			log.Warn(fmt.Sprintf("request to EDP failed: %s. Retry...", err))
+		} else {
 			return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), "request to EDP failed", edpRetryInterval, edpRetryTimeout, log, err)
 		}
+	}
+
+	if s.config.Required {
+		return s.operationManager.OperationFailed(operation, msg, err, log)
+	} else {
 		log.Warn(fmt.Sprintf("Step %s failed. Step is not required. Quit step.", s.Name()))
 		return operation, 0, nil
 	}

--- a/internal/process/provisioning/edp_registration.go
+++ b/internal/process/provisioning/edp_registration.go
@@ -176,6 +176,6 @@ func (s *EDPRegistrationStep) handleConflict(operation internal.Operation, log *
 	}
 
 	log.Info("Retrying...")
-	// this retry operation is guarded by operation timeout at staged manager level
+	// CAVEAT this retry operation is guarded by operation timeout at staged manager level, and it fails eventually after timeout
 	return operation, time.Second, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- EDP registration step
- EDP deregistration step 
- Deprovisioning initialization step

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
