### PR TITLE
Display runtime-config in SKR-tester

### DIFF
--- a/testing/e2e/skr-tester/pkg/command/check_operation.go
+++ b/testing/e2e/skr-tester/pkg/command/check_operation.go
@@ -50,22 +50,19 @@ func (cmd *CheckOperationCommand) Run() error {
 	}
 	var state string
 	defer func() {
+		fmt.Println("Operation status:")
 		status, err := kcpClient.GetStatus(cmd.instanceID)
 		if err != nil {
 			fmt.Printf("failed to get status: %v\n", err)
 			return
 		}
-		fmt.Println("Operation status:")
 		fmt.Println(status)
-		if state != "failed" {
-			return
-		}
+		fmt.Println("\nRuntime config:")
 		runtimeConfig, err := kcpClient.GetRuntimeConfig(cmd.instanceID)
 		if err != nil {
 			fmt.Printf("failed to get runtime config: %v\n", err)
 			return
 		}
-		fmt.Println("\nRuntime config:")
 		fmt.Println(runtimeConfig)
 	}()
 	err = wait(func() (bool, error) {

--- a/testing/e2e/skr-tester/pkg/command/check_operation.go
+++ b/testing/e2e/skr-tester/pkg/command/check_operation.go
@@ -57,7 +57,7 @@ func (cmd *CheckOperationCommand) Run() error {
 			return
 		}
 		fmt.Println(status)
-		fmt.Println("\nRuntime config:")
+		fmt.Println("Runtime config:")
 		runtimeConfig, err := kcpClient.GetRuntimeConfig(cmd.instanceID)
 		if err != nil {
 			fmt.Printf("failed to get runtime config: %v\n", err)

--- a/testing/e2e/skr-tester/pkg/command/check_operation.go
+++ b/testing/e2e/skr-tester/pkg/command/check_operation.go
@@ -57,7 +57,7 @@ func (cmd *CheckOperationCommand) Run() error {
 			return
 		}
 		fmt.Println(status)
-		fmt.Println("Runtime config:")
+		fmt.Println("\nRuntime config:")
 		runtimeConfig, err := kcpClient.GetRuntimeConfig(cmd.instanceID)
 		if err != nil {
 			fmt.Printf("failed to get runtime config: %v\n", err)

--- a/testing/e2e/skr-tester/pkg/kcp/client.go
+++ b/testing/e2e/skr-tester/pkg/kcp/client.go
@@ -259,6 +259,9 @@ func (c *KCPClient) GetRuntimeConfig(instanceID string) (string, error) {
 	if len(result.Data) == 0 {
 		return "", newKCPClientError("no runtime config found in the kcp cli output")
 	}
+	if result.Data[0].RuntimeConfig == nil {
+		return "", newKCPClientError("runtimeCR does not exist")
+	}
 	formatted, err := json.MarshalIndent(result.Data[0].RuntimeConfig, "", "  ")
 	if err != nil {
 		return "", newKCPClientError("failed to format runtime config: %w", err)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- display `runtime-config` during `check_operation` command in SKR-tester.

