### PR TITLE
Fix kubeconfig builder to use additionalOIDC

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -323,7 +323,7 @@ func main() {
 	fatalOnError(err, log)
 
 	// create kubeconfig builder
-	kcBuilder := kubeconfig.NewBuilder(kcpK8sClient, skrK8sClientProvider)
+	kcBuilder := kubeconfig.NewBuilder(kcpK8sClient, skrK8sClientProvider, cfg.Provisioner.UseMainOIDC, cfg.Provisioner.UseAdditionalOIDC)
 
 	// create server
 	router := httputil.NewRouter()

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -430,8 +430,8 @@ func createAPI(router *httputil.Router, servicesConfig broker.ServicesConfig, pl
 			planDefaults, logs, cfg.KymaDashboardConfig, kcBuilder, convergedCloudRegionProvider, kcpK8sClient, regionsSupportingMachine),
 		GetInstanceEndpoint:          broker.NewGetInstance(cfg.Broker, db.Instances(), db.Operations(), kcBuilder, logs),
 		LastOperationEndpoint:        broker.NewLastOperation(db.Operations(), db.InstancesArchived(), logs),
-		BindEndpoint:                 broker.NewBind(cfg.Broker.Binding, db, logs, clientProvider, kubeconfigProvider, publisher),
-		UnbindEndpoint:               broker.NewUnbind(logs, db, brokerBindings.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider), publisher),
+		BindEndpoint:                 broker.NewBind(cfg.Broker.Binding, db, logs, clientProvider, kubeconfigProvider, publisher, cfg.Provisioner.UseAdditionalOIDC, cfg.Provisioner.UseMainOIDC),
+		UnbindEndpoint:               broker.NewUnbind(logs, db, brokerBindings.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider, cfg.Provisioner.UseAdditionalOIDC, cfg.Provisioner.UseMainOIDC), publisher),
 		GetBindingEndpoint:           broker.NewGetBinding(logs, db),
 		LastBindingOperationEndpoint: broker.NewLastBindingOperation(logs),
 	}

--- a/internal/broker/bind_create.go
+++ b/internal/broker/bind_create.go
@@ -70,14 +70,14 @@ type Credentials struct {
 }
 
 func NewBind(cfg BindingConfig, db storage.BrokerStorage, log *slog.Logger, clientProvider broker.ClientProvider, kubeconfigProvider broker.KubeconfigProvider,
-	publisher event.Publisher) *BindEndpoint {
+	publisher event.Publisher, useAdditionalOIDC, useMainOIDC bool) *BindEndpoint {
 	return &BindEndpoint{config: cfg,
 		instancesStorage:             db.Instances(),
 		bindingsStorage:              db.Bindings(),
 		publisher:                    publisher,
 		operationsStorage:            db.Operations(),
 		log:                          log.With("service", "BindEndpoint"),
-		serviceAccountBindingManager: broker.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider),
+		serviceAccountBindingManager: broker.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider, useAdditionalOIDC, useMainOIDC),
 	}
 }
 

--- a/internal/broker/bind_create_test.go
+++ b/internal/broker/bind_create_test.go
@@ -93,7 +93,7 @@ func TestCreateBindingEndpoint_dbInsertionInCaseOfError(t *testing.T) {
 	publisher := event.NewPubSub(log)
 
 	//// api handler
-	bindEndpoint := NewBind(*bindingCfg, db, fixLogger(), &provider{}, &provider{}, publisher)
+	bindEndpoint := NewBind(*bindingCfg, db, fixLogger(), &provider{}, &provider{}, publisher, false, true)
 
 	// test relies on checking if got nil on kubeconfig provider but the instance got inserted either way
 	t.Run("should INSERT binding despite error on k8s api call", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestCreateSecondBindingWithTheSameIdButDifferentParams(t *testing.T) {
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, false, true)
 	params := BindingParams{
 		ExpirationSeconds: 601,
 	}
@@ -394,7 +394,7 @@ func TestCreateSecondBindingWithTheSameIdAndParams(t *testing.T) {
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, false, true)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -446,7 +446,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForExpired(t *testing.T) {
 	// event publisher
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, false, true)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -500,7 +500,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForBindingInProgress(t *testin
 	// event publisher
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, false, true)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -551,7 +551,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsNotExplicitlyDefined(t *testin
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, false, true)
 
 	// when
 	resp, err := svc.Bind(context.Background(), instanceID, bindingID, domain.BindDetails{}, false)
@@ -577,5 +577,5 @@ func prepareBindingEndpoint(t *testing.T, cfg BindingConfig) (*BindEndpoint, sto
 	err = db.Operations().InsertOperation(operation)
 	require.NoError(t, err)
 
-	return NewBind(cfg, db, log, k8sClientProvider, k8sClientProvider, event.NewPubSub(log)), db
+	return NewBind(cfg, db, log, k8sClientProvider, k8sClientProvider, event.NewPubSub(log), false, true), db
 }

--- a/internal/broker/bind_envtest_test.go
+++ b/internal/broker/bind_envtest_test.go
@@ -105,8 +105,8 @@ func TestCreateBinding(t *testing.T) {
 		Level: slog.LevelDebug,
 	}))
 	publisher := event.NewPubSub(log)
-	svc := NewBind(bindingCfg, db, log, skrK8sClientProvider, skrK8sClientProvider, publisher)
-	unbindSvc := NewUnbind(log, db, brokerBindings.NewServiceAccountBindingsManager(skrK8sClientProvider, skrK8sClientProvider), publisher)
+	svc := NewBind(bindingCfg, db, log, skrK8sClientProvider, skrK8sClientProvider, publisher, false, true)
+	unbindSvc := NewUnbind(log, db, brokerBindings.NewServiceAccountBindingsManager(skrK8sClientProvider, skrK8sClientProvider, false, true), publisher)
 
 	t.Run("should create a new service binding without error", func(t *testing.T) {
 		// When

--- a/internal/broker/bindings/bindings_manager.go
+++ b/internal/broker/bindings/bindings_manager.go
@@ -44,10 +44,10 @@ type ServiceAccountBindingsManager struct {
 	kubeconfigBuilder *kubeconfig.Builder
 }
 
-func NewServiceAccountBindingsManager(clientProvider ClientProvider, kubeconfigProvider KubeconfigProvider) *ServiceAccountBindingsManager {
+func NewServiceAccountBindingsManager(clientProvider ClientProvider, kubeconfigProvider KubeconfigProvider, useAdditionalOIDC, useMainOIDC bool) *ServiceAccountBindingsManager {
 	return &ServiceAccountBindingsManager{
 		clientProvider:    clientProvider,
-		kubeconfigBuilder: kubeconfig.NewBuilder(nil, kubeconfigProvider),
+		kubeconfigBuilder: kubeconfig.NewBuilder(nil, kubeconfigProvider, useAdditionalOIDC, useMainOIDC),
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Part of the migration to additionalOIDC. When KEB doesn't set the oidcConfig in RuntimeCR we should use the additionalConfig to build the kubeconfig.

Changes proposed in this pull request:

- Use additionalOIDCs first element to build the kubeconfig
- Use migration feature flags

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #423 