### PR TITLE
`ingressFiltering` - provisioning parameters updated during update operation

### DIFF
--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -1959,6 +1959,9 @@ func TestUpdateNetworkFilterForInternal(t *testing.T) {
 	updateOp, _ := suite.db.Operations().GetOperationByID(updateOperationID)
 	assert.NotNil(suite.t, updateOp.ProvisioningParameters.ErsContext.LicenseType)
 	suite.AssertNetworkFiltering(instance.InstanceID, true, true)
+	// check if updated parameters is populated to provisioning parameters - so it will be reflected in get instance response
+	instanceUpdated := suite.GetInstance(id)
+	assert.True(suite.t, *instanceUpdated.Parameters.Parameters.IngressFiltering)
 }
 
 func TestUpdateNetworkFilterForExternal_WithIngressForExternal(t *testing.T) {

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -328,6 +328,12 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		updateStorage = append(updateStorage, "OIDC")
 	}
 
+	if b.infrastructureManagerConfig.EnableIngressFiltering {
+		instance.Parameters.Parameters.IngressFiltering = params.IngressFiltering
+		updateStorage = append(updateStorage, "Ingress Filtering")
+
+	}
+
 	if len(params.RuntimeAdministrators) != 0 {
 		newAdministrators := make([]string, 0, len(params.RuntimeAdministrators))
 		newAdministrators = append(newAdministrators, params.RuntimeAdministrators...)

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -328,10 +328,9 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 		updateStorage = append(updateStorage, "OIDC")
 	}
 
-	if b.infrastructureManagerConfig.EnableIngressFiltering {
+	if b.infrastructureManagerConfig.EnableIngressFiltering && params.IngressFiltering != nil {
 		instance.Parameters.Parameters.IngressFiltering = params.IngressFiltering
 		updateStorage = append(updateStorage, "Ingress Filtering")
-
 	}
 
 	if len(params.RuntimeAdministrators) != 0 {

--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -73,13 +73,14 @@ func FixProvisioningParameters(id string) internal.ProvisioningParameters {
 	trialCloudProvider := pkg.Azure
 
 	provisioningParametersDTO := pkg.ProvisioningParametersDTO{
-		Name:         "cluster-test",
-		VolumeSizeGb: ptr.Integer(50),
-		MachineType:  ptr.String("Standard_D8_v3"),
-		Region:       ptr.String(Region),
-		Purpose:      ptr.String("Purpose"),
-		LicenceType:  ptr.String("LicenceType"),
-		Zones:        []string{"1"},
+		Name:             "cluster-test",
+		VolumeSizeGb:     ptr.Integer(50),
+		MachineType:      ptr.String("Standard_D8_v3"),
+		Region:           ptr.String(Region),
+		Purpose:          ptr.String("Purpose"),
+		LicenceType:      ptr.String("LicenceType"),
+		Zones:            []string{"1"},
+		IngressFiltering: ptr.Bool(true),
 		AutoScalerParameters: pkg.AutoScalerParameters{
 			AutoScalerMin:  ptr.Integer(3),
 			AutoScalerMax:  ptr.Integer(10),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- when ingressFiltering is changed during update operation, we store update parameter in provisioning parameters, so this latest value is returned in get instance call

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
