### PR TITLE
KCP CLI display licenseType and commercialModel

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -63,6 +63,8 @@ type RuntimeDTO struct {
 	BetaEnabled                 string                         `json:"betaEnabled,omitempty"`
 	UsedForProduction           string                         `json:"usedForProduction,omitempty"`
 	SubscriptionSecretName      *string                        `json:"subscriptionSecretName,omitempty"`
+	LicenseType                 *string                        `json:"licenseType,omitempty"`
+	CommercialModel             *string                        `json:"commercialModel,omitempty"`
 }
 
 type CloudProvider string

--- a/internal/runtime/converter.go
+++ b/internal/runtime/converter.go
@@ -97,7 +97,9 @@ func (c *converter) NewDTO(instance internal.Instance) (pkg.RuntimeDTO, error) {
 			ModifiedAt: instance.UpdatedAt,
 			ExpiredAt:  instance.ExpiredAt,
 		},
-		Parameters: instance.Parameters.Parameters,
+		Parameters:      instance.Parameters.Parameters,
+		LicenseType:     instance.Parameters.ErsContext.LicenseType,
+		CommercialModel: instance.Parameters.ErsContext.CommercialModel,
 	}
 
 	toReturn.SubscriptionSecretName = instance.Parameters.Parameters.TargetSecret


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- extend runtimes endpoint output with `licenseType` and `commercialModel`.

**Related issue(s)**
See also #1900
