### PR TITLE
Same region for Seed and Shoot validation

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -241,7 +241,7 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 	}
 	ts.poller = &broker.TimerPoller{PollInterval: 3 * time.Millisecond, PollTimeout: 800 * time.Millisecond, Log: ts.t.Log}
 
-	ts.CreateAPI(cfg, db, provisioningQueue, deprovisioningQueue, updateQueue, log, k8sClientProvider, eventBroker)
+	ts.CreateAPI(cfg, db, provisioningQueue, deprovisioningQueue, updateQueue, log, k8sClientProvider, eventBroker, configProvider)
 
 	expirationHandler := expiration.NewHandler(db.Instances(), db.Operations(), deprovisioningQueue, log)
 	expirationHandler.AttachRoutes(ts.router)
@@ -329,7 +329,9 @@ func (s *BrokerSuiteTest) CallAPI(method string, path string, body string) *http
 	return resp
 }
 
-func (s *BrokerSuiteTest) CreateAPI(cfg *Config, db storage.BrokerStorage, provisioningQueue *process.Queue, deprovisionQueue *process.Queue, updateQueue *process.Queue, log *slog.Logger, skrK8sClientProvider *kubeconfig.FakeProvider, eventBroker *event.PubSub) {
+func (s *BrokerSuiteTest) CreateAPI(cfg *Config, db storage.BrokerStorage, provisioningQueue *process.Queue,
+	deprovisionQueue *process.Queue, updateQueue *process.Queue, log *slog.Logger,
+	skrK8sClientProvider *kubeconfig.FakeProvider, eventBroker *event.PubSub, configProvider kebConfig.Provider) {
 	servicesConfig := map[string]broker.Service{
 		broker.KymaServiceName: {
 			Description: "",
@@ -379,7 +381,7 @@ func (s *BrokerSuiteTest) CreateAPI(cfg *Config, db storage.BrokerStorage, provi
 
 	createAPI(s.router, schemaService, servicesConfig, cfg, db, provisioningQueue, deprovisionQueue, updateQueue,
 		lager.NewLogger("api"), log, kcBuilder, skrK8sClientProvider, skrK8sClientProvider, fakeKcpK8sClient, eventBroker, defaultOIDCValues(),
-		regionssupportingmachine.RegionsSupportingMachine{})
+		regionssupportingmachine.RegionsSupportingMachine{}, configProvider)
 
 	s.httpServer = httptest.NewServer(s.router)
 }

--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -193,7 +193,7 @@ func TestProvisioning_SeedAndShootSameRegion(t *testing.T) {
 					},
 					"parameters": {
 						"name": "testing-cluster",
-						"region": "eu-central-1",
+						"region": "us-west-2",
 						"shootAndSeedSameRegion": false
 					}
 		}`)
@@ -223,7 +223,7 @@ func TestProvisioning_SeedAndShootSameRegion(t *testing.T) {
 					},
 					"parameters": {
 						"name": "testing-cluster",
-						"region": "us-east-1",
+						"region": "eu-central-1",
 						"shootAndSeedSameRegion": true
 					}
 		}`)
@@ -236,6 +236,30 @@ func TestProvisioning_SeedAndShootSameRegion(t *testing.T) {
 
 		runtime := suite.GetRuntimeResourceByInstanceID(iid)
 		assert.True(t, *runtime.Spec.Shoot.EnforceSeedLocation)
+	})
+
+	t.Run("should return error when seed does not exist in selected region and shootAndSeedSameRegion is set to true", func(t *testing.T) {
+		iid := uuid.New().String()
+
+		// when
+		resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", iid),
+			`{
+					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+					"plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15",
+					"context": {
+						"globalaccount_id": "g-account-id",
+						"subaccount_id": "sub-id",
+						"user_id": "john.smith@email.com"
+					},
+					"parameters": {
+						"name": "testing-cluster",
+						"region": "us-east-1",
+						"shootAndSeedSameRegion": true
+					}
+		}`)
+
+		parsedResponse := suite.ReadResponse(resp)
+		assert.Contains(t, string(parsedResponse), "validation of the same region for seed and shoot: seed does not exist in us-east-1 region")
 	})
 }
 

--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -193,11 +193,32 @@ kyma-template: |-
 		},
 	}
 
+	providerCfg := &coreV1.ConfigMap{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "gardener-seeds-cache",
+			Namespace: "kcp-system",
+		},
+		Data: map[string]string{
+			"aws": `
+seedRegions:
+- eu-central-1`,
+			"azure": `
+seedRegions:
+- westeurope`,
+			"gcp": `
+seedRegions:
+- europe-west1`,
+			"openstack": `
+seedRegions:
+- eu-de-1`,
+		},
+	}
+
 	for _, version := range additionalKymaVersions {
 		kebCfg.ObjectMeta.Labels[fmt.Sprintf("runtime-version-%s", version)] = "true"
 	}
 
-	resources = append(resources, override, scOverride, kebCfg)
+	resources = append(resources, override, scOverride, kebCfg, providerCfg)
 
 	return resources
 }
@@ -257,8 +278,9 @@ func fixConfig() *Config {
 				MaxBindingsCount:     10,
 				CreateBindingTimeout: 15 * time.Second,
 			},
-			WorkerHealthCheckInterval:     10 * time.Minute,
-			WorkerHealthCheckWarnInterval: 10 * time.Minute,
+			WorkerHealthCheckInterval:       10 * time.Minute,
+			WorkerHealthCheckWarnInterval:   10 * time.Minute,
+			GardenerSeedsCacheConfigMapName: "gardener-seeds-cache",
 		},
 		TrialRegionMappingFilePath:                "testdata/trial-regions.yaml",
 		MaxPaginationPage:                         100,

--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -20,6 +20,7 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_BROKER_ENABLE_&#x200b;SHOOT_AND_SEED_SAME_&#x200b;REGION** | <code>false</code> | If true, enforces that the Gardener seed is placed in the same region as the shoot region selected during provisioning |
 | **APP_BROKER_FREE_&#x200b;DOCS_URL** | <code>https://help.sap.com/docs/</code> | URL to the documentation of free Kyma runtimes. Used in API responses and UI labels to direct users to help or documentation about free plans |
 | **APP_BROKER_FREE_&#x200b;EXPIRATION_PERIOD** | <code>720h</code> | Determines when to show expiration info to users |
+| **APP_BROKER_GARDENER_SEEDS_CACHE_CONFIG_MAP_NAME** | None | - |
 | **APP_BROKER_INCLUDE_&#x200b;ADDITIONAL_PARAMS_&#x200b;IN_SCHEMA** | <code>false</code> | If true, additional (advanced or less common) parameters are included in the provisioning schema for service plans |
 | **APP_BROKER_MONITOR_&#x200b;ADDITIONAL_&#x200b;PROPERTIES** | <code>false</code> | If true, collects properties from the provisioning request that are not explicitly defined in the schema and stores them in persistent storage |
 | **APP_BROKER_ONLY_ONE_&#x200b;FREE_PER_GA** | <code>false</code> | If true, restricts each global account to only one free (freemium) Kyma runtime. When enabled, provisioning another free environment for the same global account is blocked even if the previous one is deprovisioned |

--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -20,7 +20,7 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_BROKER_ENABLE_&#x200b;SHOOT_AND_SEED_SAME_&#x200b;REGION** | <code>false</code> | If true, enforces that the Gardener seed is placed in the same region as the shoot region selected during provisioning |
 | **APP_BROKER_FREE_&#x200b;DOCS_URL** | <code>https://help.sap.com/docs/</code> | URL to the documentation of free Kyma runtimes. Used in API responses and UI labels to direct users to help or documentation about free plans |
 | **APP_BROKER_FREE_&#x200b;EXPIRATION_PERIOD** | <code>720h</code> | Determines when to show expiration info to users |
-| **APP_BROKER_GARDENER_SEEDS_CACHE_CONFIG_MAP_NAME** | None | - |
+| **APP_BROKER_GARDENER_&#x200b;SEEDS_CACHE_CONFIG_&#x200b;MAP_NAME** | None | - |
 | **APP_BROKER_INCLUDE_&#x200b;ADDITIONAL_PARAMS_&#x200b;IN_SCHEMA** | <code>false</code> | If true, additional (advanced or less common) parameters are included in the provisioning schema for service plans |
 | **APP_BROKER_MONITOR_&#x200b;ADDITIONAL_&#x200b;PROPERTIES** | <code>false</code> | If true, collects properties from the provisioning request that are not explicitly defined in the schema and stores them in persistent storage |
 | **APP_BROKER_ONLY_ONE_&#x200b;FREE_PER_GA** | <code>false</code> | If true, restricts each global account to only one free (freemium) Kyma runtime. When enabled, provisioning another free environment for the same global account is blocked even if the previous one is deprovisioned |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -64,8 +64,9 @@ type Config struct {
 
 	UseAdditionalOIDCSchema bool `envconfig:"default=false"`
 
-	MonitorAdditionalProperties bool   `envconfig:"default=false"`
-	AdditionalPropertiesPath    string `envconfig:"default=/additional-properties"`
+	MonitorAdditionalProperties     bool   `envconfig:"default=false"`
+	AdditionalPropertiesPath        string `envconfig:"default=/additional-properties"`
+	GardenerSeedsCacheConfigMapName string `envconfig:"default=gardener-seeds-cache"`
 }
 
 type ServicesConfig map[string]Service

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/additionalproperties"
+	"github.com/kyma-project/kyma-environment-broker/internal/config"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/validator"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -94,6 +95,7 @@ type ProvisionEndpoint struct {
 	valuesProvider         ValuesProvider
 	useSmallerMachineTypes bool
 	schemaService          *SchemaService
+	providerConfigProvider config.ConfigMapConfigProvider
 }
 
 const (
@@ -117,6 +119,7 @@ func NewProvision(brokerConfig Config,
 	regionsSupportingMachine RegionsSupporter,
 	valuesProvider ValuesProvider,
 	useSmallerMachineTypes bool,
+	providerConfigProvider config.ConfigMapConfigProvider,
 ) *ProvisionEndpoint {
 	enabledPlanIDs := map[string]struct{}{}
 	for _, planName := range brokerConfig.EnablePlans {
@@ -144,6 +147,7 @@ func NewProvision(brokerConfig Config,
 		valuesProvider:           valuesProvider,
 		useSmallerMachineTypes:   useSmallerMachineTypes,
 		schemaService:            schemaService,
+		providerConfigProvider:   providerConfigProvider,
 	}
 }
 

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -786,7 +786,7 @@ func (b *ProvisionEndpoint) validateSeedAndShootRegion(providerType, region stri
 		return fmt.Errorf("cannot load provider config: %w", err)
 	}
 	if !slices.Contains(providerConfig.SeedRegions, region) {
-		return fmt.Errorf("seed does not exist in %s region", region)
+		return fmt.Errorf("seed does not exist in %s region. Provider %s has seeds in the following regions: %s", region, providerType, providerConfig.SeedRegions)
 	}
 
 	return nil

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -14,36 +14,28 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/additionalproperties"
-	"github.com/kyma-project/kyma-environment-broker/internal/config"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/validator"
-	"github.com/santhosh-tekuri/jsonschema/v6"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/kubeconfig"
-	"github.com/kyma-project/kyma-environment-broker/internal/whitelist"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/networking"
-
-	"github.com/hashicorp/go-multierror"
-
-	"github.com/kyma-project/kyma-environment-broker/internal/euaccess"
-
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
 	"github.com/kyma-project/kyma-environment-broker/common/gardener"
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/additionalproperties"
+	"github.com/kyma-project/kyma-environment-broker/internal/config"
 	"github.com/kyma-project/kyma-environment-broker/internal/dashboard"
+	"github.com/kyma-project/kyma-environment-broker/internal/euaccess"
+	"github.com/kyma-project/kyma-environment-broker/internal/kubeconfig"
 	"github.com/kyma-project/kyma-environment-broker/internal/middleware"
+	"github.com/kyma-project/kyma-environment-broker/internal/networking"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
+	"github.com/kyma-project/kyma-environment-broker/internal/validator"
+	"github.com/kyma-project/kyma-environment-broker/internal/whitelist"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
 	"github.com/pivotal-cf/brokerapi/v12/domain/apiresponses"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 //go:generate mockery --name=Queue --output=automock --outpkg=automock --case=underscore

--- a/internal/broker/instance_create_input_params_test.go
+++ b/internal/broker/instance_create_input_params_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/common/gardener"
+	"github.com/kyma-project/kyma-environment-broker/internal/config"
 	"github.com/kyma-project/kyma-environment-broker/internal/dashboard"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
@@ -46,6 +47,7 @@ func TestShootAndSeedSameRegion(t *testing.T) {
 			nil,
 			nil,
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -78,6 +80,7 @@ func TestShootAndSeedSameRegion(t *testing.T) {
 			nil,
 			nil,
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -109,6 +112,7 @@ func TestShootAndSeedSameRegion(t *testing.T) {
 			nil,
 			nil,
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/additionalproperties"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker/automock"
+	"github.com/kyma-project/kyma-environment-broker/internal/config"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	kcMock "github.com/kyma-project/kyma-environment-broker/internal/kubeconfig/automock"
 	"github.com/kyma-project/kyma-environment-broker/internal/middleware"
@@ -90,6 +91,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -162,6 +164,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -238,6 +241,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -285,6 +289,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when shootDomain is missing
@@ -357,6 +362,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -431,6 +437,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -479,6 +486,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -528,6 +536,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -591,6 +600,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -654,6 +664,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -697,6 +708,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -735,6 +747,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -772,6 +785,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -816,6 +830,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -865,6 +880,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"issuerURL":"https://test.local"`
@@ -920,6 +936,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256","notValid"]`
@@ -974,6 +991,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"],"requiredClaims":["claim=value"]`
@@ -1031,6 +1049,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"],"groupsPrefix":"-", "usernameClaim":"-", "usernamePrefix":"-", "requiredClaims":["claim=value"], "groupsClaim":"-"`
@@ -1086,6 +1105,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		testCases := []struct {
@@ -1183,6 +1203,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		testCases := []struct {
@@ -1268,6 +1289,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -1311,6 +1333,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -1376,6 +1399,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -1431,6 +1455,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -1484,6 +1509,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -1527,6 +1553,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -1573,6 +1600,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -1622,6 +1650,7 @@ func TestProvision_Provision(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -1762,6 +1791,7 @@ func TestAdditionalWorkerNodePools(t *testing.T) {
 				regionssupportingmachine.RegionsSupportingMachine{},
 				fixValueProvider(t),
 				false,
+				config.FakeProviderConfigProvider{},
 			)
 
 			// when
@@ -1826,6 +1856,7 @@ func TestAdditionalWorkerNodePoolsForUnsupportedPlans(t *testing.T) {
 				regionssupportingmachine.RegionsSupportingMachine{},
 				fixValueProvider(t),
 				false,
+				config.FakeProviderConfigProvider{},
 			)
 
 			additionalWorkerNodePools := `[{"name": "name-1", "machineType": "m6i.large", "autoScalerMin": 3, "autoScalerMax": 20}]`
@@ -1977,6 +2008,7 @@ func TestNetworkingValidation(t *testing.T) {
 				regionssupportingmachine.RegionsSupportingMachine{},
 				fixValueProvider(t),
 				false,
+				config.FakeProviderConfigProvider{},
 			)
 
 			// when
@@ -2076,6 +2108,7 @@ func TestRegionValidation(t *testing.T) {
 				regionssupportingmachine.RegionsSupportingMachine{},
 				fixValueProvider(t),
 				false,
+				config.FakeProviderConfigProvider{},
 			)
 
 			// when
@@ -2136,6 +2169,7 @@ func TestSapConvergedCloudBlocking(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -2184,6 +2218,7 @@ func TestSapConvergedCloudBlocking(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -2231,6 +2266,7 @@ func TestSapConvergedCloudBlocking(t *testing.T) {
 			regionssupportingmachine.RegionsSupportingMachine{},
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
@@ -2292,6 +2328,7 @@ func TestUnsupportedMachineType(t *testing.T) {
 		fixRegionsSupportingMachine(),
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 
 	// when
@@ -2343,6 +2380,7 @@ func TestUnsupportedMachineTypeInAdditionalWorkerNodePools(t *testing.T) {
 		fixRegionsSupportingMachine(),
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 
 	testCases := []struct {
@@ -2420,6 +2458,7 @@ func TestGPUMachineForInternalUser(t *testing.T) {
 		fixRegionsSupportingMachine(),
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 
 	additionalWorkerNodePools := `[{"name": "name-1", "machineType": "g6.xlarge", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`
@@ -2470,6 +2509,7 @@ func TestGPUMachinesForExternalCustomer(t *testing.T) {
 		fixRegionsSupportingMachine(),
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 
 	testCases := []struct {
@@ -2602,6 +2642,7 @@ func TestAvailableZonesValidation(t *testing.T) {
 		fixRegionsSupportingMachine(),
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 
 	additionalWorkerNodePools := `[{"name": "name-1", "machineType": "g6.xlarge", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`
@@ -2661,6 +2702,7 @@ func TestAdditionalProperties(t *testing.T) {
 			fixRegionsSupportingMachine(),
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -2730,6 +2772,7 @@ func TestAdditionalProperties(t *testing.T) {
 			fixRegionsSupportingMachine(),
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -2813,6 +2856,7 @@ func TestAdditionalProperties(t *testing.T) {
 			fixRegionsSupportingMachine(),
 			fixValueProvider(t),
 			false,
+			config.FakeProviderConfigProvider{},
 		)
 
 		// when
@@ -2830,6 +2874,120 @@ func TestAdditionalProperties(t *testing.T) {
 		contents, err := os.ReadFile(expectedFile)
 		assert.Nil(t, contents)
 		assert.Error(t, err)
+	})
+}
+
+func TestSameRegionForSeedAndShoot(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	t.Run("should succeed if configuration contains region from provisioning parameters", func(t *testing.T) {
+		// given
+		const expectedRegion = "eu-central-1"
+		memoryStorage := storage.NewMemoryStorage()
+
+		queue := &automock.Queue{}
+		queue.On("Add", mock.AnythingOfType("string"))
+
+		factoryBuilder := &automock.PlanValidator{}
+		factoryBuilder.On("IsPlanSupport", broker.AWSPlanID).Return(true)
+
+		kcBuilder := &kcMock.KcBuilder{}
+		kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+		// #create provisioner endpoint
+		provisionEndpoint := broker.NewProvision(
+			broker.Config{
+				EnablePlans:              []string{broker.AWSPlanName},
+				URL:                      brokerURL,
+				DisableSapConvergedCloud: false,
+			},
+			gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+			imConfigFixture,
+			memoryStorage,
+			queue,
+			broker.PlansConfig{},
+			log,
+			dashboardConfig,
+			kcBuilder,
+			whitelist.Set{},
+			newSchemaService(t),
+			regionssupportingmachine.RegionsSupportingMachine{},
+			fixValueProvider(t),
+			false,
+			config.FakeProviderConfigProvider{},
+		)
+
+		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
+
+		// when
+		_, err := provisionEndpoint.Provision(fixRequestContext(t, expectedRegion), instanceID, domain.ProvisionDetails{
+			ServiceID:     serviceID,
+			PlanID:        broker.AWSPlanID,
+			RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s", "shootAndSeedSameRegion": true, "oidc":{ %s }}`, clusterName, expectedRegion, oidcParams)),
+			RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, "any-global-account-id", subAccountID, "broker.tester@local.dev")),
+		}, true)
+		t.Logf("%+v\n", *provisionEndpoint)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("should fail if configuration does not contain region from provisioning parameters", func(t *testing.T) {
+		// given
+		const missingRegion = "eu-west-2"
+		memoryStorage := storage.NewMemoryStorage()
+
+		queue := &automock.Queue{}
+		queue.On("Add", mock.AnythingOfType("string"))
+
+		factoryBuilder := &automock.PlanValidator{}
+		factoryBuilder.On("IsPlanSupport", broker.AWSPlanID).Return(true)
+
+		kcBuilder := &kcMock.KcBuilder{}
+		provisionEndpoint := broker.NewProvision(
+			broker.Config{
+				EnablePlans:              []string{broker.AWSPlanName},
+				URL:                      brokerURL,
+				DisableSapConvergedCloud: true,
+			},
+			gardener.Config{Project: "test", ShootDomain: "example.com", DNSProviders: fixDNSProviders()},
+			imConfigFixture,
+			memoryStorage,
+			queue,
+			broker.PlansConfig{},
+			log,
+			dashboardConfig,
+			kcBuilder,
+			whitelist.Set{},
+			newSchemaService(t),
+			regionssupportingmachine.RegionsSupportingMachine{},
+			fixValueProvider(t),
+			false,
+			config.FakeProviderConfigProvider{},
+		)
+
+		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
+		expectedErr := fmt.Errorf("[instanceID: %s] validation of the same region for seed and shoot: seed does not exist in %s region", instanceID, missingRegion)
+		expectedAPIResponse := apiresponses.NewFailureResponse(
+			expectedErr,
+			http.StatusBadRequest,
+			expectedErr.Error())
+
+		// when
+		_, err := provisionEndpoint.Provision(fixRequestContext(t, missingRegion), instanceID, domain.ProvisionDetails{
+			ServiceID:     serviceID,
+			PlanID:        broker.AWSPlanID,
+			RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s", "region": "%s", "shootAndSeedSameRegion": true, "oidc":{ %s }}`, clusterName, missingRegion, oidcParams)),
+			RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, globalAccountID, subAccountID, "broker.tester@local.dev")),
+		}, true)
+		t.Logf("%+v\n", *provisionEndpoint)
+
+		// then
+		require.Error(t, err)
+		assert.IsType(t, &apiresponses.FailureResponse{}, err)
+		apierr := err.(*apiresponses.FailureResponse)
+		assert.Equal(t, expectedAPIResponse.(*apiresponses.FailureResponse).ValidatedStatusCode(nil), apierr.ValidatedStatusCode(nil))
+		assert.Equal(t, expectedAPIResponse.(*apiresponses.FailureResponse).LoggerAction(), apierr.LoggerAction())
 	})
 }
 

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -2881,6 +2881,8 @@ func TestSameRegionForSeedAndShoot(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
+	existingAWSSeedRegions := []string{"eu-central-1"}
+
 	t.Run("should succeed if configuration contains region from provisioning parameters", func(t *testing.T) {
 		// given
 		const expectedRegion = "eu-central-1"
@@ -2967,7 +2969,8 @@ func TestSameRegionForSeedAndShoot(t *testing.T) {
 		)
 
 		oidcParams := `"clientID":"client-id","issuerURL":"https://test.local","signingAlgs":["RS256"]`
-		expectedErr := fmt.Errorf("[instanceID: %s] validation of the same region for seed and shoot: seed does not exist in %s region", instanceID, missingRegion)
+		expectedErr := fmt.Errorf("[instanceID: %s] validation of the same region for seed and shoot: seed does not exist in %s region. Provider aws has seeds in the following regions: %s",
+			instanceID, missingRegion, existingAWSSeedRegions)
 		expectedAPIResponse := apiresponses.NewFailureResponse(
 			expectedErr,
 			http.StatusBadRequest,

--- a/internal/broker/instance_get_test.go
+++ b/internal/broker/instance_get_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/internal/config"
 	"github.com/kyma-project/kyma-environment-broker/internal/regionssupportingmachine"
 	"github.com/kyma-project/kyma-environment-broker/internal/whitelist"
 
@@ -67,6 +68,7 @@ func TestGetEndpoint_GetProvisioningInstance(t *testing.T) {
 		regionssupportingmachine.RegionsSupportingMachine{},
 		fixValueProvider(t),
 		false,
+		config.FakeProviderConfigProvider{},
 	)
 	getSvc := broker.NewGetInstance(broker.Config{}, st.Instances(), st.Operations(), kcBuilder, fixLogger())
 

--- a/internal/config/fake.go
+++ b/internal/config/fake.go
@@ -1,0 +1,23 @@
+package config
+
+import "github.com/kyma-project/kyma-environment-broker/internal"
+
+type FakeProviderConfigProvider struct{}
+
+func (p FakeProviderConfigProvider) Provide(cfgKeyName string, cfgDestObj any) error {
+	cfg, _ := cfgDestObj.(*internal.ProviderConfig)
+	regions := make([]string, 0)
+	switch cfgKeyName {
+	case "aws":
+		regions = append(regions, "eu-central-1")
+	case "azure":
+		regions = append(regions, "westeurope")
+	case "gcp":
+		regions = append(regions, "europe-west1")
+	case "sapconvergedcloud", "openstack":
+		regions = append(regions, "eu-de-1")
+	}
+	cfg.SeedRegions = regions
+
+	return nil
+}

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -9,7 +9,10 @@ import (
 )
 
 // comma separated list of required fields
-const RuntimeConfigurationRequiredFields = "kyma-template"
+const (
+	RuntimeConfigurationRequiredFields  = "kyma-template"
+	ProviderConfigurationRequiredFields = "seedRegions"
+)
 
 type ConfigMapKeysValidator struct{}
 

--- a/internal/model.go
+++ b/internal/model.go
@@ -67,8 +67,8 @@ func (i *Instance) GetSubscriptionGlobalAccoundID() string {
 
 func (i *Instance) GetInstanceDetails() (InstanceDetails, error) {
 	result := i.InstanceDetails
-	//overwrite RuntimeID in InstanceDetails with Instance.RuntimeID
-	//needed for runtimes suspended without clearing RuntimeID in deprovisioning operation
+	// overwrite RuntimeID in InstanceDetails with Instance.RuntimeID
+	// needed for runtimes suspended without clearing RuntimeID in deprovisioning operation
 	result.RuntimeID = i.RuntimeID
 	return result, nil
 }
@@ -527,4 +527,8 @@ type Binding struct {
 type RetryTuple struct {
 	Timeout  time.Duration
 	Interval time.Duration
+}
+
+type ProviderConfig struct {
+	SeedRegions []string `json:"seedRegions" yaml:"seedRegions"`
 }

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -278,6 +278,8 @@ spec:
               value: /config/trialRegionMapping.yaml
             - name: APP_UPDATE_PROCESSING_ENABLED
               value: "{{ .Values.osbUpdateProcessingEnabled }}"
+            - name: APP_BROKER_GARDENER_SEEDS_CACHE_CONFIG_MAP_NAME
+              value: "gardener-seeds-cache"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: "{{ .Values.broker.freeDocsURL }}"
             - name: APP_BROKER_FREE_EXPIRATION_PERIOD
               value: "{{ .Values.broker.freeExpirationPeriod }}"
+            - name: APP_BROKER_GARDENER_SEEDS_CACHE_CONFIG_MAP_NAME
+              value: "gardener-seeds-cache"
             - name: APP_BROKER_INCLUDE_ADDITIONAL_PARAMS_IN_SCHEMA
               value: "{{ .Values.broker.includeAdditionalParamsInSchema }}"
             - name: APP_BROKER_MONITOR_ADDITIONAL_PROPERTIES
@@ -278,8 +280,6 @@ spec:
               value: /config/trialRegionMapping.yaml
             - name: APP_UPDATE_PROCESSING_ENABLED
               value: "{{ .Values.osbUpdateProcessingEnabled }}"
-            - name: APP_BROKER_GARDENER_SEEDS_CACHE_CONFIG_MAP_NAME
-              value: "gardener-seeds-cache"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

read provider's seed config and validate whether seed and shoot could be in the same region when user requests it.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #2055 