### PR TITLE
Allow AutoscalerMin zero value for non-HA Additional Worker Node Pools

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -103,6 +103,8 @@ type ProvisioningParametersDTO struct {
 	IngressFiltering          *bool                      `json:"ingressFiltering,omitempty"`
 }
 
+const minAutoScalerMinValueForHA = 3
+
 type AutoScalerParameters struct {
 	AutoScalerMin  *int `json:"autoScalerMin,omitempty"`
 	AutoScalerMax  *int `json:"autoScalerMax,omitempty"`
@@ -519,8 +521,8 @@ func (a AdditionalWorkerNodePool) Validate() error {
 	if a.AutoScalerMin > a.AutoScalerMax {
 		return fmt.Errorf("AutoScalerMax %v should be larger than AutoScalerMin %v for %s additional worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
 	}
-	if a.HAZones && a.AutoScalerMin < 3 {
-		return fmt.Errorf("AutoScalerMin %v should be at least 3 when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, a.Name)
+	if a.HAZones && a.AutoScalerMin < minAutoScalerMinValueForHA {
+		return fmt.Errorf("AutoScalerMin %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, minAutoScalerMinValueForHA, a.Name)
 	}
 	return nil
 }

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -524,6 +524,9 @@ func (a AdditionalWorkerNodePool) Validate() error {
 	if a.HAZones && a.AutoScalerMin < minAutoScalerMinValueForHA {
 		return fmt.Errorf("AutoScalerMin %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, minAutoScalerMinValueForHA, a.Name)
 	}
+	if a.AutoScalerMin < 0 {
+		return fmt.Errorf("AutoScalerMin value cannot be lower than 0 for %s additional worker node pool", a.Name)
+	}
 	return nil
 }
 

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -103,7 +103,7 @@ type ProvisioningParametersDTO struct {
 	IngressFiltering          *bool                      `json:"ingressFiltering,omitempty"`
 }
 
-const minAutoScalerMinValueForHA = 3
+const HAAutoscalerMinimumValue = 3
 
 type AutoScalerParameters struct {
 	AutoScalerMin  *int `json:"autoScalerMin,omitempty"`
@@ -521,8 +521,8 @@ func (a AdditionalWorkerNodePool) Validate() error {
 	if a.AutoScalerMin > a.AutoScalerMax {
 		return fmt.Errorf("AutoScalerMax %v should be larger than AutoScalerMin %v for %s additional worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
 	}
-	if a.HAZones && a.AutoScalerMin < minAutoScalerMinValueForHA {
-		return fmt.Errorf("AutoScalerMin %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, minAutoScalerMinValueForHA, a.Name)
+	if a.HAZones && a.AutoScalerMin < HAAutoscalerMinimumValue {
+		return fmt.Errorf("AutoScalerMin %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, HAAutoscalerMinimumValue, a.Name)
 	}
 	if a.AutoScalerMin < 0 {
 		return fmt.Errorf("AutoScalerMin value cannot be lower than 0 for %s additional worker node pool", a.Name)

--- a/docs/user/04-40-additional-worker-node-pools.md
+++ b/docs/user/04-40-additional-worker-node-pools.md
@@ -52,7 +52,7 @@ The **haZones** property specifies whether high availability zones are supported
 With high availability enabled, resources are distributed across three zones to enhance fault tolerance.
 In this scenario, you must set **autoScalerMin** to at least `3`.
 
-If high availability is disabled, all resources are placed in a single, randomly selected zone. In this case, you can set both **autoScalerMin** and **autoScalerMax** to `1`, which helps reduce costs. 
+If high availability is disabled, all resources are placed in a single, randomly selected zone. In this case, you can set **autoScalerMin** to 0 and **autoScalerMax** to `1`, which helps reduce costs. 
 However, it is not recommended for production environments. 
 
 See the following JSON example without the `additionalWorkerNodePools` list:
@@ -107,7 +107,7 @@ The update operation overwrites the additional worker node pools with the list p
       "name": "worker-2",
       "machineType": "Standard_D4s_v5",
       "haZones": false,
-      "autoScalerMin": 1,
+      "autoScalerMin": 0,
       "autoScalerMax": 1
     }
   ]

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -1742,6 +1742,14 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 			additionalWorkerNodePools: `[{"name": "cpu-worker-0", "machineType": "m6i.large", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
 			expectedError:             true,
 		},
+		"Min values of AutoScalerMin and AutoScalerMax when HA zones are disabled": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "haZones": false, "autoScalerMin": 0, "autoScalerMax": 1}]`,
+			expectedError:             false,
+		},
+		"AutoScalerMin set to zero when HA zones are enabled": {
+			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m6i.large", "haZones": true, "autoScalerMin": 0, "autoScalerMax": 3}]`,
+			expectedError:             true,
+		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			// given

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -550,15 +550,19 @@ func AzureLiteSchema(machineTypesDisplay, regionsDisplay map[string]string, defa
 	properties := NewProvisioningProperties(machineTypesDisplay, machineTypesDisplay, regionsDisplay, machineTypes, machineTypes, AzureRegions(euAccessRestricted), update, flags.disabledMachineTypeUpdate)
 
 	properties.AutoScalerMax.Minimum = 2
+	properties.AutoScalerMin.Maximum = 40
 	properties.AutoScalerMin.Minimum = 2
 	properties.AutoScalerMax.Maximum = 40
 
 	properties.AdditionalWorkerNodePools.Items.Properties.HAZones = nil
 	properties.AdditionalWorkerNodePools.Items.ControlsOrder = removeString(properties.AdditionalWorkerNodePools.Items.ControlsOrder, "haZones")
 	properties.AdditionalWorkerNodePools.Items.Required = removeString(properties.AdditionalWorkerNodePools.Items.Required, "haZones")
+	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Minimum = 0
+	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Maximum = 40
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Default = 2
-	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Default = 10
+	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Minimum = 1
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Maximum = 40
+	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Default = 10
 
 	if !update {
 		properties.AutoScalerMax.Default = 10

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -557,6 +557,7 @@ func AzureLiteSchema(machineTypesDisplay, regionsDisplay map[string]string, defa
 	properties.AdditionalWorkerNodePools.Items.ControlsOrder = removeString(properties.AdditionalWorkerNodePools.Items.ControlsOrder, "haZones")
 	properties.AdditionalWorkerNodePools.Items.Required = removeString(properties.AdditionalWorkerNodePools.Items.Required, "haZones")
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Default = 2
+	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Minimum = 0
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Default = 10
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Maximum = 40
 

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -557,7 +557,6 @@ func AzureLiteSchema(machineTypesDisplay, regionsDisplay map[string]string, defa
 	properties.AdditionalWorkerNodePools.Items.ControlsOrder = removeString(properties.AdditionalWorkerNodePools.Items.ControlsOrder, "haZones")
 	properties.AdditionalWorkerNodePools.Items.Required = removeString(properties.AdditionalWorkerNodePools.Items.Required, "haZones")
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Default = 2
-	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMin.Minimum = 0
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Default = 10
 	properties.AdditionalWorkerNodePools.Items.Properties.AutoScalerMax.Maximum = 40
 

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -621,11 +621,11 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					Type:        "boolean",
 					Title:       "HA zones",
 					Default:     true,
-					Description: "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+					Description: "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
 				},
 				AutoScalerMin: Type{
 					Type:        "integer",
-					Minimum:     1,
+					Minimum:     0,
 					Default:     3,
 					Description: "Specifies the minimum number of virtual machines to create.",
 				},

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -9,6 +9,14 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/networking"
 )
 
+const (
+	haAutoscalerMin      = 3
+	nonHAAutoscalerMin   = 0
+	nonHAAutoscalerMax   = 1
+	autoscalerMax        = 300
+	defaultAutoscalerMax = 20
+)
+
 type RootSchema struct {
 	Schema string `json:"$schema"`
 	Type
@@ -36,9 +44,9 @@ type ProvisioningProperties struct {
 }
 
 type UpdateProperties struct {
-	Kubeconfig    *Type `json:"kubeconfig,omitempty"`
-	AutoScalerMin *Type `json:"autoScalerMin,omitempty"`
-	AutoScalerMax *Type `json:"autoScalerMax,omitempty"`
+	Kubeconfig    *Type           `json:"kubeconfig,omitempty"`
+	AutoScalerMin *AutoscalerType `json:"autoScalerMin,omitempty"`
+	AutoScalerMax *AutoscalerType `json:"autoScalerMax,omitempty"`
 	// Change the type to *OIDCs after we are fully migrated to additionalOIDC
 	OIDC                      interface{}                    `json:"oidc,omitempty"`
 	Administrators            *Type                          `json:"administrators,omitempty"`
@@ -112,6 +120,14 @@ type Type struct {
 	AdditionalProperties interface{}       `json:"additionalProperties,omitempty"`
 }
 
+type AutoscalerType struct {
+	Type        string      `json:"type"`
+	Description string      `json:"description"`
+	Minimum     int         `json:"minimum"`
+	Maximum     int         `json:"maximum"`
+	Default     interface{} `json:"default"`
+}
+
 type NameType struct {
 	Type
 	BTPdefaultTemplate BTPdefaultTemplate `json:"_BTPdefaultTemplate,omitempty"`
@@ -176,11 +192,11 @@ type AdditionalWorkerNodePoolsItems struct {
 }
 
 type AdditionalWorkerNodePoolsItemsProperties struct {
-	Name          Type  `json:"name,omitempty"`
-	MachineType   Type  `json:"machineType,omitempty"`
-	HAZones       *Type `json:"haZones,omitempty"`
-	AutoScalerMin Type  `json:"autoScalerMin,omitempty"`
-	AutoScalerMax Type  `json:"autoScalerMax,omitempty"`
+	Name          Type           `json:"name,omitempty"`
+	MachineType   Type           `json:"machineType,omitempty"`
+	HAZones       *Type          `json:"haZones,omitempty"`
+	AutoScalerMin AutoscalerType `json:"autoScalerMin,omitempty"`
+	AutoScalerMax AutoscalerType `json:"autoScalerMax,omitempty"`
 }
 
 type OIDCs struct {
@@ -487,17 +503,18 @@ func NewProvisioningProperties(machineTypesDisplay, additionalMachineTypesDispla
 
 	properties := ProvisioningProperties{
 		UpdateProperties: UpdateProperties{
-			AutoScalerMin: &Type{
+			AutoScalerMin: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     3,
-				Default:     3,
+				Minimum:     haAutoscalerMin,
+				Maximum:     autoscalerMax,
+				Default:     haAutoscalerMin,
 				Description: "Specifies the minimum number of virtual machines to create",
 			},
-			AutoScalerMax: &Type{
+			AutoScalerMax: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     3,
-				Maximum:     300,
-				Default:     20,
+				Minimum:     haAutoscalerMin,
+				Maximum:     autoscalerMax,
+				Default:     defaultAutoscalerMax,
 				Description: "Specifies the maximum number of virtual machines to create",
 			},
 			MachineType: &Type{
@@ -623,16 +640,18 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					Default:     true,
 					Description: "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
 				},
-				AutoScalerMin: Type{
+				AutoScalerMin: AutoscalerType{
 					Type:        "integer",
-					Default:     3,
+					Minimum:     nonHAAutoscalerMin,
+					Maximum:     autoscalerMax,
+					Default:     haAutoscalerMin,
 					Description: "Specifies the minimum number of virtual machines to create.",
 				},
-				AutoScalerMax: Type{
+				AutoScalerMax: AutoscalerType{
 					Type:        "integer",
-					Minimum:     1,
-					Maximum:     300,
-					Default:     20,
+					Minimum:     nonHAAutoscalerMax,
+					Maximum:     autoscalerMax,
+					Default:     defaultAutoscalerMax,
 					Description: "Specifies the maximum number of virtual machines to create.",
 				},
 			},

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	haAutoscalerMinimumValue       = 3
 	nonHAAutoscalerMinMinimumValue = 0
 	nonHAAutoscalerMaxMinimumValue = 1
 	autoscalerMaximumValue         = 300
@@ -505,14 +504,14 @@ func NewProvisioningProperties(machineTypesDisplay, additionalMachineTypesDispla
 		UpdateProperties: UpdateProperties{
 			AutoScalerMin: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     haAutoscalerMinimumValue,
+				Minimum:     pkg.HAAutoscalerMinimumValue,
 				Maximum:     autoscalerMaximumValue,
-				Default:     haAutoscalerMinimumValue,
+				Default:     pkg.HAAutoscalerMinimumValue,
 				Description: "Specifies the minimum number of virtual machines to create",
 			},
 			AutoScalerMax: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     haAutoscalerMinimumValue,
+				Minimum:     pkg.HAAutoscalerMinimumValue,
 				Maximum:     autoscalerMaximumValue,
 				Default:     autoscalerMaxDefaultValue,
 				Description: "Specifies the maximum number of virtual machines to create",
@@ -644,7 +643,7 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					Type:        "integer",
 					Minimum:     nonHAAutoscalerMinMinimumValue,
 					Maximum:     autoscalerMaximumValue,
-					Default:     haAutoscalerMinimumValue,
+					Default:     pkg.HAAutoscalerMinimumValue,
 					Description: "Specifies the minimum number of virtual machines to create.",
 				},
 				AutoScalerMax: AutoscalerType{

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -125,7 +125,7 @@ type AutoscalerType struct {
 	Description string      `json:"description"`
 	Minimum     int         `json:"minimum"`
 	Maximum     int         `json:"maximum"`
-	Default     interface{} `json:"default"`
+	Default     interface{} `json:"default,omitempty"`
 }
 
 type NameType struct {

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -625,7 +625,6 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 				},
 				AutoScalerMin: Type{
 					Type:        "integer",
-					Minimum:     0,
 					Default:     3,
 					Description: "Specifies the minimum number of virtual machines to create.",
 				},

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	haAutoscalerMin      = 3
-	nonHAAutoscalerMin   = 0
-	nonHAAutoscalerMax   = 1
-	autoscalerMax        = 300
-	defaultAutoscalerMax = 20
+	haAutoscalerMinimumValue       = 3
+	nonHAAutoscalerMinMinimumValue = 0
+	nonHAAutoscalerMaxMinimumValue = 1
+	autoscalerMaximumValue         = 300
+	autoscalerMaxDefaultValue      = 20
 )
 
 type RootSchema struct {
@@ -505,16 +505,16 @@ func NewProvisioningProperties(machineTypesDisplay, additionalMachineTypesDispla
 		UpdateProperties: UpdateProperties{
 			AutoScalerMin: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     haAutoscalerMin,
-				Maximum:     autoscalerMax,
-				Default:     haAutoscalerMin,
+				Minimum:     haAutoscalerMinimumValue,
+				Maximum:     autoscalerMaximumValue,
+				Default:     haAutoscalerMinimumValue,
 				Description: "Specifies the minimum number of virtual machines to create",
 			},
 			AutoScalerMax: &AutoscalerType{
 				Type:        "integer",
-				Minimum:     haAutoscalerMin,
-				Maximum:     autoscalerMax,
-				Default:     defaultAutoscalerMax,
+				Minimum:     haAutoscalerMinimumValue,
+				Maximum:     autoscalerMaximumValue,
+				Default:     autoscalerMaxDefaultValue,
 				Description: "Specifies the maximum number of virtual machines to create",
 			},
 			MachineType: &Type{
@@ -642,16 +642,16 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 				},
 				AutoScalerMin: AutoscalerType{
 					Type:        "integer",
-					Minimum:     nonHAAutoscalerMin,
-					Maximum:     autoscalerMax,
-					Default:     haAutoscalerMin,
+					Minimum:     nonHAAutoscalerMinMinimumValue,
+					Maximum:     autoscalerMaximumValue,
+					Default:     haAutoscalerMinimumValue,
 					Description: "Specifies the minimum number of virtual machines to create.",
 				},
 				AutoScalerMax: AutoscalerType{
 					Type:        "integer",
-					Minimum:     nonHAAutoscalerMax,
-					Maximum:     autoscalerMax,
-					Default:     defaultAutoscalerMax,
+					Minimum:     nonHAAutoscalerMaxMinimumValue,
+					Maximum:     autoscalerMaximumValue,
+					Default:     autoscalerMaxDefaultValue,
 					Description: "Specifies the maximum number of virtual machines to create.",
 				},
 			},

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -92,7 +92,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -92,7 +92,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -92,6 +92,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -122,6 +124,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-eu.json
@@ -84,7 +84,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -93,6 +93,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -123,6 +125,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -85,7 +85,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -93,7 +93,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -93,7 +93,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -93,6 +93,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -123,6 +125,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -85,7 +85,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -93,7 +93,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -93,7 +93,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -84,7 +84,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true
@@ -123,7 +123,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
-      "minimum": 0,
+      "minimum": 3,
       "type": "integer"
     },
     "machineType": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -92,7 +92,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {
@@ -123,7 +123,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
-      "minimum": 3,
+      "minimum": 0,
       "type": "integer"
     },
     "machineType": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -92,7 +92,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params.json
@@ -92,6 +92,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -122,6 +124,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -89,7 +89,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -81,7 +81,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -89,6 +89,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -111,6 +113,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-eu.json
@@ -89,7 +89,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -89,7 +89,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -81,7 +81,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -89,6 +89,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -111,6 +113,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/aws-schema.json
+++ b/internal/broker/testdata/aws/aws-schema.json
@@ -89,7 +89,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -80,7 +80,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -88,7 +88,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -88,6 +88,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -116,6 +118,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -88,7 +88,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -87,7 +87,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -87,7 +87,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -79,7 +79,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params.json
@@ -87,6 +87,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -115,6 +117,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -85,7 +85,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -85,6 +85,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -105,6 +107,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -85,7 +85,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/aws/update-aws-schema.json
+++ b/internal/broker/testdata/aws/update-aws-schema.json
@@ -77,7 +77,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced-ingress.json
@@ -48,6 +48,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -78,6 +80,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced-ingress.json
@@ -48,7 +48,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -47,6 +47,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -77,6 +79,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -47,7 +47,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu-reduced.json
@@ -47,7 +47,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -50,6 +50,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -80,6 +82,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -50,7 +50,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-eu.json
@@ -50,7 +50,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
@@ -51,7 +51,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
@@ -51,6 +51,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -81,6 +83,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
@@ -51,7 +51,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
@@ -51,6 +51,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -81,6 +83,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced-ingress.json
@@ -48,6 +48,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -78,6 +80,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced-ingress.json
@@ -48,7 +48,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -47,6 +47,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -77,6 +79,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -47,7 +47,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-reduced.json
@@ -47,7 +47,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -50,6 +50,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -80,6 +82,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -50,7 +50,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params.json
@@ -50,7 +50,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -45,7 +45,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -45,6 +45,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -67,6 +69,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu-reduced.json
@@ -45,7 +45,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -47,6 +47,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -69,6 +71,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -47,7 +47,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-eu.json
@@ -47,7 +47,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -45,7 +45,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-reduced.json
@@ -45,6 +45,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -67,6 +69,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -47,6 +47,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -69,6 +71,7 @@
     "autoScalerMin": {
       "default": 2,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-lite-schema.json
+++ b/internal/broker/testdata/azure/azure-lite-schema.json
@@ -47,7 +47,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -98,6 +98,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -128,6 +130,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -90,7 +90,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-eu.json
@@ -98,7 +98,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -91,7 +91,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -99,6 +99,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -129,6 +131,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -99,7 +99,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -91,7 +91,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -99,6 +99,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -129,6 +131,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -99,7 +99,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -98,6 +98,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -128,6 +130,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -90,7 +90,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params.json
@@ -98,7 +98,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -95,6 +95,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -117,6 +119,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -87,7 +87,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/azure-schema-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-eu.json
@@ -95,7 +95,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -95,6 +95,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -117,6 +119,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -87,7 +87,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true
@@ -95,7 +95,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/azure-schema.json
+++ b/internal/broker/testdata/azure/azure-schema.json
@@ -95,7 +95,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -46,7 +46,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -46,7 +46,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -46,6 +46,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -74,6 +76,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced-ingress.json
@@ -44,6 +44,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -72,6 +74,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced-ingress.json
@@ -44,7 +44,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -43,6 +43,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -71,6 +73,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-reduced.json
@@ -43,7 +43,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -45,6 +45,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -73,6 +75,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -45,7 +45,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params.json
@@ -45,7 +45,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -41,7 +41,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-reduced.json
@@ -41,6 +41,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -61,6 +63,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -43,6 +43,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 40,
             "default": 2
           },
           "autoScalerMax": {
@@ -63,6 +65,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 40,
       "minimum": 2,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -43,7 +43,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-lite-schema.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema.json
@@ -43,7 +43,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 2
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -94,6 +94,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -122,6 +124,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -86,7 +86,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -94,7 +94,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -85,7 +85,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -93,6 +93,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -121,6 +123,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -93,7 +93,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params.json
@@ -93,7 +93,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -91,7 +91,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -83,7 +83,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -91,7 +91,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/azure/update-azure-schema.json
+++ b/internal/broker/testdata/azure/update-azure-schema.json
@@ -91,6 +91,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -111,6 +113,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
@@ -91,7 +91,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
@@ -83,7 +83,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
@@ -91,6 +91,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -121,6 +123,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads-ingress.json
@@ -91,7 +91,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -90,6 +90,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -120,6 +122,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -82,7 +82,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -90,7 +90,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-assured-workloads.json
@@ -90,7 +90,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -91,7 +91,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -83,7 +83,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -91,6 +91,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -121,6 +123,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -91,7 +91,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -90,6 +90,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -120,6 +122,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -82,7 +82,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -90,7 +90,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params.json
@@ -90,7 +90,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -87,7 +87,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -87,7 +87,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -87,6 +87,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -109,6 +111,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
+++ b/internal/broker/testdata/gcp/gcp-schema-assured-workloads.json
@@ -79,7 +79,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -87,7 +87,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -87,7 +87,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -87,6 +87,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -109,6 +111,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/gcp-schema.json
+++ b/internal/broker/testdata/gcp/gcp-schema.json
@@ -79,7 +79,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -86,6 +86,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -114,6 +116,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -78,7 +78,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -86,7 +86,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -86,7 +86,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -85,7 +85,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -85,7 +85,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -77,7 +77,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params.json
@@ -85,6 +85,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -113,6 +115,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -83,7 +83,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -83,6 +83,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -103,6 +105,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -83,7 +83,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/gcp/update-gcp-schema.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema.json
@@ -75,7 +75,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -59,7 +59,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -67,7 +67,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -67,6 +67,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -97,6 +99,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -58,7 +58,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -66,7 +66,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -66,6 +66,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -96,6 +98,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params.json
@@ -66,7 +66,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -63,6 +63,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -85,6 +87,7 @@
     "autoScalerMin": {
       "default": 3,
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -63,7 +63,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -63,7 +63,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema.json
@@ -55,7 +55,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -62,7 +62,7 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -54,7 +54,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -62,6 +62,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -90,6 +92,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -62,7 +62,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 0,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -61,7 +61,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -61,6 +61,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -89,6 +91,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params.json
@@ -53,7 +53,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -51,7 +51,7 @@
             }
           },
           "haZones": {
-            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting both autoScalerMin and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
+            "description": "Specifies whether high availability (HA) zones are supported. This setting is permanent and cannot be changed later. If HA is disabled, all resources are placed in a single, randomly selected zone. Disabled HA allows setting autoScalerMin to 0 and autoScalerMax to 1, which helps reduce costs. It is not recommended for production environments. When enabled, resources are distributed across three zones to enhance fault tolerance. Enabled HA requires setting autoScalerMin to the minimal value 3.",
             "title": "HA zones",
             "type": "boolean",
             "default": true

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -59,6 +59,8 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
+            "minimum": 0,
+            "maximum": 300,
             "default": 3
           },
           "autoScalerMax": {
@@ -79,6 +81,7 @@
     },
     "autoScalerMin": {
       "description": "Specifies the minimum number of virtual machines to create",
+      "maximum": 300,
       "minimum": 3,
       "type": "integer"
     },

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema.json
@@ -59,7 +59,6 @@
           "autoScalerMin": {
             "description": "Specifies the minimum number of virtual machines to create.",
             "type": "integer",
-            "minimum": 1,
             "default": 3
           },
           "autoScalerMax": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Change the allowed AutoscalerMin value to be >= 0 for non-HA additional worker node pools.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
