### PR TITLE
Use kcp rt status in skr-tester

### DIFF
--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -181,6 +181,26 @@ func (c *KCPClient) GetPlanName(instanceID string) (string, error) {
 	return planName, nil
 }
 
+func (c *KCPClient) GetStatus(instanceID string) (string, error) {
+	args := []string{"rt", "-i", instanceID, "-o", "custom=:{.status}"}
+	if clientSecret := os.Getenv("KCP_OIDC_CLIENT_SECRET"); clientSecret != "" {
+		args = append(args, "--config", "config.yaml")
+	}
+	output, err := exec.Command("kcp", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get status: %w", err)
+	}
+	var status map[string]interface{}
+	if err := json.Unmarshal(output, &status); err != nil {
+		return "", fmt.Errorf("failed to parse JSON: %w", err)
+	}
+	formattedStatus, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to format JSON: %w", err)
+	}
+	return string(formattedStatus), nil
+}
+
 func getEnvOrThrow(key string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -190,6 +190,13 @@ func (c *KCPClient) GetStatus(instanceID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get status: %w", err)
 	}
+	if len(strings.TrimSpace(string(output))) == 0 {
+		args = append(args, "--state", "deprovisioned")
+		output, err = exec.Command("kcp", args...).Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to get status: %w", err)
+		}
+	}
 	var status map[string]interface{}
 	if err := json.Unmarshal(output, &status); err != nil {
 		return "", fmt.Errorf("failed to parse JSON: %w", err)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- print `kcp rt` status at the end of the `check_operation` command.

**Related issue(s)**
See also #1820
