### PR TITLE
Validate hap rules with defined plans (not enabled ones)

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -298,8 +298,16 @@ func main() {
 	// metrics collectors
 	_ = metricsv2.Register(ctx, eventBroker, db, cfg.MetricsV2, log)
 
-	rulesService, err := rules.NewRulesServiceFromFile(cfg.HapRuleFilePath, &cfg.Broker.EnablePlans)
+	rulesService, err := rules.NewRulesServiceFromFile(cfg.HapRuleFilePath)
 	fatalOnError(err, log)
+	processingErrors := rulesService.ProcessingErrors()
+	parsingErrors := rulesService.ParsingErrors()
+	for _, err := range processingErrors {
+		log.Error(fmt.Sprintf("HAP parser processing Error: %s", err))
+	}
+	for _, err := range parsingErrors {
+		log.Error(fmt.Sprintf("HAP parser parsing Error: %s", err))
+	}
 	err = rulesService.FirstParsingError()
 	if err != nil {
 		log.Error(fmt.Sprintf("Error: %s", err))

--- a/cmd/parser/parse.go
+++ b/cmd/parser/parse.go
@@ -86,9 +86,9 @@ func (cmd *ParseCommand) Run() {
 	var err error
 	if cmd.ruleFilePath != "" {
 		cmd.cobraCmd.Printf("Parsing rules from file: %s\n", cmd.ruleFilePath)
-		rulesService, err = rules.NewRulesServiceFromFile(cmd.ruleFilePath, &enabledPlans)
+		rulesService, err = rules.NewRulesServiceFromFile(cmd.ruleFilePath)
 	} else {
-		rulesService, err = rules.NewRulesServiceFromString(cmd.rule, &enabledPlans)
+		rulesService, err = rules.NewRulesServiceFromString(cmd.rule)
 	}
 
 	if err != nil {

--- a/common/hyperscaler/rules/definitions.go
+++ b/common/hyperscaler/rules/definitions.go
@@ -3,8 +3,6 @@ package rules
 import (
 	"fmt"
 	"strconv"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 )
 
 const (
@@ -170,13 +168,7 @@ func setEuAccess(r *Rule, value string) (*Rule, error) {
 	return r, nil
 }
 
-func (r *Rule) SetPlan(value string, enabledPlans *broker.EnablePlans) (*Rule, error) {
-	// validate that the plan is supported
-	ok := enabledPlans.Contains(value)
-	if !ok {
-		return nil, fmt.Errorf("plan %s is not supported", value)
-	}
-
+func (r *Rule) SetPlan(value string) (*Rule, error) {
 	return r.SetPlanNoValidation(value)
 }
 

--- a/common/hyperscaler/rules/definitions.go
+++ b/common/hyperscaler/rules/definitions.go
@@ -169,10 +169,6 @@ func setEuAccess(r *Rule, value string) (*Rule, error) {
 }
 
 func (r *Rule) SetPlan(value string) (*Rule, error) {
-	return r.SetPlanNoValidation(value)
-}
-
-func (r *Rule) SetPlanNoValidation(value string) (*Rule, error) {
 	if value == "" {
 		return nil, fmt.Errorf("plan is empty")
 	}

--- a/common/hyperscaler/rules/match_test.go
+++ b/common/hyperscaler/rules/match_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +37,7 @@ func TestMatchDifferentArtificialScenarios(t *testing.T) {
 
 	defer os.Remove(tmpfile)
 
-	svc, err := NewRulesServiceFromFile(tmpfile, &broker.EnablePlans{"azure", "gcp", "trial", "aws", "free"})
+	svc, err := NewRulesServiceFromFile(tmpfile)
 	require.NoError(t, err)
 
 	for _, result := range svc.Parsed.Results {

--- a/common/hyperscaler/rules/parser_test.go
+++ b/common/hyperscaler/rules/parser_test.go
@@ -1,16 +1,16 @@
 package rules
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParserHappyPath(t *testing.T) {
 
 	t.Run("with plan", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 
 		rule, err := parser.Parse("azure")
 		require.NoError(t, err)
@@ -25,7 +25,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan and single input attribute", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure(PR=westeurope)")
 		require.NoError(t, err)
 
@@ -50,7 +50,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan all output attributes - different positions", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure(PR=easteurope,HR=westeurope)")
 		require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan and single output attribute", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure->S")
 		require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan and all output attributes - different positions", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure->S,EU")
 		require.NoError(t, err)
 
@@ -125,7 +125,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan and single output/input attributes", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure(PR=westeurope)->EU")
 		require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestParserHappyPath(t *testing.T) {
 	})
 
 	t.Run("with plan and all input/output attributes", func(t *testing.T) {
-		parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+		parser := &SimpleParser{}
 		rule, err := parser.Parse("azure(PR=westeurope, HR=easteurope)->EU,S")
 		require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func TestParserHappyPath(t *testing.T) {
 
 func TestParserValidation(t *testing.T) {
 
-	parser := &SimpleParser{&broker.EnablePlans{"azure"}}
+	parser := &SimpleParser{}
 
 	t.Run("with paranthesis only, no attributes", func(t *testing.T) {
 		rule, err := parser.Parse("()")
@@ -271,6 +271,12 @@ func TestParserValidation(t *testing.T) {
 		rule, err := parser.Parse("->")
 		require.Nil(t, rule)
 		require.Error(t, err)
+	})
+
+	t.Run("unknown plan", func(t *testing.T) {
+		rule, err := parser.Parse("notvalidplan")
+		assert.Nil(t, rule)
+		assert.Error(t, err)
 	})
 
 	t.Run("with incorrect attributes list", func(t *testing.T) {

--- a/common/hyperscaler/rules/rule.go
+++ b/common/hyperscaler/rules/rule.go
@@ -199,7 +199,7 @@ func (r *Rule) IsResolved() bool {
 
 func (r *Rule) Combine(rule Rule) *Rule {
 	newRule := NewRule()
-	_, err := newRule.SetPlanNoValidation(r.Plan)
+	_, err := newRule.SetPlan(r.Plan)
 	if err != nil {
 		log.Panicf("unexpected error while setting a plan : %v", err)
 	}

--- a/common/hyperscaler/rules/rules_service_test.go
+++ b/common/hyperscaler/rules/rules_service_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,8 +11,8 @@ func TestNewRulesServiceFromFile(t *testing.T) {
 	t.Run("should create RulesService from valid file ane parse simple rules", func(t *testing.T) {
 		// given
 		content := `rule:
-                      - rule1
-                      - rule2`
+                      - aws
+                      - azure`
 
 		tmpfile, err := CreateTempFile(content)
 		require.NoError(t, err)
@@ -21,8 +20,7 @@ func TestNewRulesServiceFromFile(t *testing.T) {
 		defer os.Remove(tmpfile)
 
 		// when
-		enabledPlans := &broker.EnablePlans{"rule1", "rule2"}
-		service, err := NewRulesServiceFromFile(tmpfile, enabledPlans)
+		service, err := NewRulesServiceFromFile(tmpfile)
 
 		// then
 		require.NoError(t, err)
@@ -36,7 +34,7 @@ func TestNewRulesServiceFromFile(t *testing.T) {
 
 	t.Run("should return error when file path is empty", func(t *testing.T) {
 		// when
-		service, err := NewRulesServiceFromFile("", &broker.EnablePlans{})
+		service, err := NewRulesServiceFromFile("")
 
 		// then
 		require.Error(t, err)
@@ -46,7 +44,7 @@ func TestNewRulesServiceFromFile(t *testing.T) {
 
 	t.Run("should return error when file does not exist", func(t *testing.T) {
 		// when
-		service, err := NewRulesServiceFromFile("nonexistent.yaml", &broker.EnablePlans{})
+		service, err := NewRulesServiceFromFile("nonexistent.yaml")
 
 		// then
 		require.Error(t, err)
@@ -62,7 +60,7 @@ func TestNewRulesServiceFromFile(t *testing.T) {
 		defer os.Remove(tmpfile)
 
 		// when
-		service, err := NewRulesServiceFromFile(tmpfile, &broker.EnablePlans{})
+		service, err := NewRulesServiceFromFile(tmpfile)
 
 		// then
 		require.Error(t, err)

--- a/common/hyperscaler/rules/signature_set_mirrored_test.go
+++ b/common/hyperscaler/rules/signature_set_mirrored_test.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +14,7 @@ func TestSignatureSet_Mirrored(t *testing.T) {
 
 		signatureSet := NewSignatureSet([]*ParsingResult{})
 
-		_, err := rule1.SetPlan("aws", &broker.EnablePlans{"aws"})
+		_, err := rule1.SetPlan("aws")
 		require.NoError(t, err)
 		mirroredResults := signatureSet.Mirrored(rule1)
 

--- a/common/hyperscaler/rules/simple_parser.go
+++ b/common/hyperscaler/rules/simple_parser.go
@@ -16,7 +16,6 @@ const (
 )
 
 type SimpleParser struct {
-	enabledPlans *broker.EnablePlans
 }
 
 func (g *SimpleParser) Parse(ruleEntry string) (*Rule, error) {
@@ -52,7 +51,10 @@ func (g *SimpleParser) Parse(ruleEntry string) (*Rule, error) {
 		return nil, fmt.Errorf("rule has unclosed parentheses")
 	}
 
-	_, err := outputRule.SetPlan(planAndInputAttr[0], g.enabledPlans)
+	if _, found := broker.PlanIDsMapping[planAndInputAttr[0]]; !found {
+		return nil, fmt.Errorf("unknown plan %s", planAndInputAttr[0])
+	}
+	_, err := outputRule.SetPlan(planAndInputAttr[0])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- hap parser validation allows plans which are disabled

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
