### PR TITLE
Check KEB pod status in chart install tests

### DIFF
--- a/.github/workflows/run-keb-chart-install-tests-reusable.yaml
+++ b/.github/workflows/run-keb-chart-install-tests-reusable.yaml
@@ -122,4 +122,5 @@ jobs:
           else
             helm install keb ../keb --namespace kcp-system -f values.yaml --set global.database.embedded.enabled=false --set testConfig.kebDeployment.useAnnotations=true --set global.images.container_registry.path="europe-docker.pkg.dev/kyma-project/dev" --set global.secrets.mechanism=secrets --debug --wait
           fi
-          kubectl get pods -n kcp-system
+          echo "Waiting for kyma-environment-broker pod to be in READY state..."
+          kubectl wait --namespace kcp-system --for=condition=Ready pod -l app.kubernetes.io/name=kyma-environment-broker --timeout=180s

--- a/.github/workflows/run-keb-chart-install-tests-reusable.yaml
+++ b/.github/workflows/run-keb-chart-install-tests-reusable.yaml
@@ -122,3 +122,4 @@ jobs:
           else
             helm install keb ../keb --namespace kcp-system -f values.yaml --set global.database.embedded.enabled=false --set testConfig.kebDeployment.useAnnotations=true --set global.images.container_registry.path="europe-docker.pkg.dev/kyma-project/dev" --set global.secrets.mechanism=secrets --debug --wait
           fi
+          kubectl get pods -n kcp-system

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -489,7 +489,5 @@ serviceBindingCleanup:
   requestRetries: 2
 
 regionsSupportingMachine: |-
-  c2d-highcpu:
-    - europe-west3
-    - asia-south1
-    - us-central1
+  key: value
+  key: duplicate

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -489,5 +489,7 @@ serviceBindingCleanup:
   requestRetries: 2
 
 regionsSupportingMachine: |-
-  key: value
-  key: duplicate
+  c2d-highcpu:
+    - europe-west3
+    - asia-south1
+    - us-central1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add a check at the end of the chart install tests to ensure the `kyma-environment-broker` pod is in a READY state.

**Related issue(s)**
See also #1882
