### PR TITLE
Use `ProviderValues` from operation

### DIFF
--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -92,7 +92,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		// postcondition: operation.KymaResourceName, operation.RuntimeResourceName is set
 		{
 			stage:     createRuntimeStageName,
-			step:      provisioning.NewCreateRuntimeResourceStep(db.Operations(), db.Instances(), cli, cfg.Provisioner, trialRegionsMapping, cfg.Broker.UseSmallerMachineTypes, defaultOIDC),
+			step:      provisioning.NewCreateRuntimeResourceStep(db.Operations(), db.Instances(), cli, cfg.Provisioner, defaultOIDC),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -67,7 +67,12 @@ func TestCreateRuntimeResourceStep_onlyMainOIDC_AllCustom(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	memoryStorage := storage.NewMemoryStorage()
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: false,
+	}
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
 	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
 		ClientID:       "client-id-custom",
 		GroupsClaim:    "gc-custom",
@@ -85,13 +90,8 @@ func TestCreateRuntimeResourceStep_onlyMainOIDC_AllCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-custom"),
 	}
-	inputConfig := input.Config{
-		MultiZoneCluster:  true,
-		UseMainOIDC:       true,
-		UseAdditionalOIDC: false,
-	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -114,7 +114,12 @@ func TestCreateRuntimeResourceStep_MainAndAdditionalOIDC_AllCustom(t *testing.T)
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	memoryStorage := storage.NewMemoryStorage()
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: true,
+	}
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
 	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
 		ClientID:       "client-id-custom",
 		GroupsClaim:    "gc-custom",
@@ -132,13 +137,8 @@ func TestCreateRuntimeResourceStep_MainAndAdditionalOIDC_AllCustom(t *testing.T)
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-custom"),
 	}
-	inputConfig := input.Config{
-		MultiZoneCluster:  true,
-		UseMainOIDC:       true,
-		UseAdditionalOIDC: true,
-	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -161,7 +161,12 @@ func TestCreateRuntimeResourceStep_onlyAdditionalOIDC_AllCustom(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	memoryStorage := storage.NewMemoryStorage()
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       false,
+		UseAdditionalOIDC: true,
+	}
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
 	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
 		ClientID:       "client-id-custom",
 		GroupsClaim:    "gc-custom",
@@ -179,13 +184,8 @@ func TestCreateRuntimeResourceStep_onlyAdditionalOIDC_AllCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-custom"),
 	}
-	inputConfig := input.Config{
-		MultiZoneCluster:  true,
-		UseMainOIDC:       false,
-		UseAdditionalOIDC: true,
-	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -213,7 +213,12 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	memoryStorage := storage.NewMemoryStorage()
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
+	inputConfig := input.Config{
+		MultiZoneCluster:  true,
+		UseMainOIDC:       true,
+		UseAdditionalOIDC: false,
+	}
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
 	operation.ProvisioningParameters.Parameters.OIDC = &pkg.OIDCConfigDTO{
 		ClientID:      "client-id-custom",
 		GroupsClaim:   "gc-custom",
@@ -229,13 +234,8 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		UsernameClaim:  ptr.String("uc-custom"),
 		UsernamePrefix: ptr.String("up-default"),
 	}
-	inputConfig := input.Config{
-		MultiZoneCluster:  true,
-		UseMainOIDC:       true,
-		UseAdditionalOIDC: false,
-	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -258,16 +258,16 @@ func TestCreateRuntimeResourceStep_FailureToleranceForTrial(t *testing.T) {
 	assert.NoError(t, imv1.AddToScheme(scheme.Scheme))
 	memoryStorage := storage.NewMemoryStorage()
 
-	instance, operation := fixInstanceAndOperation(broker.TrialPlanID, "westeurope", "platform-region")
-	assertInsertions(t, memoryStorage, instance, operation)
-
 	inputConfig := input.Config{MultiZoneCluster: true}
 	inputConfig.ControlPlaneFailureTolerance = "zone"
 	inputConfig.DefaultTrialProvider = "AWS"
 
+	instance, operation := fixInstanceAndOperation(broker.TrialPlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
+	assertInsertions(t, memoryStorage, instance, operation)
+
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -288,15 +288,15 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercial(t *testing.T) {
 	assert.NoError(t, imv1.AddToScheme(scheme.Scheme))
 	memoryStorage := storage.NewMemoryStorage()
 
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
-	assertInsertions(t, memoryStorage, instance, operation)
-
 	inputConfig := input.Config{MultiZoneCluster: true}
 	inputConfig.ControlPlaneFailureTolerance = "zone"
 
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
+	assertInsertions(t, memoryStorage, instance, operation)
+
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -317,15 +317,15 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercialWithNoConfig(t *
 	assert.NoError(t, imv1.AddToScheme(scheme.Scheme))
 	memoryStorage := storage.NewMemoryStorage()
 
-	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region")
-	assertInsertions(t, memoryStorage, instance, operation)
-
 	inputConfig := input.Config{MultiZoneCluster: true}
 	inputConfig.ControlPlaneFailureTolerance = ""
 
+	instance, operation := fixInstanceAndOperation(broker.AzurePlanID, "westeurope", "platform-region", inputConfig, pkg.Azure)
+	assertInsertions(t, memoryStorage, instance, operation)
+
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -346,15 +346,15 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercialWithConfiguredNo
 	assert.NoError(t, imv1.AddToScheme(scheme.Scheme))
 	memoryStorage := storage.NewMemoryStorage()
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "westeurope", "platform-region")
-	assertInsertions(t, memoryStorage, instance, operation)
-
 	inputConfig := input.Config{MultiZoneCluster: true}
 	inputConfig.ControlPlaneFailureTolerance = "node"
 
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "westeurope", "platform-region", inputConfig, pkg.AWS)
+	assertInsertions(t, memoryStorage, instance, operation)
+
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -377,15 +377,14 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_EnforceSeed_ActualCre
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	operation.ProvisioningParameters.Parameters.ShootAndSeedSameRegion = ptr.Bool(true)
 	assertInsertions(t, memoryStorage, instance, operation)
 
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
-
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -424,15 +423,14 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DisableEnterpriseFilt
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	operation.ProvisioningParameters.ErsContext.LicenseType = ptr.String("PARTNER")
 	assertInsertions(t, memoryStorage, instance, operation)
 
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
-
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -471,15 +469,14 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DefaultAdmin_ActualCr
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	operation.ProvisioningParameters.Parameters.RuntimeAdministrators = nil
 	assertInsertions(t, memoryStorage, instance, operation)
 
-	inputConfig := input.Config{MultiZoneCluster: false, ControlPlaneFailureTolerance: "zone", DefaultGardenerShootPurpose: provider.PurposeProduction}
-
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -517,8 +514,9 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "any-string"}
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	operation.ProvisioningParameters.Parameters.Networking = &pkg.NetworkingDTO{
 		NodesCidr:    "192.168.48.0/20",
 		PodsCidr:     ptr.String("10.104.0.0/24"),
@@ -528,9 +526,8 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking_ActualCr
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "any-string"}
 
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -574,13 +571,13 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZone_ActualCreation(t *test
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "any-string"}
 
-	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: true, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "any-string"}
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -616,13 +613,13 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation(t 
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "zone"}
 
-	instance, operation := fixInstanceAndOperation(broker.PreviewPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.PreviewPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "zone"}
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -660,13 +657,13 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_ActualCreation_Wi
 	memoryStorage := storage.NewMemoryStorage()
 
 	err := imv1.AddToScheme(scheme.Scheme)
+	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "zone"}
 
-	instance, operation := fixInstanceAndOperation(broker.PreviewPlanID, "eu-west-2", "platform-region")
+	instance, operation := fixInstanceAndOperation(broker.PreviewPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	inputConfig := input.Config{MultiZoneCluster: false, DefaultGardenerShootPurpose: provider.PurposeProduction, ControlPlaneFailureTolerance: "zone"}
-	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+	step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -737,13 +734,12 @@ func TestCreateRuntimeResourceStep_SapConvergedCloud(t *testing.T) {
 			memoryStorage := storage.NewMemoryStorage()
 			err := imv1.AddToScheme(scheme.Scheme)
 			assert.NoError(t, err)
-			instance, operation := fixInstanceAndOperation(broker.SapConvergedCloudPlanID, "", "platform-region")
-			operation.ProvisioningParameters.PlatformProvider = testCase.gotProvider
+			inputConfig := input.Config{MultiZoneCluster: testCase.expectedZonesCount > 1, ControlPlaneFailureTolerance: "zone"}
+			instance, operation := fixInstanceAndOperation(broker.SapConvergedCloudPlanID, "", "platform-region", inputConfig, testCase.gotProvider)
 			assertInsertions(t, memoryStorage, instance, operation)
 
 			cli := getClientForTests(t)
-			inputConfig := input.Config{MultiZoneCluster: testCase.expectedZonesCount > 1, ControlPlaneFailureTolerance: "zone"}
-			step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+			step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 			// when
 			gotOperation, repeat, err := step.Run(operation, fixLogger())
@@ -788,13 +784,12 @@ func TestCreateRuntimeResourceStep_Defaults_Freemium(t *testing.T) {
 			memoryStorage := storage.NewMemoryStorage()
 			err := imv1.AddToScheme(scheme.Scheme)
 			assert.NoError(t, err)
-			instance, operation := fixInstanceAndOperation(broker.FreemiumPlanID, "", "platform-region")
-			operation.ProvisioningParameters.PlatformProvider = testCase.gotProvider
+			inputConfig := input.Config{MultiZoneCluster: true}
+			instance, operation := fixInstanceAndOperation(broker.FreemiumPlanID, "", "platform-region", inputConfig, testCase.gotProvider)
 			assertInsertions(t, memoryStorage, instance, operation)
 
 			cli := getClientForTests(t)
-			inputConfig := input.Config{MultiZoneCluster: true}
-			step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, nil, false, defaultOIDSConfig)
+			step := NewCreateRuntimeResourceStep(memoryStorage.Operations(), memoryStorage.Instances(), cli, inputConfig, defaultOIDSConfig)
 
 			// when
 			gotOperation, repeat, err := step.Run(operation, fixLogger())
@@ -939,13 +934,13 @@ func getClientForTests(t *testing.T) client.Client {
 	return cli
 }
 
-func fixInstanceAndOperation(planID, region, platformRegion string) (internal.Instance, internal.Operation) {
+func fixInstanceAndOperation(planID, region, platformRegion string, inputConfig input.Config, platformProvider pkg.CloudProvider) (internal.Instance, internal.Operation) {
 	instance := fixInstance()
-	operation := fixOperationForCreateRuntimeResourceStep(OperationID, instance.InstanceID, planID, region, platformRegion)
+	operation := fixOperationForCreateRuntimeResourceStep(OperationID, instance.InstanceID, planID, region, platformRegion, inputConfig, platformProvider)
 	return instance, operation
 }
 
-func fixOperationForCreateRuntimeResourceStep(operationID, instanceID, planID, region, platformRegion string) internal.Operation {
+func fixOperationForCreateRuntimeResourceStep(operationID, instanceID, planID, region, platformRegion string, inputConfig input.Config, platformProvider pkg.CloudProvider) internal.Operation {
 	var regionToSet *string
 	if region != "" {
 		regionToSet = &region
@@ -978,5 +973,9 @@ strategy: secret
 channel: stable
 modules: []
 `
+	operation.ProvisioningParameters.PlatformProvider = platformProvider
+	values, _ := provider.GetPlanSpecificValues(&operation, inputConfig.MultiZoneCluster, inputConfig.DefaultTrialProvider, false, nil,
+		inputConfig.DefaultGardenerShootPurpose, inputConfig.ControlPlaneFailureTolerance)
+	operation.ProviderValues = &values
 	return operation
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use `ProviderValues` from operation instead of using `GetPlanSpecificValues` function in CreateRuntimeResourceStep.

