### PR TITLE
Support multiple OIDCs for KEB

### DIFF
--- a/resources/keb/templates/authorization-policy.yaml
+++ b/resources/keb/templates/authorization-policy.yaml
@@ -60,7 +60,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[scp]
       values:
@@ -106,7 +113,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[scp]
       values:
@@ -133,7 +147,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[groups]
       values:
@@ -175,7 +196,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[groups]
       values:
@@ -217,7 +245,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[groups]
       values:
@@ -245,7 +280,14 @@ spec:
     from:
       - source:
           requestPrincipals:
+          {{- $oidcs := .Values.oidcs | default list }}
+          {{- if gt (len $oidcs) 0 }}
+          {{- range $i, $p := $oidcs }}
+          - {{ $p.issuer }}/*
+          {{- end }}
+          {{- else }}
           - {{ tpl .Values.oidc.issuer $ }}/*
+          {{- end }}
     when:
     - key: request.auth.claims[groups]
       values:

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -330,6 +330,12 @@ oidc:
     orchestrations: orchestrationsAdmin
     viewer: runtimeViewer
 
+oidcs:
+  - issuer: https://kymatest.accounts400.ondemand.com
+    keysURL: https://kymatest.accounts400.ondemand.com/oauth2/certs
+  - issuer: https://kymacanary.newIAS.ondemand.com
+    keysURL: https://kymacanary.newIAS.ondemand.com/oauth2/certs
+
 kebClient:
   scope: "broker:write cld:read"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Introduced a new system to populate Authorization-policy CRs with multiple oidc tenants, if they are defined in values.yaml.
- For stage we are going to support two tenants. Thats why we need this change. Here is the related issue: https://github.tools.sap/kyma/backlog/issues/3899
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
