### PR TITLE
Fail operation on failed runtime custom resource state

### DIFF
--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -2,7 +2,6 @@ package steps
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -54,9 +53,8 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log *slog.Logge
 	case imv1.RuntimeStateReady:
 		return operation, 0, nil
 	case imv1.RuntimeStateFailed:
-		msg := fmt.Sprintf("Runtime resource in %s state", imv1.RuntimeStateFailed)
-		log.Info(fmt.Sprintf("%s, status: %v; failing operation", msg, runtime.Status))
-		return s.operationManager.OperationFailed(operation, msg, errors.New(msg), log)
+		log.Info(fmt.Sprintf("Runtime resource status: %v; failing operation", runtime.Status))
+		return s.operationManager.OperationFailed(operation, fmt.Sprintf("Runtime resource in %s state", imv1.RuntimeStateFailed), nil, log)
 	default:
 		log.Info(fmt.Sprintf("Runtime resource status: %v; retrying in %v steps for: %v", runtime.Status, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout))
 		return s.operationManager.RetryOperation(operation, fmt.Sprintf("Runtime resource not in %s state", imv1.RuntimeStateReady), nil, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout, log)

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -49,11 +50,17 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log *slog.Logge
 	// check status
 	state := runtime.Status.State
 	log.Info(fmt.Sprintf("Runtime resource state: %s", state))
-	if state != imv1.RuntimeStateReady {
+	switch state {
+	case imv1.RuntimeStateReady:
+		return operation, 0, nil
+	case imv1.RuntimeStateFailed:
+		msg := fmt.Sprintf("Runtime resource in %s state", imv1.RuntimeStateFailed)
+		log.Info(fmt.Sprintf("%s, status: %v; failing operation", msg, runtime.Status))
+		return s.operationManager.OperationFailed(operation, msg, errors.New(msg), log)
+	default:
 		log.Info(fmt.Sprintf("Runtime resource status: %v; retrying in %v steps for: %v", runtime.Status, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout))
 		return s.operationManager.RetryOperation(operation, fmt.Sprintf("Runtime resource not in %s state", imv1.RuntimeStateReady), nil, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout, log)
 	}
-	return operation, 0, nil
 }
 
 func (s *checkRuntimeResource) GetRuntimeResource(name string, namespace string) (*imv1.Runtime, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

fail operation immediately when runtime custom resource is in failed state.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1799 