### PR TITLE
Add `used-for-production` label to Kyma CR

### DIFF
--- a/docs/contributor/07-20-subaccount-sync.md
+++ b/docs/contributor/07-20-subaccount-sync.md
@@ -5,11 +5,9 @@ resource (CR) labels with subaccount attributes.
 
 ## Details
 
-The `operator.kyma-project.io/beta` label of all Kyma CRs for a given subaccount is synchronized with
-the `Enable beta features` attribute of this subaccount.
-The current state of the attribute is persisted in the `subaccount_states` database table.
-`Used for production` is monitored as well and its state is persisted in the same table. However, it does not affect
-any resources.
+The `operator.kyma-project.io/beta` and `operator.kyma-project.io/used-for-production` labels of all Kyma CRs for a given subaccount are synchronized 
+with the `Enable beta features` and `Used for Production` attributes accordingly.
+The current state of the attributes is persisted in the `subaccount_states` database table.
 
 The table structure:
 

--- a/internal/kymacustomresource/kyma_cr_updater.go
+++ b/internal/kymacustomresource/kyma_cr_updater.go
@@ -14,43 +14,39 @@ import (
 )
 
 const (
-	namespace               = "kcp-system"
-	subaccountIdLabelKey    = "kyma-project.io/subaccount-id"
-	subaccountIdLabelFormat = "kyma-project.io/subaccount-id=%s"
-	k8sRequestInterval      = 5 * time.Second
+	namespace                 = "kcp-system"
+	subaccountIdLabelKey      = "kyma-project.io/subaccount-id"
+	subaccountIdLabelFormat   = "kyma-project.io/subaccount-id=%s"
+	k8sRequestInterval        = 5 * time.Second
+	BetaEnabledLabelKey       = "operator.kyma-project.io/beta"
+	UsedForProductionLabelKey = "operator.kyma-project.io/used-for-production"
 )
 
 type Updater struct {
-	k8sClient                 dynamic.Interface
-	queue                     syncqueues.MultiConsumerPriorityQueue
-	kymaGVR                   schema.GroupVersionResource
-	sleepDuration             time.Duration
-	betaEnabledLabelKey       string
-	usedForProductionLabelKey string
-	ctx                       context.Context
-	logger                    *slog.Logger
+	k8sClient     dynamic.Interface
+	queue         syncqueues.MultiConsumerPriorityQueue
+	kymaGVR       schema.GroupVersionResource
+	sleepDuration time.Duration
+	ctx           context.Context
+	logger        *slog.Logger
 }
 
 func NewUpdater(k8sClient dynamic.Interface,
 	queue syncqueues.MultiConsumerPriorityQueue,
 	gvr schema.GroupVersionResource,
 	sleepDuration time.Duration,
-	betaEnabledLabelKey string,
-	usedForProductionLabelKey string,
 	ctx context.Context,
 	logger *slog.Logger) (*Updater, error) {
 
-	logger.Info(fmt.Sprintf("Creating Kyma CR updater for labels: %s and %s", betaEnabledLabelKey, usedForProductionLabelKey))
+	logger.Info(fmt.Sprintf("Creating Kyma CR updater for labels: %s and %s", BetaEnabledLabelKey, UsedForProductionLabelKey))
 
 	return &Updater{
-		k8sClient:                 k8sClient,
-		queue:                     queue,
-		kymaGVR:                   gvr,
-		logger:                    logger,
-		sleepDuration:             sleepDuration,
-		betaEnabledLabelKey:       betaEnabledLabelKey,
-		usedForProductionLabelKey: usedForProductionLabelKey,
-		ctx:                       ctx,
+		k8sClient:     k8sClient,
+		queue:         queue,
+		kymaGVR:       gvr,
+		logger:        logger,
+		sleepDuration: sleepDuration,
+		ctx:           ctx,
 	}, nil
 }
 
@@ -98,8 +94,8 @@ func (u *Updater) updateLabels(un unstructured.Unstructured, betaEnabled string,
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[u.betaEnabledLabelKey] = betaEnabled
-	labels[u.usedForProductionLabelKey] = usedForProduction
+	labels[BetaEnabledLabelKey] = betaEnabled
+	labels[UsedForProductionLabelKey] = usedForProduction
 	un.SetLabels(labels)
 	_, err := u.k8sClient.Resource(u.kymaGVR).Namespace(namespace).Update(ctx, &un, metav1.UpdateOptions{})
 	return err

--- a/internal/kymacustomresource/kyma_cr_updater_test.go
+++ b/internal/kymacustomresource/kyma_cr_updater_test.go
@@ -28,11 +28,9 @@ const (
 )
 
 const (
-	subaccountID              = "subaccount-id-1"
-	betaEnabledLabelKey       = "operator.kyma-project.io/beta"
-	usedForProductionLabelKey = "operator.kyma-project.io/used-for-production"
-	interval                  = 100 * time.Millisecond
-	timeout                   = 2 * time.Second
+	subaccountID = "subaccount-id-1"
+	interval     = 100 * time.Millisecond
+	timeout      = 2 * time.Second
 )
 
 var log = slog.New(slog.NewTextHandler(os.Stderr, nil))
@@ -62,7 +60,7 @@ func TestUpdater(t *testing.T) {
 
 		queue := syncqueues.NewPriorityQueueWithCallbacksForSize(log, nil, 4)
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, usedForProductionLabelKey, context.TODO(), log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -75,7 +73,7 @@ func TestUpdater(t *testing.T) {
 
 		actual, err := fakeK8sClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), kymaCRName, metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.NotContains(t, actual.GetLabels(), betaEnabledLabelKey)
+		assert.NotContains(t, actual.GetLabels(), BetaEnabledLabelKey)
 	})
 
 	t.Run("should update a Kyma CR with the given subaccount id label when the queue has a matching element", func(t *testing.T) {
@@ -98,7 +96,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, usedForProductionLabelKey, context.TODO(), log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -110,7 +108,7 @@ func TestUpdater(t *testing.T) {
 		err = wait.PollUntilContextTimeout(context.Background(), interval, timeout, true, func(ctx context.Context) (bool, error) {
 			actual, err := fakeK8sClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), kymaCRName, metav1.GetOptions{})
 			require.NoError(t, err)
-			if actual.GetLabels()[betaEnabledLabelKey] == "true" && actual.GetLabels()[usedForProductionLabelKey] == "USED_FOR_PRODUCTION" {
+			if actual.GetLabels()[BetaEnabledLabelKey] == "true" && actual.GetLabels()[UsedForProductionLabelKey] == "USED_FOR_PRODUCTION" {
 				return true, nil
 			}
 			return false, nil
@@ -143,7 +141,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR1, mockKymaCR2)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, usedForProductionLabelKey, context.TODO(), log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -157,7 +155,7 @@ func TestUpdater(t *testing.T) {
 			assert.Len(t, actual.Items, 2)
 			require.NoError(t, err)
 			for _, un := range actual.Items {
-				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
+				if un.GetLabels()[BetaEnabledLabelKey] != "true" && un.GetLabels()[UsedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
 					return false, nil
 				}
 			}
@@ -194,7 +192,7 @@ func TestUpdater(t *testing.T) {
 		assert.False(t, queue.IsEmpty())
 
 		fakeK8sClient := fake.NewSimpleDynamicClient(scheme, mockKymaCR1, mockKymaCR2)
-		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, betaEnabledLabelKey, usedForProductionLabelKey, context.TODO(), log)
+		updater, err := NewUpdater(fakeK8sClient, queue, gvr, timeout, context.TODO(), log)
 		require.NoError(t, err)
 
 		// when
@@ -208,7 +206,7 @@ func TestUpdater(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, actual.Items, 1)
 			for _, un := range actual.Items {
-				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
+				if un.GetLabels()[BetaEnabledLabelKey] != "true" && un.GetLabels()[UsedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
 					return false, nil
 				}
 			}
@@ -218,8 +216,8 @@ func TestUpdater(t *testing.T) {
 
 		actual, err := fakeK8sClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), kymaCRName2, metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.NotContains(t, actual.GetLabels(), betaEnabledLabelKey)
-		assert.NotContains(t, actual.GetLabels(), usedForProductionLabelKey)
+		assert.NotContains(t, actual.GetLabels(), BetaEnabledLabelKey)
+		assert.NotContains(t, actual.GetLabels(), UsedForProductionLabelKey)
 		assert.True(t, queue.IsEmpty())
 	})
 }

--- a/internal/kymacustomresource/kyma_cr_updater_test.go
+++ b/internal/kymacustomresource/kyma_cr_updater_test.go
@@ -157,7 +157,7 @@ func TestUpdater(t *testing.T) {
 			assert.Len(t, actual.Items, 2)
 			require.NoError(t, err)
 			for _, un := range actual.Items {
-				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] == "USED_FOR_PRODUCTION" {
+				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
 					return false, nil
 				}
 			}
@@ -208,7 +208,7 @@ func TestUpdater(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, actual.Items, 1)
 			for _, un := range actual.Items {
-				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] == "USED_FOR_PRODUCTION" {
+				if un.GetLabels()[betaEnabledLabelKey] != "true" && un.GetLabels()[usedForProductionLabelKey] != "USED_FOR_PRODUCTION" {
 					return false, nil
 				}
 			}
@@ -219,6 +219,7 @@ func TestUpdater(t *testing.T) {
 		actual, err := fakeK8sClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), kymaCRName2, metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.NotContains(t, actual.GetLabels(), betaEnabledLabelKey)
+		assert.NotContains(t, actual.GetLabels(), usedForProductionLabelKey)
 		assert.True(t, queue.IsEmpty())
 	})
 }

--- a/internal/subaccountsync/informer.go
+++ b/internal/subaccountsync/informer.go
@@ -19,12 +19,12 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("added Kyma CR is not an Unstructured: %s", obj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
+			subaccountID, runtimeID, betaEnabled, usedForProduction, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
 			if err != nil {
 				return
 			}
 
-			stateReconciler.reconcileResourceUpdate(subaccountIDType(subaccountID), runtimeIDType(runtimeID), runtimeStateType{betaEnabled: betaEnabled})
+			stateReconciler.reconcileResourceUpdate(subaccountIDType(subaccountID), runtimeIDType(runtimeID), runtimeStateType{betaEnabled: betaEnabled, usedForProduction: usedForProduction})
 			data, err := stateReconciler.accountsClient.GetSubaccountData(subaccountID)
 			if err != nil {
 				logger.Warn(fmt.Sprintf("while getting data for subaccount:%s", err))
@@ -39,12 +39,12 @@ func configureInformer(informer *cache.SharedIndexInformer, stateReconciler *sta
 				logger.Error(fmt.Sprintf("updated Kyma CR is not an Unstructured: %s", newObj))
 				return
 			}
-			subaccountID, runtimeID, betaEnabled, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
+			subaccountID, runtimeID, betaEnabled, usedForProduction, err := getRequiredData(u, logger, stateReconciler, alwaysUseDB)
 			if err != nil {
 				return
 			}
 			if !reflect.DeepEqual(oldObj.(*unstructured.Unstructured).GetLabels(), u.GetLabels()) {
-				stateReconciler.reconcileResourceUpdate(subaccountIDType(subaccountID), runtimeIDType(runtimeID), runtimeStateType{betaEnabled: betaEnabled})
+				stateReconciler.reconcileResourceUpdate(subaccountIDType(subaccountID), runtimeIDType(runtimeID), runtimeStateType{betaEnabled: betaEnabled, usedForProduction: usedForProduction})
 			}
 		},
 		DeleteFunc: func(obj interface{}) {

--- a/internal/subaccountsync/state_reconciler.go
+++ b/internal/subaccountsync/state_reconciler.go
@@ -324,7 +324,7 @@ func (reconciler *stateReconcilerType) enqueueSubaccountIfOutdated(subaccountID 
 	if reconciler.isResourceOutdated(subaccountID, state) {
 		reconciler.logger.Debug(fmt.Sprintf("Subaccount %s is outdated, enqueuing, setting betaEnabled %t", subaccountID, state.cisState.BetaEnabled))
 		state := reconciler.inMemoryState[subaccountID]
-		element := syncqueues.QueueElement{SubaccountID: string(subaccountID), ModifiedAt: state.cisState.ModifiedDate, BetaEnabled: fmt.Sprintf("%t", state.cisState.BetaEnabled)}
+		element := syncqueues.QueueElement{SubaccountID: string(subaccountID), ModifiedAt: state.cisState.ModifiedDate, BetaEnabled: fmt.Sprintf("%t", state.cisState.BetaEnabled), UsedForProduction: state.cisState.UsedForProduction}
 		reconciler.syncQueue.Insert(element)
 	} else {
 		reconciler.logger.Debug(fmt.Sprintf("Subaccount %s is not to be updated", subaccountID))

--- a/internal/subaccountsync/state_reconciler.go
+++ b/internal/subaccountsync/state_reconciler.go
@@ -339,8 +339,10 @@ func (reconciler *stateReconcilerType) isResourceOutdated(subaccountID subaccoun
 		cisState := state.cisState
 		for _, runtimeState := range runtimes {
 			outdated = outdated || runtimeState.betaEnabled == ""
+			outdated = outdated || runtimeState.usedForProduction == ""
 			outdated = outdated || (cisState.BetaEnabled && runtimeState.betaEnabled != "true")
 			outdated = outdated || (!cisState.BetaEnabled && runtimeState.betaEnabled != "false")
+			outdated = outdated || cisState.UsedForProduction != runtimeState.usedForProduction
 		}
 		reconciler.logger.Debug(fmt.Sprintf("Subaccount %s has %d runtimes, outdated: %t", subaccountID, len(runtimes), outdated))
 	} else {

--- a/internal/subaccountsync/state_reconciler_test.go
+++ b/internal/subaccountsync/state_reconciler_test.go
@@ -121,14 +121,14 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -141,15 +141,15 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		// then we add kyma resource, so we got update from informer
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -162,7 +162,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID2, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID2].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
 
@@ -174,8 +174,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -190,11 +190,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -213,8 +213,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -229,11 +229,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -246,11 +246,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "UNSET", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
@@ -263,8 +263,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -279,11 +279,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated first resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		// but we still have one resource with true label so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -291,11 +291,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
@@ -308,8 +308,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -324,11 +324,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated first resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		// but we still have one resource with true label so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -343,11 +343,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "UNSET", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got outstanding update from the plane (updater updated second resource with false label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		// so we have not reached the stable state so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -358,7 +358,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource with true label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		assert.False(t, reconciler.syncQueue.IsEmpty())
 		element, ok = reconciler.syncQueue.Extract()
@@ -368,7 +368,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource with true label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
 }
@@ -379,152 +379,226 @@ func TestOutdatedPredicate(t *testing.T) {
 
 	t.Run("should detect difference between false and true", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state))
 	})
 	t.Run("should detect difference between true and false", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
+	t.Run("should detect difference between USED_FOR_PRODUCTION and NOT_USED_FOR_PRODUCTION", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state))
+	})
+	t.Run("should detect difference between NOT_USED_FOR_PRODUCTION and USED_FOR_PRODUCTION", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state))
+	})
 	t.Run("should detect difference between true and any other than boolean", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "any"},
+				runtimeId11: runtimeStateType{betaEnabled: "any", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between false and any other than boolean", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "any"},
+				runtimeId11: runtimeStateType{betaEnabled: "any", usedForProduction: "USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
+	})
+	t.Run("should detect difference between USED_FOR_PRODUCTION and any other", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "any"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
+	})
+	t.Run("should detect difference between NOT_USED_FOR_PRODUCTION and any other than boolean", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "any"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between true and empty", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: ""},
+				runtimeId11: runtimeStateType{betaEnabled: "", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between false and empty", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: ""},
+				runtimeId11: runtimeStateType{betaEnabled: "", usedForProduction: "USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
+	})
+	t.Run("should detect difference between USED_FOR_PRODUCTION and empty", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: ""},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
+	})
+	t.Run("should detect difference between NOT_USED_FOR_PRODUCTION and empty", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: ""},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should treat as up-to-date true and true", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.False(t, reconciler.isResourceOutdated(subaccountId1, state))
 	})
 	t.Run("should treat as up-to-date false and false", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.False(t, reconciler.isResourceOutdated(subaccountId1, state))
 	})
 	t.Run("should detect difference between false and true if one is true", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "true"},
-				runtimeId12: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state))
 	})
 	t.Run("should detect difference between true and false if one is false", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "false"},
-				runtimeId12: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
+	})
+	t.Run("should detect difference between NOT_USED_FOR_PRODUCTION and USED_FOR_PRODUCTION if one is USED_FOR_PRODUCTION", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
+			},
+		}
+		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state))
+	})
+	t.Run("should detect difference between USED_FOR_PRODUCTION and NOT_USED_FOR_PRODUCTION if one is NOT_USED_FOR_PRODUCTION", func(t *testing.T) {
+		state := subaccountStateType{
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
+			resourcesState: subaccountRuntimesType{
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between true and any other than boolean", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "any"},
-				runtimeId12: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "any", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between false and any other than boolean if one is not boolean", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "any"},
-				runtimeId12: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "any", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between true and empty if one is empty", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: ""},
-				runtimeId12: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should detect difference between false and empty if one is empty", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: ""},
-				runtimeId12: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "false", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.True(t, reconciler.isResourceOutdated(subaccountId1, state)) // outdated
 	})
 	t.Run("should treat as up-to-date true and all true", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: true, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "true"},
-				runtimeId12: runtimeStateType{betaEnabled: "true"},
+				runtimeId11: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.False(t, reconciler.isResourceOutdated(subaccountId1, state))
 	})
 	t.Run("should treat as up-to-date false and all false", func(t *testing.T) {
 		state := subaccountStateType{
-			cisState: CisStateType{BetaEnabled: false, ModifiedDate: veryOldTime},
+			cisState: CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime},
 			resourcesState: subaccountRuntimesType{
-				runtimeId11: runtimeStateType{betaEnabled: "false"},
-				runtimeId12: runtimeStateType{betaEnabled: "false"},
+				runtimeId11: runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
+				runtimeId12: runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"},
 			},
 		}
 		assert.False(t, reconciler.isResourceOutdated(subaccountId1, state))
@@ -575,14 +649,14 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// when the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		// then
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
@@ -594,7 +668,7 @@ func TestStateReconciler(t *testing.T) {
 
 		// when we get recent event from CIS with true label
 
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", oldTime))
 
 		// then queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -616,20 +690,20 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// when the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		// then
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// when we get recent event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", oldTime))
 
 		// then queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -655,20 +729,20 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// when the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		// then
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// when we get recent event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", oldTime))
 
 		// then queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -694,19 +768,19 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get event from CIS with false label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", "NOT_USED_FOR_PRODUCTION", oldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -719,7 +793,7 @@ func TestStateReconciler(t *testing.T) {
 
 		// then we get event from CIS with false label
 
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", notSoOldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", notSoOldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -738,25 +812,25 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get event from CIS with false label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", "NOT_USED_FOR_PRODUCTION", oldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get event from CIS with false label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", notSoOldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", notSoOldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -775,22 +849,22 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get recent event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", notSoOldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", notSoOldTime))
 
 		// then we get older event from CIS with false label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", "NOT_USED_FOR_PRODUCTION", oldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -812,14 +886,14 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get recent event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", notSoOldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", notSoOldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -829,7 +903,7 @@ func TestStateReconciler(t *testing.T) {
 		assert.Equal(t, "true", element.BetaEnabled)
 
 		// then we get older event from CIS with false label, we do not know if real update already happened
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", "NOT_USED_FOR_PRODUCTION", oldTime))
 
 		// queue should be empty since we used more recent event to update the resource
 		assert.True(t, reconciler.syncQueue.IsEmpty())
@@ -842,14 +916,14 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get recent event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", notSoOldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", notSoOldTime))
 
 		// queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -859,10 +933,10 @@ func TestStateReconciler(t *testing.T) {
 		assert.Equal(t, "true", element.BetaEnabled)
 
 		// then we got confirmation that the update was applied
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"})
 
 		// then we get older event from CIS with false label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "false", "NOT_USED_FOR_PRODUCTION", oldTime))
 
 		// queue should be empty since we used more recent event to update the resource
 		assert.True(t, reconciler.syncQueue.IsEmpty())
@@ -880,7 +954,7 @@ func TestStateReconciler(t *testing.T) {
 
 		// when
 		// initial add event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// then we fetch state from accounts endpoint
@@ -895,7 +969,7 @@ func TestStateReconciler(t *testing.T) {
 		newReconciler.recreateStateFromDB()
 		// when
 		// initial add event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		reconciler.reconcileCisAccount(subaccountId1, CisStateType{BetaEnabled: false, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: veryOldTime})
 		// queue should contain one element again
 
@@ -913,7 +987,7 @@ func TestStateReconciler(t *testing.T) {
 
 		// when
 		// initial add event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// then we fetch state from accounts endpoint
@@ -939,7 +1013,7 @@ func TestStateReconciler(t *testing.T) {
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get update event from informer
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 
 		// then there is nothing to do
 		assert.True(t, newReconciler.syncQueue.IsEmpty())
@@ -957,7 +1031,7 @@ func TestStateReconciler(t *testing.T) {
 
 		// when
 		// initial add event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// then we fetch state from accounts endpoint
@@ -967,7 +1041,7 @@ func TestStateReconciler(t *testing.T) {
 		assert.False(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get old event from CIS with true label
-		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", oldTime))
+		reconciler.reconcileCisEvent(fixCisUpdateEvent(subaccountId1, "true", "USED_FOR_PRODUCTION", oldTime))
 
 		// then queue should contain one element
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -979,7 +1053,7 @@ func TestStateReconciler(t *testing.T) {
 		assert.Equal(t, "true", element.BetaEnabled)
 
 		// and update resource so update event comes from informer
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"})
 
 		// then comes app restart
 		newReconciler := createNewReconciler(brokerStorage)
@@ -987,8 +1061,8 @@ func TestStateReconciler(t *testing.T) {
 		newReconciler.recreateStateFromDB()
 		// when
 		// initial add event from the kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true"})
-		reconciler.reconcileCisAccount(subaccountId1, CisStateType{BetaEnabled: true, UsedForProduction: "NOT_USED_FOR_PRODUCTION", ModifiedDate: oldTime})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "USED_FOR_PRODUCTION"})
+		reconciler.reconcileCisAccount(subaccountId1, CisStateType{BetaEnabled: true, UsedForProduction: "USED_FOR_PRODUCTION", ModifiedDate: oldTime})
 		// queue should be empty - no difference, resource is up-to-date
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
@@ -1000,14 +1074,14 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -1034,18 +1108,18 @@ func TestStateReconciler(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// initial event from a second kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(subaccountId2, runtimeId21, runtimeStateType{betaEnabled: ""})
+		reconciler.reconcileResourceUpdate(subaccountId2, runtimeId21, runtimeStateType{betaEnabled: "", usedForProduction: ""})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(subaccountId1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -1259,7 +1333,7 @@ func TestStateReconciler(t *testing.T) {
 		reconciler.reconcileCisAccount(subaccountId3, CisStateType{BetaEnabled: true, UsedForProduction: "NOT_SET", ModifiedDate: veryOldTime})
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
-		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", veryOldTime))
+		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", "NOT_SET", veryOldTime))
 
 		// then
 		// queue should be empty
@@ -1289,7 +1363,7 @@ func TestStateReconciler(t *testing.T) {
 		assert.False(t, reconciler.syncQueue.IsEmpty())
 
 		// then we get the creation event
-		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", veryOldTime))
+		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", "NOT_SET", veryOldTime))
 
 		// then
 		// queue should contain one element
@@ -1320,7 +1394,7 @@ func TestStateReconciler(t *testing.T) {
 		reconciler.reconcileCisAccount(subaccountId3, CisStateType{BetaEnabled: true, UsedForProduction: "NOT_SET", ModifiedDate: veryOldTime})
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
-		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", veryOldTime))
+		reconciler.reconcileCisEvent(fixCisCreateEvent(subaccountId3, "true", "NOT_SET", veryOldTime))
 
 		// then
 		// queue should be empty since there is nothing to be updated
@@ -1416,21 +1490,22 @@ func fixInstance(id string, subaccountID string, runtimeID string) internal.Inst
 	}
 }
 
-func fixCisUpdateEvent(subaccountID string, betaEnabled string, actionTime int64) Event {
-	return fixCisEvent(subaccountID, "Subaccount_Update", betaEnabled, actionTime)
+func fixCisUpdateEvent(subaccountID string, betaEnabled string, usedForProduction string, actionTime int64) Event {
+	return fixCisEvent(subaccountID, "Subaccount_Update", betaEnabled, usedForProduction, actionTime)
 }
 
-func fixCisCreateEvent(subaccountID string, betaEnabled string, actionTime int64) Event {
-	return fixCisEvent(subaccountID, "Subaccount_Create", betaEnabled, actionTime)
+func fixCisCreateEvent(subaccountID string, betaEnabled string, usedForProduction string, actionTime int64) Event {
+	return fixCisEvent(subaccountID, "Subaccount_Create", betaEnabled, usedForProduction, actionTime)
 }
 
-func fixCisEvent(subaccountID string, eventType string, betaEnabled string, actionTime int64) Event {
+func fixCisEvent(subaccountID string, eventType string, betaEnabled string, usedForProduction string, actionTime int64) Event {
 	return Event{
 		ActionTime:   actionTime,
 		SubaccountID: subaccountID,
 		Type:         eventType,
 		Details: EventDetails{
-			BetaEnabled: betaEnabled == "true",
+			BetaEnabled:       betaEnabled == "true",
+			UsedForProduction: usedForProduction,
 		},
 	}
 }

--- a/internal/subaccountsync/state_reconciler_test.go
+++ b/internal/subaccountsync/state_reconciler_test.go
@@ -121,14 +121,14 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resource, first runtime, no label
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: ""})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		// then the same subaccount, second runtime, with false label
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -141,15 +141,15 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
 
 		// then we add kyma resource, so we got update from informer
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "false"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -162,7 +162,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID2, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID2].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
 
@@ -174,8 +174,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -190,11 +190,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -213,8 +213,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID2, runtimeId21, runtimeStateType{betaEnabled: "true"})
 		assert.Equal(t, 2, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -229,11 +229,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
@@ -246,11 +246,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "UNSET", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated resources)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
@@ -263,8 +263,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -279,11 +279,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated first resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
 
 		// but we still have one resource with true label so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -291,11 +291,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
 
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
@@ -308,8 +308,8 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 
 		// given
 		// initial event from a kyma resources, all true
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
 		assert.Equal(t, 1, len(reconciler.inMemoryState))
 
 		// queue should be empty since we have not got state from CIS
@@ -324,11 +324,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "false", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated first resource)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "false"})
 
 		// but we still have one resource with true label so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -343,11 +343,11 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, cis.FakeSubaccountID1, element.SubaccountID)
 		assert.Equal(t, "true", element.BetaEnabled)
-		assert.Equal(t, "NOT_USED_FOR_PRODUCTION", element.UsedForProduction)
+		assert.Equal(t, "UNSET", reconciler.inMemoryState[cis.FakeSubaccountID1].cisState.UsedForProduction)
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got outstanding update from the plane (updater updated second resource with false label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "false"})
 
 		// so we have not reached the stable state so we enqueue the update request again
 		assert.False(t, reconciler.syncQueue.IsEmpty())
@@ -358,7 +358,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource with true label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId12, runtimeStateType{betaEnabled: "true"})
 
 		assert.False(t, reconciler.syncQueue.IsEmpty())
 		element, ok = reconciler.syncQueue.Extract()
@@ -368,7 +368,7 @@ func TestStateReconcilerWithFakeCisServer(t *testing.T) {
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 
 		//then we got update from the plane (updater updated second resource with true label)
-		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true", usedForProduction: "NOT_USED_FOR_PRODUCTION"})
+		reconciler.reconcileResourceUpdate(cis.FakeSubaccountID1, runtimeId11, runtimeStateType{betaEnabled: "true"})
 		assert.True(t, reconciler.syncQueue.IsEmpty())
 	})
 }

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -23,12 +23,13 @@ import (
 )
 
 const (
-	subaccountIDLabel     = "kyma-project.io/subaccount-id"
-	runtimeIDLabel        = "kyma-project.io/runtime-id"
-	betaEnabledLabel      = "operator.kyma-project.io/beta"
-	eventServicePath      = "%s/events/v1/events/central"
-	subaccountServicePath = "%s/accounts/v1/technical/subaccounts/%s"
-	eventType             = "Subaccount_Creation,Subaccount_Update"
+	subaccountIDLabel         = "kyma-project.io/subaccount-id"
+	runtimeIDLabel            = "kyma-project.io/runtime-id"
+	betaEnabledLabel          = "operator.kyma-project.io/beta"
+	usedForProductionLabelKey = "operator.kyma-project.io/used-for-production"
+	eventServicePath          = "%s/events/v1/events/central"
+	subaccountServicePath     = "%s/accounts/v1/technical/subaccounts/%s"
+	eventType                 = "Subaccount_Creation,Subaccount_Update"
 )
 
 type (
@@ -134,6 +135,7 @@ func (s *SyncService) Run() {
 			s.kymaGVR,
 			s.cfg.SyncQueueSleepInterval,
 			betaEnabledLabel,
+			usedForProductionLabelKey,
 			s.ctx,
 			logger.With("component", "updater"))
 		fatalOnError(err)

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -23,20 +23,19 @@ import (
 )
 
 const (
-	subaccountIDLabel         = "kyma-project.io/subaccount-id"
-	runtimeIDLabel            = "kyma-project.io/runtime-id"
-	betaEnabledLabel          = "operator.kyma-project.io/beta"
-	usedForProductionLabelKey = "operator.kyma-project.io/used-for-production"
-	eventServicePath          = "%s/events/v1/events/central"
-	subaccountServicePath     = "%s/accounts/v1/technical/subaccounts/%s"
-	eventType                 = "Subaccount_Creation,Subaccount_Update"
+	subaccountIDLabel     = "kyma-project.io/subaccount-id"
+	runtimeIDLabel        = "kyma-project.io/runtime-id"
+	eventServicePath      = "%s/events/v1/events/central"
+	subaccountServicePath = "%s/accounts/v1/technical/subaccounts/%s"
+	eventType             = "Subaccount_Creation,Subaccount_Update"
 )
 
 type (
 	subaccountIDType string
 	runtimeIDType    string
 	runtimeStateType struct {
-		betaEnabled string
+		betaEnabled       string
+		usedForProduction string
 	}
 	subaccountRuntimesType map[runtimeIDType]runtimeStateType
 	statesFromCisType      map[subaccountIDType]CisStateType
@@ -134,8 +133,6 @@ func (s *SyncService) Run() {
 			priorityQueue,
 			s.kymaGVR,
 			s.cfg.SyncQueueSleepInterval,
-			betaEnabledLabel,
-			usedForProductionLabelKey,
 			s.ctx,
 			logger.With("component", "updater"))
 		fatalOnError(err)
@@ -214,11 +211,12 @@ func getSubaccountIDFromDB(runtimeID string, db storage.BrokerStorage) (string, 
 	return subaccountID, nil
 }
 
-func getRequiredData(u *unstructured.Unstructured, logger *slog.Logger, stateReconciler *stateReconcilerType, alwaysUseDB bool) (string, string, string, error) {
+func getRequiredData(u *unstructured.Unstructured, logger *slog.Logger, stateReconciler *stateReconcilerType, alwaysUseDB bool) (string, string, string, string, error) {
 	labels := u.GetLabels()
 	subaccountID := labels[subaccountIDLabel]
 	runtimeID := labels[runtimeIDLabel]
-	betaEnabled := labels[betaEnabledLabel]
+	betaEnabled := labels[kymacustomresource.BetaEnabledLabelKey]
+	usedForProduction := labels[kymacustomresource.UsedForProductionLabelKey]
 	if runtimeID == "" {
 		logger.Warn(fmt.Sprintf("Kyma resource has no runtime label, falling back to resource name: %s", u.GetName()))
 		runtimeID = u.GetName()
@@ -227,10 +225,10 @@ func getRequiredData(u *unstructured.Unstructured, logger *slog.Logger, stateRec
 	if subaccountID == "" || alwaysUseDB {
 		subaccountID, err = getSubaccountIDFromDB(runtimeID, stateReconciler.db)
 		if err != nil {
-			return "", "", "", fmt.Errorf("cannot determine subaccountID for Kyma resource: %s - %s", u.GetName(), err)
+			return "", "", "", "", fmt.Errorf("cannot determine subaccountID for Kyma resource: %s - %s", u.GetName(), err)
 		}
 	}
-	return subaccountID, runtimeID, betaEnabled, nil
+	return subaccountID, runtimeID, betaEnabled, usedForProduction, nil
 }
 
 func fatalOnError(err error) {

--- a/internal/subaccountsync/testdata/events.json
+++ b/internal/subaccountsync/testdata/events.json
@@ -14,7 +14,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": true,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": "USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",
@@ -86,7 +86,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "USED_FOR_PRODUCTION",
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",

--- a/internal/subaccountsync/testdata/events.json
+++ b/internal/subaccountsync/testdata/events.json
@@ -38,7 +38,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": true,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": "UNSET",
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",
@@ -62,7 +62,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": true,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": "USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",
@@ -86,7 +86,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": "USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",
@@ -110,7 +110,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": null,
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",
@@ -134,7 +134,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+      "usedForProduction": "USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",

--- a/internal/subaccountsync/testdata/events.json
+++ b/internal/subaccountsync/testdata/events.json
@@ -38,7 +38,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": true,
-      "usedForProduction": "UNSET",
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",
@@ -62,7 +62,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": true,
-      "usedForProduction": "USED_FOR_PRODUCTION",
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",
@@ -86,7 +86,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-2-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "USED_FOR_PRODUCTION",
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "54130280-9eef-4fab-94b6-be2bea4fa1d0",
@@ -110,7 +110,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": false,
-      "usedForProduction": null,
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",
@@ -134,7 +134,7 @@
       "jobLocation": null,
       "subdomain": "subaccount-1-subdomain",
       "betaEnabled": false,
-      "usedForProduction": "USED_FOR_PRODUCTION",
+      "usedForProduction": "NOT_USED_FOR_PRODUCTION",
       "labels": {}
     },
     "globalAccountGUID": "bbecf441-f9bd-4d09-8a3d-877a7519b949",

--- a/internal/subaccountsync/testdata/subaccounts.json
+++ b/internal/subaccountsync/testdata/subaccounts.json
@@ -31,7 +31,7 @@
     "region": "eu10-canary",
     "subdomain": "subaccount-2-efgh",
     "betaEnabled": true,
-    "usedForProduction": "USED_FOR_PRODUCTION",
+    "usedForProduction": "NOT_USED_FOR_PRODUCTION",
     "description": null,
     "state": "OK",
     "stateMessage": "Subaccount created.",

--- a/internal/subaccountsync/testdata/subaccounts.json
+++ b/internal/subaccountsync/testdata/subaccounts.json
@@ -31,7 +31,7 @@
     "region": "eu10-canary",
     "subdomain": "subaccount-2-efgh",
     "betaEnabled": true,
-    "usedForProduction": "NOT_USED_FOR_PRODUCTION",
+    "usedForProduction": "USED_FOR_PRODUCTION",
     "description": null,
     "state": "OK",
     "stateMessage": "Subaccount created.",

--- a/internal/syncqueues/model.go
+++ b/internal/syncqueues/model.go
@@ -16,9 +16,10 @@ type ElementWrapper struct {
 }
 
 type QueueElement struct {
-	SubaccountID string
-	BetaEnabled  string
-	ModifiedAt   int64
+	SubaccountID      string
+	BetaEnabled       string
+	UsedForProduction string
+	ModifiedAt        int64
 }
 
 type EventHandler struct {

--- a/internal/syncqueues/priority_queue.go
+++ b/internal/syncqueues/priority_queue.go
@@ -54,7 +54,7 @@ func (q *SubaccountAwarePriorityQueueWithCallbacks) Insert(element QueueElement)
 	if idx, ok := q.idx[e.SubaccountID]; ok {
 		if q.elements[idx].ModifiedAt > e.ModifiedAt {
 			// new element is older than one already in the queue, do not insert
-			q.log.Debug(fmt.Sprintf("Element with subaccountID %s, betaEnabled %s, modifiedAt %d is older than %d - ignoring", e.SubaccountID, e.BetaEnabled, e.ModifiedAt, q.elements[idx].ModifiedAt))
+			q.log.Debug(fmt.Sprintf("Element with subaccountID %s, betaEnabled %s, usedForProduction %s, modifiedAt %d is older than %d - ignoring", e.SubaccountID, e.BetaEnabled, e.UsedForProduction, e.ModifiedAt, q.elements[idx].ModifiedAt))
 			return
 		}
 		// extraction and re-insertion
@@ -66,9 +66,9 @@ func (q *SubaccountAwarePriorityQueueWithCallbacks) Insert(element QueueElement)
 		q.idx[q.elements[0].SubaccountID] = 0
 		q.size--
 		q.siftDown()
-		q.log.Debug(fmt.Sprintf("Element with subaccountID %s is updated with betaEnabled %s, modifiedAt %d", e.SubaccountID, e.BetaEnabled, e.ModifiedAt))
+		q.log.Debug(fmt.Sprintf("Element with subaccountID %s is updated with betaEnabled %s, usedForProduction %s, modifiedAt %d", e.SubaccountID, e.BetaEnabled, e.UsedForProduction, e.ModifiedAt))
 	} else {
-		q.log.Debug(fmt.Sprintf("Element with subaccountID %s is inserted with betaEnabled %s, modifiedAt %d", e.SubaccountID, e.BetaEnabled, e.ModifiedAt))
+		q.log.Debug(fmt.Sprintf("Element with subaccountID %s is inserted with betaEnabled %s, usedForProduction %s, modifiedAt %d", e.SubaccountID, e.BetaEnabled, e.UsedForProduction, e.ModifiedAt))
 		q.idx[e.SubaccountID] = q.size
 	}
 
@@ -103,7 +103,7 @@ func (q *SubaccountAwarePriorityQueueWithCallbacks) Extract() (QueueElement, boo
 	if q.eventHandler != nil && q.eventHandler.OnExtract != nil {
 		q.eventHandler.OnExtract(q.size, time.Now().UnixNano()-e.entryTime)
 	}
-	q.log.Debug(fmt.Sprintf("Element dequeued - subaccountID: %s, betaEnabled %s", e.SubaccountID, e.BetaEnabled))
+	q.log.Debug(fmt.Sprintf("Element dequeued - subaccountID: %s, betaEnabled %s, usedForProduction %s", e.SubaccountID, e.BetaEnabled, e.UsedForProduction))
 	return e.QueueElement, true
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- enhance the Kyma CR updater to add the `operator.kyma-project.io/used-for-production` label to the Kyma CR,
- update docs.

**Related issue(s)**
See also #1813