### PR TITLE
Add events command in skr-tester

### DIFF
--- a/testing/e2e/skr-tester/pkg/command/events.go
+++ b/testing/e2e/skr-tester/pkg/command/events.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"fmt"
+
+	"skr-tester/pkg/kcp"
+	"skr-tester/pkg/logger"
+
+	"github.com/spf13/cobra"
+)
+
+type EventsCommand struct {
+	cobraCmd   *cobra.Command
+	log        logger.Logger
+	instanceID string
+}
+
+func NewEventsCmd() *cobra.Command {
+	cmd := EventsCommand{}
+	cobraCmd := &cobra.Command{
+		Use:     "events",
+		Aliases: []string{"e"},
+		Short:   "Gets events for the instance",
+		Long:    "Gets events for the instance",
+		Example: "	skr-tester events -i instanceID                            Gets events for the instance.",
+
+		PreRunE: func(_ *cobra.Command, _ []string) error { return cmd.Validate() },
+		RunE:    func(_ *cobra.Command, _ []string) error { return cmd.Run() },
+	}
+	cmd.cobraCmd = cobraCmd
+
+	cobraCmd.Flags().StringVarP(&cmd.instanceID, "instanceID", "i", "", "Instance ID of the specific instance.")
+
+	return cobraCmd
+}
+
+func (cmd *EventsCommand) Run() error {
+	cmd.log = logger.New()
+	kcpClient, err := kcp.NewKCPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create KCP client: %v", err)
+	}
+	events, err := kcpClient.GetEvents(cmd.instanceID)
+	if err != nil {
+		return fmt.Errorf("failed to get events: %v", err)
+	}
+	fmt.Println(events)
+
+	return nil
+}
+
+func (cmd *EventsCommand) Validate() error {
+	if cmd.instanceID != "" {
+		return nil
+	} else {
+		return fmt.Errorf("at least one of the following options have to be specified: instanceID")
+	}
+}

--- a/testing/e2e/skr-tester/pkg/command/root.go
+++ b/testing/e2e/skr-tester/pkg/command/root.go
@@ -19,6 +19,7 @@ func New() *cobra.Command {
 		NewUpdateCommand(),
 		NewAsertCmd(),
 		NewBindingCmd(),
+		NewEventsCmd(),
 	)
 
 	return cmd

--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -208,6 +208,18 @@ func (c *KCPClient) GetStatus(instanceID string) (string, error) {
 	return string(formattedStatus), nil
 }
 
+func (c *KCPClient) GetEvents(instanceID string) (string, error) {
+	args := []string{"rt", "-i", instanceID, "--events"}
+	if clientSecret := os.Getenv("KCP_OIDC_CLIENT_SECRET"); clientSecret != "" {
+		args = append(args, "--config", "config.yaml")
+	}
+	events, err := exec.Command("kcp", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get events: %w", err)
+	}
+	return string(events), nil
+}
+
 func getEnvOrThrow(key string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -213,11 +213,15 @@ func (c *KCPClient) GetEvents(instanceID string) (string, error) {
 	if clientSecret := os.Getenv("KCP_OIDC_CLIENT_SECRET"); clientSecret != "" {
 		args = append(args, "--config", "config.yaml")
 	}
-	events, err := exec.Command("kcp", args...).Output()
+	output, err := exec.Command("kcp", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get events: %w", err)
 	}
-	return string(events), nil
+	events := strings.Split(string(output), "\n")
+	if len(events) <= 2 {
+		return "", fmt.Errorf("failed to format events")
+	}
+	return strings.Join(events[2:], "\n"), nil
 }
 
 func getEnvOrThrow(key string) string {

--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -213,15 +213,11 @@ func (c *KCPClient) GetEvents(instanceID string) (string, error) {
 	if clientSecret := os.Getenv("KCP_OIDC_CLIENT_SECRET"); clientSecret != "" {
 		args = append(args, "--config", "config.yaml")
 	}
-	output, err := exec.Command("kcp", args...).Output()
+	events, err := exec.Command("kcp", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get events: %w", err)
 	}
-	events := strings.Split(string(output), "\n")
-	if len(events) <= 2 {
-		return "", fmt.Errorf("failed to format events")
-	}
-	return strings.Join(events[2:], "\n"), nil
+	return string(events), nil
 }
 
 func getEnvOrThrow(key string) string {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add events command in skr-tester which is required to run `kcp rt --events` for the instance when a test fails.

**Related issue(s)**
See also #1820
