### PR TITLE
Increase SKR access timeout

### DIFF
--- a/testing/e2e/skr-tester/pkg/command/assert.go
+++ b/testing/e2e/skr-tester/pkg/command/assert.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	SKRAccessInterval = 10 * time.Second
-	SKRAccessTimeout  = 30 * time.Second
+	SKRAccessTimeout  = 2 * time.Minute
 )
 
 type AssertCommand struct {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- due to a recurring access error with SKR, extend the timeout duration to two minutes.

**Related issue(s)**
See also #1820
