### PR TITLE
Separate timeouts for create and update in `checkRuntimeResource` step

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -280,14 +280,12 @@ func main() {
 	fatalOnError(err, log)
 	dynamicGardener, err := dynamic.NewForConfig(gardenerClusterConfig)
 	fatalOnError(err, log)
-	gardenerClient, err := initClient(gardenerClusterConfig)
-	fatalOnError(err, log)
 
 	gardenerNamespace := fmt.Sprintf("garden-%v", cfg.Gardener.Project)
 	gardenerAccountPool := hyperscaler.NewAccountPool(dynamicGardener, gardenerNamespace)
 	gardenerSharedPool := hyperscaler.NewSharedGardenerAccountPool(dynamicGardener, gardenerNamespace)
 	accountProvider := hyperscaler.NewAccountProvider(gardenerAccountPool, gardenerSharedPool)
-	gardenetClient := gardener.NewClient(dynamicGardener, gardenerNamespace)
+	gardenerClient := gardener.NewClient(dynamicGardener, gardenerNamespace)
 
 	regions, err := provider.ReadPlatformRegionMappingFromFile(cfg.TrialRegionMappingFilePath)
 	fatalOnError(err, log)
@@ -318,7 +316,7 @@ func main() {
 	// run queues
 	provisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Provisioning, log.With("provisioning", "manager"))
 	provisionQueue := NewProvisioningProcessingQueue(ctx, provisionManager, cfg.Provisioning.WorkersAmount, &cfg, db, configProvider,
-		edpClient, accountProvider, skrK8sClientProvider, kcpK8sClient, gardenetClient, oidcDefaultValues, log, rulesService)
+		edpClient, accountProvider, skrK8sClientProvider, kcpK8sClient, gardenerClient, oidcDefaultValues, log, rulesService)
 
 	deprovisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.OperationTimeout, cfg.Deprovisioning, log.With("deprovisioning", "manager"))
 	deprovisionQueue := NewDeprovisioningProcessingQueue(ctx, cfg.Deprovisioning.WorkersAmount, deprovisionManager, &cfg, db, edpClient, accountProvider,

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -110,7 +110,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		},
 		{
 			stage:     createRuntimeStageName,
-			step:      steps.NewCheckRuntimeResourceStep(db.Operations(), cli, internal.RetryTuple{Timeout: cfg.Provisioner.RuntimeResourceStepTimeout, Interval: resourceStateRetryInterval}),
+			step:      steps.NewCheckRuntimeResourceStep(db.Operations(), cli, internal.RetryTuple{Timeout: cfg.StepTimeouts.checkRuntimeResourceCreate, Interval: resourceStateRetryInterval}),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{ // TODO: this step must be removed when kubeconfig is created by IM and own_cluster plan is permanently removed

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -275,6 +275,10 @@ func fixConfig() *Config {
 			UseMainOIDC:                             true,
 			UseAdditionalOIDC:                       false,
 		},
+		StepTimeouts: StepTimeoutsConfig{
+			checkRuntimeResourceUpdate: 180 * time.Second,
+			checkRuntimeResourceCreate: 60 * time.Second,
+		},
 		Database: storage.Config{
 			SecretKey: dbSecretKey,
 		},

--- a/cmd/broker/update.go
+++ b/cmd/broker/update.go
@@ -41,7 +41,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManage
 		},
 		{
 			stage:     "check_runtime_resource",
-			step:      steps.NewCheckRuntimeResourceStep(db.Operations(), kcpClient, internal.RetryTuple{Timeout: cfg.Provisioner.RuntimeResourceStepTimeout, Interval: resourceStateRetryInterval}),
+			step:      steps.NewCheckRuntimeResourceStep(db.Operations(), kcpClient, internal.RetryTuple{Timeout: cfg.StepTimeouts.checkRuntimeResourceUpdate, Interval: resourceStateRetryInterval}),
 			condition: update.SkipForOwnClusterPlan,
 		},
 	}

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -136,6 +136,10 @@ spec:
               value: "{{ .Values.gardener.defaultShootPurpose }}"
             - name: APP_PROVISIONER_DEFAULT_TRIAL_PROVIDER
               value: "{{ .Values.gardener.defaultTrialProvider }}"
+            - name: APP_STEP_TIMEOUTS_CHECK_RUNTIME_RESOURCE_CREATE
+              value: "{{ .Values.stepTimeouts.checkRuntimeResourceCreate }}"
+            - name: APP_STEP_TIMEOUTS_CHECK_RUNTIME_RESOURCE_UPDATE
+              value: "{{ .Values.stepTimeouts.checkRuntimeResourceUpdate }}"
             - name: APP_PORT
               value: "{{ .Values.broker.port }}"
             - name: APP_STATUS_PORT

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -220,6 +220,10 @@ provisioner:
   useMainOIDC: "true"
   useAdditionalOIDC: "false"
 
+stepTimeouts:
+  checkRuntimeResourceUpdate: 180m
+  checkRuntimeResourceCreate: 60m
+
 trialRegionsMapping: |-
   cf-eu10: europe
   cf-us10: us


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- `checkRuntimeResourceStep` is executed during provisioning and update operations waiting for RuntimeResource to change state. We introduce two separate settings for each of these operations.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
