### PR TITLE
Increase operation timeout in SKR-tester

### DIFF
--- a/testing/e2e/skr-tester/pkg/command/check_operation.go
+++ b/testing/e2e/skr-tester/pkg/command/check_operation.go
@@ -35,7 +35,7 @@ func NewCheckOperationCommand() *cobra.Command {
 
 	cobraCmd.Flags().StringVarP(&cmd.instanceID, "instanceID", "i", "", "Instance ID of the specific instance.")
 	cobraCmd.Flags().StringVarP(&cmd.operationID, "operationID", "o", "", "OperationID of the specific operation.")
-	cobraCmd.Flags().DurationVarP(&cmd.timeout, "timeout", "t", 40*time.Minute, "Timeout for the operation to finish.")
+	cobraCmd.Flags().DurationVarP(&cmd.timeout, "timeout", "t", 25*time.Hour, "Timeout for the operation to finish.")
 	cobraCmd.Flags().DurationVarP(&cmd.interval, "interval", "n", 1*time.Minute, "Interval between operation checks.")
 
 	return cobraCmd


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- increase `check_operation` timeout in SKR-tester to allow operations to fail on KEB timeout, not on test timeout.

**Related issue(s)**
See also #1820
