### PR TITLE
Add seeds regions ConfigMap for local deployment

### DIFF
--- a/resources/installation/templates/gardener-seeds-cache.yaml
+++ b/resources/installation/templates/gardener-seeds-cache.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-seeds-cache
+  namespace: kcp-system
+data:
+  alicloud: |-
+    seedRegions:
+    - eu-central-1
+  aws: |-
+    seedRegions:
+    - eu-west-1
+    - eu-central-1
+    - us-east-1
+  azure: |-
+    seedRegions:
+    - westeurope
+    - northeurope
+    - westus2
+    - eastus
+    - eastus2
+  gcp: |-
+    seedRegions:
+    - europe-west1
+    - us-central1
+  openstack: |-
+    seedRegions:
+    - eu-de-1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- create the `gardener-seeds-cache` ConfigMap to validate whether the selected region has a seed and supports the same seed and shoot region feature for local deployment.

**Related issue(s)**
See also #2066, https://github.com/kyma-project/kyma-environment-broker/issues/2066#issuecomment-2939592000
