### PR TITLE
Update provisioning parameters in E2E tests

### DIFF
--- a/testing/e2e/provisioning/pkg/client/broker/broker_client.go
+++ b/testing/e2e/provisioning/pkg/client/broker/broker_client.go
@@ -100,10 +100,9 @@ type instanceDetailsResponse struct {
 }
 
 type provisionParameters struct {
-	Name        string   `json:"name"`
-	Region      string   `json:"region"`
-	Components  []string `json:"components"`
-	KymaVersion string   `json:"kymaVersion,omitempty"`
+	Name        string `json:"name"`
+	Region      string `json:"region"`
+	KymaVersion string `json:"kymaVersion,omitempty"`
 }
 
 // ProvisionRuntime requests Runtime provisioning in KEB
@@ -304,7 +303,6 @@ func (c *Client) FetchDashboardURL() (string, error) {
 func (c *Client) prepareProvisionDetails(customVersion string) ([]byte, error) {
 	parameters := provisionParameters{
 		Name:        c.clusterName,
-		Components:  []string{},    // fill with optional components
 		KymaVersion: customVersion, // If empty filed will be omitted
 	}
 	if c.brokerConfig.PlanID != trialPlanID {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- the `components` parameter is no longer supported in the KEB schema and should be removed. Once we enable [rejection of unsupported parameters](https://github.com/kyma-project/kyma-environment-broker/pull/2099), E2E tests will begin to fail.

**Related issue(s)**
See also #1997
