### PR TITLE
KCP cli shows actions

### DIFF
--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/customresources"
 	"github.com/kyma-project/kyma-environment-broker/internal/ptr"
@@ -237,7 +238,7 @@ func TestUpdatePlan(t *testing.T) {
 	actions, err := suite.db.Actions().ListActionsByInstanceID(iid)
 	assert.NoError(t, err)
 	require.Len(t, actions, 1)
-	assert.Equal(t, actions[0].Type, internal.PlanUpdateActionType)
+	assert.Equal(t, actions[0].Type, pkg.PlanUpdateActionType)
 	assert.Equal(t, actions[0].Message, "Plan updated from 361c511f-f939-4621-b228-d0fb79a1fe15 to 6aae0ff3-89f7-4f12-86de-51466145422e.")
 	assert.Equal(t, actions[0].OldValue, "361c511f-f939-4621-b228-d0fb79a1fe15")
 	assert.Equal(t, actions[0].NewValue, "6aae0ff3-89f7-4f12-86de-51466145422e")
@@ -3362,7 +3363,7 @@ func TestUpdateGlobalAccountID(t *testing.T) {
 	actions, err := suite.db.Actions().ListActionsByInstanceID(iid)
 	assert.NoError(t, err)
 	require.Len(t, actions, 1)
-	assert.Equal(t, actions[0].Type, internal.SubaccountMovementActionType)
+	assert.Equal(t, actions[0].Type, pkg.SubaccountMovementActionType)
 	assert.Equal(t, actions[0].Message, "Subaccount sub-id moved from Global Account g-account-id to new-g-account-id.")
 	assert.Equal(t, actions[0].OldValue, "g-account-id")
 	assert.Equal(t, actions[0].NewValue, "new-g-account-id")

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -62,6 +62,7 @@ type RuntimeDTO struct {
 	SubscriptionSecretName      *string                   `json:"subscriptionSecretName,omitempty"`
 	LicenseType                 *string                   `json:"licenseType,omitempty"`
 	CommercialModel             *string                   `json:"commercialModel,omitempty"`
+	Actions                     []Action                  `json:"actions,omitempty"`
 }
 
 type CloudProvider string
@@ -347,6 +348,23 @@ type BindingDTO struct {
 	CreatedBy         string    `json:"createdBy"`
 }
 
+type ActionType string
+
+const (
+	PlanUpdateActionType         ActionType = "plan_update"
+	SubaccountMovementActionType ActionType = "subaccount_movement"
+)
+
+type Action struct {
+	ID         string     `json:"ID,omitempty"`
+	Type       ActionType `json:"type,omitempty"`
+	InstanceID string     `json:"-"`
+	Message    string     `json:"message,omitempty"`
+	OldValue   string     `json:"oldValue,omitempty"`
+	NewValue   string     `json:"newValue,omitempty"`
+	CreatedAt  time.Time  `json:"createdAt,omitempty"`
+}
+
 type RuntimeStatus struct {
 	CreatedAt        time.Time       `json:"createdAt"`
 	ModifiedAt       time.Time       `json:"modifiedAt"`
@@ -415,6 +433,7 @@ const (
 	RuntimeConfigParam   = "runtime_config"
 	BindingsParam        = "bindings"
 	WithBindingsParam    = "with_bindings"
+	ActionsParam         = "actions"
 )
 
 type OperationDetail string

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -403,13 +403,13 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 		if slices.Contains(updateStorage, "Plan change") {
 			message := fmt.Sprintf("Plan updated from %s to %s.", oldPlanID, details.PlanID)
 			if err := b.actionStorage.InsertAction(
-				internal.PlanUpdateActionType,
+				pkg.PlanUpdateActionType,
 				instance.InstanceID,
 				message,
 				oldPlanID,
 				details.PlanID,
 			); err != nil {
-				logger.Error(fmt.Sprintf("while inserting action %q with message %s for instance ID %s: %v", internal.PlanUpdateActionType, message, instance.InstanceID, err))
+				logger.Error(fmt.Sprintf("while inserting action %q with message %s for instance ID %s: %v", pkg.PlanUpdateActionType, message, instance.InstanceID, err))
 			}
 		}
 	}
@@ -469,13 +469,13 @@ func (b *UpdateEndpoint) processContext(instance *internal.Instance, details dom
 	if b.subaccountMovementEnabled && (instance.GlobalAccountID != ersContext.GlobalAccountID && ersContext.GlobalAccountID != "") {
 		message := fmt.Sprintf("Subaccount %s moved from Global Account %s to %s.", ersContext.SubAccountID, instance.GlobalAccountID, ersContext.GlobalAccountID)
 		if err := b.actionStorage.InsertAction(
-			internal.SubaccountMovementActionType,
+			pkg.SubaccountMovementActionType,
 			instance.InstanceID,
 			message,
 			instance.GlobalAccountID,
 			ersContext.GlobalAccountID,
 		); err != nil {
-			logger.Error(fmt.Sprintf("while inserting action %q with message %s for instance ID %s: %v", internal.SubaccountMovementActionType, message, instance.InstanceID, err))
+			logger.Error(fmt.Sprintf("while inserting action %q with message %s for instance ID %s: %v", pkg.SubaccountMovementActionType, message, instance.InstanceID, err))
 		}
 		if instance.SubscriptionGlobalAccountID == "" {
 			instance.SubscriptionGlobalAccountID = instance.GlobalAccountID

--- a/internal/model.go
+++ b/internal/model.go
@@ -538,20 +538,3 @@ type RegionsSupporter interface {
 	SupportedRegions(machineType string) []string
 	AvailableZonesForAdditionalWorkers(machineType, region, planID string) ([]string, error)
 }
-
-type ActionType string
-
-const (
-	PlanUpdateActionType         ActionType = "plan_update"
-	SubaccountMovementActionType ActionType = "subaccount_movement"
-)
-
-type Action struct {
-	ID         string
-	Type       ActionType
-	InstanceID string
-	Message    string
-	OldValue   string
-	NewValue   string
-	CreatedAt  time.Time
-}

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -258,7 +258,7 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 		if actions {
 			actions, err := h.actionsDb.ListActionsByInstanceID(dto.InstanceID)
 			if err != nil {
-				h.logger.Warn(fmt.Sprintf("unable to apply actions: %s", err.Error()))
+				h.logger.Warn(fmt.Sprintf("unable to list actions: %s", err.Error()))
 				httputil.WriteErrorResponse(w, http.StatusInternalServerError, err)
 				return
 			}

--- a/internal/runtime/handler.go
+++ b/internal/runtime/handler.go
@@ -36,6 +36,7 @@ type Handler struct {
 	bindingsDb          storage.Bindings
 	instancesArchivedDb storage.InstancesArchived
 	subaccountStatesDb  storage.SubaccountStates
+	actionsDb           storage.Actions
 	converter           Converter
 	defaultMaxPage      int
 	k8sClient           client.Client
@@ -50,6 +51,7 @@ func NewHandler(storage storage.BrokerStorage, defaultMaxPage int, defaultReques
 		bindingsDb:          storage.Bindings(),
 		instancesArchivedDb: storage.InstancesArchived(),
 		subaccountStatesDb:  storage.SubaccountStates(),
+		actionsDb:           storage.Actions(),
 		converter:           NewConverter(defaultRequestRegion),
 		defaultMaxPage:      defaultMaxPage,
 		k8sClient:           k8sClient,
@@ -185,6 +187,7 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 	opDetail := getOpDetail(req)
 	runtimeResourceConfig := getBoolParam(pkg.RuntimeConfigParam, req)
 	bindings := getBoolParam(pkg.BindingsParam, req)
+	actions := getBoolParam(pkg.ActionsParam, req)
 
 	instances, count, totalCount, err := h.listInstances(filter)
 	if err != nil {
@@ -251,6 +254,15 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 				httputil.WriteErrorResponse(w, http.StatusInternalServerError, err)
 				return
 			}
+		}
+		if actions {
+			actions, err := h.actionsDb.ListActionsByInstanceID(dto.InstanceID)
+			if err != nil {
+				h.logger.Warn(fmt.Sprintf("unable to apply actions: %s", err.Error()))
+				httputil.WriteErrorResponse(w, http.StatusInternalServerError, err)
+				return
+			}
+			dto.Actions = actions
 		}
 
 		toReturn = append(toReturn, dto)

--- a/internal/storage/driver/memory/action.go
+++ b/internal/storage/driver/memory/action.go
@@ -1,24 +1,26 @@
 package memory
 
 import (
+	"sort"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
+
 	"github.com/google/uuid"
-	"github.com/kyma-project/kyma-environment-broker/internal"
 )
 
 type Action struct {
-	actions []internal.Action
+	actions []runtime.Action
 }
 
 func NewAction() *Action {
 	return &Action{
-		actions: make([]internal.Action, 0),
+		actions: make([]runtime.Action, 0),
 	}
 }
 
-func (a *Action) InsertAction(actionType internal.ActionType, instanceID, message, oldValue, newValue string) error {
-	a.actions = append(a.actions, internal.Action{
+func (a *Action) InsertAction(actionType runtime.ActionType, instanceID, message, oldValue, newValue string) error {
+	a.actions = append(a.actions, runtime.Action{
 		ID:         uuid.NewString(),
 		Type:       actionType,
 		InstanceID: instanceID,
@@ -30,12 +32,15 @@ func (a *Action) InsertAction(actionType internal.ActionType, instanceID, messag
 	return nil
 }
 
-func (a *Action) ListActionsByInstanceID(instanceID string) ([]internal.Action, error) {
-	filtered := make([]internal.Action, 0)
+func (a *Action) ListActionsByInstanceID(instanceID string) ([]runtime.Action, error) {
+	filtered := make([]runtime.Action, 0)
 	for _, action := range a.actions {
 		if action.InstanceID == instanceID {
 			filtered = append(filtered, action)
 		}
 	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].CreatedAt.After(filtered[j].CreatedAt)
+	})
 	return filtered, nil
 }

--- a/internal/storage/driver/postsql/action.go
+++ b/internal/storage/driver/postsql/action.go
@@ -1,7 +1,7 @@
 package postsql
 
 import (
-	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/postsql"
 )
 
@@ -15,10 +15,10 @@ func NewAction(sess postsql.Factory) *Action {
 	}
 }
 
-func (a *Action) InsertAction(actionType internal.ActionType, instanceID, message, oldValue, newValue string) error {
+func (a *Action) InsertAction(actionType runtime.ActionType, instanceID, message, oldValue, newValue string) error {
 	return a.Factory.NewWriteSession().InsertAction(actionType, instanceID, message, oldValue, newValue)
 }
 
-func (a *Action) ListActionsByInstanceID(instanceID string) ([]internal.Action, error) {
+func (a *Action) ListActionsByInstanceID(instanceID string) ([]runtime.Action, error) {
 	return a.Factory.NewReadSession().ListActions(instanceID)
 }

--- a/internal/storage/driver/postsql/action_test.go
+++ b/internal/storage/driver/postsql/action_test.go
@@ -3,7 +3,7 @@ package postsql_test
 import (
 	"testing"
 
-	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 
 	"github.com/stretchr/testify/assert"
@@ -26,9 +26,9 @@ func TestAction(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, actions, 0)
 
-	err = brokerStorage.Actions().InsertAction(internal.PlanUpdateActionType, instanceID, "test-message-1", "old-value-1", "new-value-1")
+	err = brokerStorage.Actions().InsertAction(runtime.PlanUpdateActionType, instanceID, "test-message-1", "old-value-1", "new-value-1")
 	assert.NoError(t, err)
-	err = brokerStorage.Actions().InsertAction(internal.SubaccountMovementActionType, instanceID, "test-message-2", "old-value-2", "new-value-2")
+	err = brokerStorage.Actions().InsertAction(runtime.SubaccountMovementActionType, instanceID, "test-message-2", "old-value-2", "new-value-2")
 	assert.NoError(t, err)
 
 	actions, err = brokerStorage.Actions().ListActionsByInstanceID(instanceID)
@@ -36,7 +36,7 @@ func TestAction(t *testing.T) {
 	assert.Len(t, actions, 2)
 
 	assert.NotEmpty(t, actions[0].ID)
-	assert.Equal(t, actions[0].Type, internal.SubaccountMovementActionType)
+	assert.Equal(t, actions[0].Type, runtime.SubaccountMovementActionType)
 	assert.Equal(t, actions[0].InstanceID, instanceID)
 	assert.Equal(t, actions[0].Message, "test-message-2")
 	assert.Equal(t, actions[0].OldValue, "old-value-2")
@@ -44,7 +44,7 @@ func TestAction(t *testing.T) {
 	assert.NotEmpty(t, actions[0].CreatedAt)
 
 	assert.NotEmpty(t, actions[1].ID)
-	assert.Equal(t, actions[1].Type, internal.PlanUpdateActionType)
+	assert.Equal(t, actions[1].Type, runtime.PlanUpdateActionType)
 	assert.Equal(t, actions[1].InstanceID, instanceID)
 	assert.Equal(t, actions[1].Message, "test-message-1")
 	assert.Equal(t, actions[1].OldValue, "old-value-1")

--- a/internal/storage/ext.go
+++ b/internal/storage/ext.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/events"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/predicate"
@@ -118,6 +119,6 @@ type Bindings interface {
 }
 
 type Actions interface {
-	InsertAction(actionType internal.ActionType, instanceID, message, oldValue, newValue string) error
-	ListActionsByInstanceID(instanceID string) ([]internal.Action, error)
+	InsertAction(actionType runtime.ActionType, instanceID, message, oldValue, newValue string) error
+	ListActionsByInstanceID(instanceID string) ([]runtime.Action, error)
 }

--- a/internal/storage/postsql/factory.go
+++ b/internal/storage/postsql/factory.go
@@ -3,12 +3,14 @@ package postsql
 import (
 	"time"
 
-	"github.com/gocraft/dbr"
 	"github.com/kyma-project/kyma-environment-broker/common/events"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/predicate"
+
+	"github.com/gocraft/dbr"
 )
 
 //go:generate mockery --name=Factory
@@ -59,7 +61,7 @@ type ReadSession interface {
 	ListBindings(instanceID string) ([]dbmodel.BindingDTO, error)
 	ListExpiredBindings() ([]dbmodel.BindingDTO, error)
 	GetBindingsStatistics() (dbmodel.BindingStatsDTO, error)
-	ListActions(instanceID string) ([]internal.Action, error)
+	ListActions(instanceID string) ([]runtime.Action, error)
 }
 
 //go:generate mockery --name=WriteSession
@@ -79,7 +81,7 @@ type WriteSession interface {
 	UpdateBinding(binding dbmodel.BindingDTO) dberr.Error
 	DeleteBinding(instanceID, bindingID string) dberr.Error
 	UpdateInstanceLastOperation(instanceID, operationID string) error
-	InsertAction(actionType internal.ActionType, instanceID, message, oldValue, newValue string) dberr.Error
+	InsertAction(actionType runtime.ActionType, instanceID, message, oldValue, newValue string) dberr.Error
 }
 
 type Transaction interface {

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/events"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
@@ -955,8 +956,8 @@ func (r readSession) getInstanceArchivedCount(filter dbmodel.InstanceFilter) (in
 	return res.Total, err
 }
 
-func (r readSession) ListActions(instanceID string) ([]internal.Action, error) {
-	var actions []internal.Action
+func (r readSession) ListActions(instanceID string) ([]runtime.Action, error) {
+	var actions []runtime.Action
 	stmt := r.session.Select("*").From(ActionsTableName)
 	stmt.Where(dbr.Eq("instance_id", instanceID))
 	stmt.OrderDesc("created_at")

--- a/internal/storage/postsql/write.go
+++ b/internal/storage/postsql/write.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/events"
-	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage/dbmodel"
 
@@ -329,7 +329,7 @@ func (ws writeSession) DeleteOperationByID(id string) dberr.Error {
 	return nil
 }
 
-func (ws writeSession) InsertAction(actionType internal.ActionType, instanceID, message, oldValue, newValue string) dberr.Error {
+func (ws writeSession) InsertAction(actionType runtime.ActionType, instanceID, message, oldValue, newValue string) dberr.Error {
 	_, err := ws.insertInto(ActionsTableName).
 		Pair("id", uuid.NewString()).
 		Pair("type", actionType).


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- move the `Action` struct to `common/runtime/model.go`,
- add a new `action` query parameter,
- update the runtime endpoint to return actions when the `action` parameter is set to `true`.

See [#7316](https://github.tools.sap/kyma/backlog/issues/7316#issuecomment-13085098)