### PR TITLE
Fix additional worker node pool autoscaler validation messages

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -519,10 +519,10 @@ type AdditionalWorkerNodePool struct {
 
 func (a AdditionalWorkerNodePool) Validate() error {
 	if a.AutoScalerMin > a.AutoScalerMax {
-		return fmt.Errorf("AutoScalerMax %v should be larger than AutoScalerMin %v for %s additional worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
+		return fmt.Errorf("AutoScalerMax value %v should be larger than AutoScalerMin value %v for %s additional worker node pool", a.AutoScalerMax, a.AutoScalerMin, a.Name)
 	}
 	if a.HAZones && a.AutoScalerMin < HAAutoscalerMinimumValue {
-		return fmt.Errorf("AutoScalerMin %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, HAAutoscalerMinimumValue, a.Name)
+		return fmt.Errorf("AutoScalerMin value %v should be at least %v when HA zones are enabled for %s additional worker node pool", a.AutoScalerMin, HAAutoscalerMinimumValue, a.Name)
 	}
 	if a.AutoScalerMin < 0 {
 		return fmt.Errorf("AutoScalerMin value cannot be lower than 0 for %s additional worker node pool", a.Name)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

fix validation messages for additional worker node pool autoscaler.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #2019 