### PR TITLE
Provisioning waits for READY state of Runtime CR

### DIFF
--- a/cmd/broker/binding_test.go
+++ b/cmd/broker/binding_test.go
@@ -3,14 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"io"
-	"net/http"
-	"testing"
 
 	"github.com/google/uuid"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
@@ -223,6 +222,7 @@ func TestFailedProvisioning(t *testing.T) {
 	cfg := fixConfig()
 	// Disable EDP to have all steps successfully executed
 	cfg.EDP.Disabled = true
+	cfg.StepTimeouts.CheckRuntimeResourceCreate = cfg.StepTimeouts.CheckRuntimeResourceCreate / testSuiteSpeedUpFactor
 	suite := NewBrokerSuiteTestWithConfig(t, cfg)
 	defer suite.TearDown()
 	iid := uuid.New().String()
@@ -244,7 +244,7 @@ func TestFailedProvisioning(t *testing.T) {
 		}`)
 	opID := suite.DecodeOperationID(response)
 	suite.WaitForOperationState(opID, domain.InProgress)
-	suite.failRuntimeByKIM(iid)
+	// just wait for timeout
 	suite.WaitForOperationState(opID, domain.Failed)
 
 	// when we create binding

--- a/cmd/broker/expiration_test.go
+++ b/cmd/broker/expiration_test.go
@@ -192,7 +192,9 @@ func TestExpiration(t *testing.T) {
 			})
 
 			t.Run("should expire a trial instance after failed provisioning", func(t *testing.T) {
-				suite := NewBrokerSuiteTest(t)
+				cfg := fixConfig()
+				cfg.StepTimeouts.CheckRuntimeResourceCreate = cfg.StepTimeouts.CheckRuntimeResourceCreate / testSuiteSpeedUpFactor
+				suite := NewBrokerSuiteTestWithConfig(t, cfg)
 				defer suite.TearDown()
 				// given
 				instanceID := uuid.NewString()

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -160,11 +160,12 @@ type KubeconfigProvider interface {
 }
 
 const (
-	createRuntimeStageName      = "create_runtime"
-	checkKymaStageName          = "check_kyma"
-	createKymaResourceStageName = "create_kyma_resource"
-	startStageName              = "start"
-	brokerAPISubrouterName      = "brokerAPI"
+	createRuntimeStageName         = "create_runtime"
+	checkKymaStageName             = "check_kyma"
+	createKymaResourceStageName    = "create_kyma_resource"
+	startStageName                 = "start"
+	brokerAPISubrouterName         = "brokerAPI"
+	provisioningTakesLongThreshold = 20 * time.Minute
 )
 
 func periodicProfile(logger *slog.Logger, profiler ProfilerConfig) {

--- a/cmd/broker/metrics_test.go
+++ b/cmd/broker/metrics_test.go
@@ -16,6 +16,7 @@ import (
 func TestMetrics(t *testing.T) {
 	cfg := fixConfig()
 	cfg.EDP.Disabled = true
+	cfg.StepTimeouts.CheckRuntimeResourceCreate = cfg.StepTimeouts.CheckRuntimeResourceCreate / testSuiteSpeedUpFactor
 	suite := NewBrokerSuitTestWithMetrics(t, cfg)
 	defer suite.TearDown()
 
@@ -96,7 +97,7 @@ func TestMetrics(t *testing.T) {
 
 		instance2 := uuid.New().String()
 		opID = provisionReq(instance2, broker.TrialPlanID)
-		suite.failRuntimeByKIM(instance2)
+		// just wait for timeout, so the operation will fail
 		suite.WaitForOperationState(opID, domain.Failed)
 		op2 := suite.GetOperation(opID)
 		assert.NotNil(t, op2)

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -90,7 +90,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		},
 		{
 			stage:     createRuntimeStageName,
-			step:      steps.NewCheckRuntimeResourceStep(db.Operations(), k8sClient, internal.RetryTuple{Timeout: cfg.StepTimeouts.CheckRuntimeResourceCreate, Interval: resourceStateRetryInterval}),
+			step:      steps.NewCheckRuntimeResourceProvisioningStep(db.Operations(), k8sClient, internal.RetryTuple{Timeout: cfg.StepTimeouts.CheckRuntimeResourceCreate, Interval: resourceStateRetryInterval}, provisioningTakesLongThreshold),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{ // TODO: this step must be removed when kubeconfig is created by IM and own_cluster plan is permanently removed

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -237,7 +237,10 @@ func TestUpdatePlan(t *testing.T) {
 
 func TestUpdateFailedInstance(t *testing.T) {
 	// given
-	suite := NewBrokerSuiteTest(t)
+	cfg := fixConfig()
+	cfg.StepTimeouts.CheckRuntimeResourceCreate = cfg.StepTimeouts.CheckRuntimeResourceCreate / testSuiteSpeedUpFactor
+
+	suite := NewBrokerSuiteTestWithConfig(t, cfg)
 	defer suite.TearDown()
 	iid := uuid.New().String()
 
@@ -261,7 +264,7 @@ func TestUpdateFailedInstance(t *testing.T) {
 				}
    }`)
 	opID := suite.DecodeOperationID(resp)
-	suite.failRuntimeByKIM(iid)
+	// just wait for timeout and failed operation
 	suite.WaitForOperationState(opID, domain.Failed)
 
 	// when

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -113,7 +113,6 @@ func (s *checkRuntimeResourceProvisioning) Run(operation internal.Operation, log
 }
 
 func (s *checkRuntimeResourceProvisioning) RetryOrFail(operation internal.Operation, log *slog.Logger, runtime *imv1.Runtime) (internal.Operation, time.Duration, error) {
-	log.Info(fmt.Sprintf("Runtime resource status: %v; retrying in %v steps for: %v", runtime.Status, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout))
 	retryOperation, retry, err := s.operationManager.RetryOperation(operation, fmt.Sprintf("Runtime resource not in %s state", imv1.RuntimeStateReady), nil, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout, log)
 	if retryOperation.State == domain.Failed {
 		log.Error(fmt.Sprintf("runtime resource status: %v; failing operation and removing Runtime CR", runtime.Status))

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -9,6 +9,7 @@ import (
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/pivotal-cf/brokerapi/v12/domain"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -26,10 +27,27 @@ func NewCheckRuntimeResourceStep(os storage.Operations, k8sClient client.Client,
 	return step
 }
 
+func NewCheckRuntimeResourceProvisioningStep(os storage.Operations, k8sClient client.Client, runtimeResourceStateRetry internal.RetryTuple, changeDescriptionThreshold time.Duration) *checkRuntimeResourceProvisioning {
+	step := &checkRuntimeResourceProvisioning{
+		k8sClient:                  k8sClient,
+		runtimeResourceStateRetry:  runtimeResourceStateRetry,
+		changeDescriptionThreshold: changeDescriptionThreshold,
+	}
+	step.operationManager = process.NewOperationManager(os, step.Name(), kebError.InfrastructureManagerDependency)
+	return step
+}
+
 type checkRuntimeResource struct {
 	k8sClient                 client.Client
 	operationManager          *process.OperationManager
 	runtimeResourceStateRetry internal.RetryTuple
+}
+
+type checkRuntimeResourceProvisioning struct {
+	k8sClient                  client.Client
+	operationManager           *process.OperationManager
+	runtimeResourceStateRetry  internal.RetryTuple
+	changeDescriptionThreshold time.Duration
 }
 
 const (
@@ -38,7 +56,7 @@ const (
 )
 
 func (_ *checkRuntimeResource) Name() string {
-	return "Check_RuntimeResource"
+	return "Check_RuntimeResource_Update"
 }
 
 func (s *checkRuntimeResource) Run(operation internal.Operation, log *slog.Logger) (internal.Operation, time.Duration, error) {
@@ -63,9 +81,61 @@ func (s *checkRuntimeResource) Run(operation internal.Operation, log *slog.Logge
 	}
 }
 
+func (_ *checkRuntimeResourceProvisioning) Name() string {
+	return "Check_RuntimeResource_Provisioning"
+}
+
+func (s *checkRuntimeResourceProvisioning) Run(operation internal.Operation, log *slog.Logger) (internal.Operation, time.Duration, error) {
+	runtime, err := s.GetRuntimeResource(operation.RuntimeID, operation.KymaResourceNamespace)
+	if err != nil {
+		log.Error(fmt.Sprintf("unable to get Runtime resource %s/%s", operation.KymaResourceNamespace, operation.RuntimeID))
+		return s.operationManager.RetryOperation(operation, "unable to get Runtime resource", err, kcpRetryInterval, kcpRetryTimeout, log)
+	}
+
+	// check status
+	state := runtime.Status.State
+	log.Info(fmt.Sprintf("Runtime resource state: %s", state))
+	if state == imv1.RuntimeStateReady {
+		return operation, 0, nil
+	} else {
+		if time.Since(operation.CreatedAt) > s.changeDescriptionThreshold {
+			var backoff time.Duration
+			operation, backoff, _ = s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+				op.Description = fmt.Sprintf("Operation created. Cluster provisioning takes longer than usual. It takes up to %s max.", s.runtimeResourceStateRetry.Timeout)
+			}, log)
+			if backoff != 0 {
+				log.Error("cannot save the operation")
+				return operation, 5 * time.Second, nil
+			}
+		}
+		return s.RetryOrFail(operation, log, runtime)
+	}
+}
+
+func (s *checkRuntimeResourceProvisioning) RetryOrFail(operation internal.Operation, log *slog.Logger, runtime *imv1.Runtime) (internal.Operation, time.Duration, error) {
+	log.Info(fmt.Sprintf("Runtime resource status: %v; retrying in %v steps for: %v", runtime.Status, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout))
+	retryOperation, retry, err := s.operationManager.RetryOperation(operation, fmt.Sprintf("Runtime resource not in %s state", imv1.RuntimeStateReady), nil, s.runtimeResourceStateRetry.Interval, s.runtimeResourceStateRetry.Timeout, log)
+	if retryOperation.State == domain.Failed {
+		log.Error(fmt.Sprintf("runtime resource status: %v; failing operation and removing Runtime CR", runtime.Status))
+		err = s.k8sClient.Delete(context.Background(), runtime)
+		if err != nil {
+			log.Warn(fmt.Sprintf("unable to delete Runtime resource %s/%s: %s", runtime.Name, runtime.Namespace, err))
+		}
+	}
+	return retryOperation, retry, err
+}
+
 func (s *checkRuntimeResource) GetRuntimeResource(name string, namespace string) (*imv1.Runtime, error) {
+	return GetRuntimeResource(name, namespace, s.k8sClient)
+}
+
+func (s *checkRuntimeResourceProvisioning) GetRuntimeResource(name string, namespace string) (*imv1.Runtime, error) {
+	return GetRuntimeResource(name, namespace, s.k8sClient)
+}
+
+func GetRuntimeResource(name string, namespace string, c client.Client) (*imv1.Runtime, error) {
 	runtime := imv1.Runtime{}
-	err := s.k8sClient.Get(context.Background(), client.ObjectKey{
+	err := c.Get(context.Background(), client.ObjectKey{
 		Namespace: namespace,
 		Name:      name,
 	}, &runtime)

--- a/internal/process/steps/runtime_resource_test.go
+++ b/internal/process/steps/runtime_resource_test.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,13 +16,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const ProvisioningTakesLongerThanUsual = 20 * time.Minute
+const ProvisioningTimeout = 2 * time.Second
+
 func TestCheckRuntimeResourceStep(t *testing.T) {
 	// given
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	os := storage.NewMemoryStorage().Operations()
 
-	t.Run("run when ready", func(t *testing.T) {
+	t.Run("succeed when ready", func(t *testing.T) {
 		// given
 		operation := createFakeProvisioningOp("1")
 		err = os.InsertOperation(operation)
@@ -40,7 +44,7 @@ func TestCheckRuntimeResourceStep(t *testing.T) {
 		assert.Zero(t, backoff)
 	})
 
-	t.Run("run when not ready and fail operation", func(t *testing.T) {
+	t.Run("fail operation when not ready and timeout", func(t *testing.T) {
 		// given
 		operation := createFakeProvisioningOp("2")
 		operation.CreatedAt = time.Now().Add(-1 * time.Hour)
@@ -62,7 +66,7 @@ func TestCheckRuntimeResourceStep(t *testing.T) {
 		assert.Equal(t, domain.Failed, op.State)
 	})
 
-	t.Run("run when not ready and retry operation", func(t *testing.T) {
+	t.Run("retry operation when not ready and not timeout", func(t *testing.T) {
 		// given
 		operation := createFakeProvisioningOp("3")
 		err = os.InsertOperation(operation)
@@ -81,7 +85,7 @@ func TestCheckRuntimeResourceStep(t *testing.T) {
 		assert.NotZero(t, backoff)
 	})
 
-	t.Run("run when failed and fail operation", func(t *testing.T) {
+	t.Run("fail operation when failed Runtime CR", func(t *testing.T) {
 		// given
 		operation := createFakeProvisioningOp("4")
 		err = os.InsertOperation(operation)
@@ -99,6 +103,106 @@ func TestCheckRuntimeResourceStep(t *testing.T) {
 		assert.Error(t, err)
 		assert.Zero(t, backoff)
 		assert.Equal(t, domain.Failed, op.State)
+	})
+}
+
+func TestCheckRuntimeResourceProvisioningStep(t *testing.T) {
+	// given
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	os := storage.NewMemoryStorage().Operations()
+
+	t.Run("succeed when ready", func(t *testing.T) {
+		// given
+		operation := createFakeProvisioningOp("1")
+		err = os.InsertOperation(operation)
+		assert.NoError(t, err)
+
+		existingRuntime := createRuntime(imv1.RuntimeStateReady)
+		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeout, Interval: time.Second}, ProvisioningTakesLongerThanUsual)
+
+		// when
+		_, backoff, err := step.Run(operation, fixLogger())
+
+		// then
+		assert.NoError(t, err)
+		assert.Zero(t, backoff)
+	})
+
+	t.Run("fail operation when not ready and timeout", func(t *testing.T) {
+		// given
+		operation := createFakeProvisioningOp("2")
+		operation.CreatedAt = time.Now().Add(-1 * time.Hour)
+		err = os.InsertOperation(operation)
+		assert.NoError(t, err)
+
+		existingRuntime := createRuntime("In Progress")
+		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+		// force immediate timeout
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: -1 * ProvisioningTimeout, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsual)
+
+		// when
+		op, backoff, err := step.Run(operation, fixLogger())
+
+		// then
+		assert.Zero(t, backoff)
+		assert.Equal(t, domain.Failed, op.State)
+		// in the real life this resource could be still there, in the step we just trigger deletion (fire-and-forget)
+		_, err = GetRuntimeResource(existingRuntime.Name, existingRuntime.Namespace, k8sClient)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("retry operation when not ready and not timeout", func(t *testing.T) {
+		// given
+		operation := createFakeProvisioningOp("3")
+		operation.Description = "Operation created"
+
+		err = os.InsertOperation(operation)
+		assert.NoError(t, err)
+
+		existingRuntime := createRuntime("In Progress")
+		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeout, Interval: time.Second}, ProvisioningTakesLongerThanUsual)
+
+		// when
+		postOperation, backoff, err := step.Run(operation, fixLogger())
+
+		// then
+		assert.NoError(t, err)
+		assert.NotZero(t, backoff)
+		assert.Equal(t, "Operation created", postOperation.Description)
+		dbOperation, _ := os.GetOperationByID("3")
+		assert.Equal(t, "Operation created", dbOperation.Description)
+	})
+
+	t.Run("retry operation when not ready and not timeout but operation takes longer than usual", func(t *testing.T) {
+		// given
+		operation := createFakeProvisioningOp("4")
+		operation.CreatedAt = time.Now().Add(-1*ProvisioningTakesLongerThanUsual - time.Minute)
+		operation.Description = "Operation created"
+		err = os.InsertOperation(operation)
+		assert.NoError(t, err)
+
+		existingRuntime := createRuntime("In Progress")
+		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeout, Interval: time.Second}, ProvisioningTakesLongerThanUsual)
+
+		// when
+		postOperation, backoff, err := step.Run(operation, fixLogger())
+
+		// then
+		assert.NoError(t, err)
+		assert.NotZero(t, backoff)
+		assert.Equal(t, fmt.Sprintf("Operation created. Cluster provisioning takes longer than usual. It takes up to %s max.", ProvisioningTimeout), postOperation.Description)
+
+		dbOperation, _ := os.GetOperationByID("4")
+		assert.Equal(t, fmt.Sprintf("Operation created. Cluster provisioning takes longer than usual. It takes up to %s max.", ProvisioningTimeout), dbOperation.Description)
 	})
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Separate steps for provisioning and update operations
- Timeout for provisioning causes Runtime CR deletion
- Operation description for provisioning is changed after threshold, hence it is reflected in response from `last_operation` endpoint

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2049 