### PR TITLE
Fix building API server, kubeconfig URLs when kubeconfig secret is missing

### DIFF
--- a/internal/kubeconfig/builder.go
+++ b/internal/kubeconfig/builder.go
@@ -7,10 +7,9 @@ import (
 	"text/template"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Config struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- log INFO instead of ERROR when kubeconfig secret is missing
- do not add API server URL to labels when the value is empty

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #1836 