### PR TITLE
Remove disable machine type update feature flag

### DIFF
--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -177,7 +177,6 @@ broker:
   subaccountMovementEnabled: "false"
   updateCustomResourcesLabelsOnAccountMove: "false"
   useAdditionalOIDCSchema: "false"
-  disableMachineTypeUpdate: "false"
   monitorAdditionalProperties: false
 
 events:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove `disableMachineTypeUpdate`, which was mistakenly introduced due to pull request merge conflicts and is no longer used.

**Related issue(s)**
See also #1924
