### PR TITLE
Check quota limit during update

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -449,7 +449,7 @@ func createAPI(router *httputil.Router, schemaService *broker.SchemaService, ser
 		DeprovisionEndpoint: broker.NewDeprovision(db.Instances(), db.Operations(), deprovisionQueue, logs),
 		UpdateEndpoint: broker.NewUpdate(cfg.Broker, db,
 			suspensionCtxHandler, cfg.UpdateProcessingEnabled, cfg.Broker.SubaccountMovementEnabled, cfg.Broker.UpdateCustomResourcesLabelsOnAccountMove, updateQueue, defaultPlansConfig,
-			valuesProvider, logs, cfg.KymaDashboardConfig, kcBuilder, kcpK8sClient, providerSpec, planSpec, cfg.InfrastructureManager, schemaService),
+			valuesProvider, logs, cfg.KymaDashboardConfig, kcBuilder, kcpK8sClient, providerSpec, planSpec, cfg.InfrastructureManager, schemaService, quotaClient, quotaWhitelistedSubaccountIds),
 		GetInstanceEndpoint:          broker.NewGetInstance(cfg.Broker, db.Instances(), db.Operations(), kcBuilder, logs),
 		LastOperationEndpoint:        broker.NewLastOperation(db.Operations(), db.InstancesArchived(), logs),
 		BindEndpoint:                 broker.NewBind(cfg.Broker.Binding, db, logs, clientProvider, kubeconfigProvider, publisher, cfg.MultipleContexts),

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -3253,7 +3253,7 @@ func TestQuotaLimitCheck(t *testing.T) {
 		t.Logf("%+v\n", *provisionEndpoint)
 
 		// then
-		assert.EqualError(t, err, "Kyma instances quota exceeded. assignedQuota: 1, remainingQuota: 0. Contact your administrator.")
+		assert.EqualError(t, err, "Kyma instances quota exceeded for plan azure. assignedQuota: 1, remainingQuota: 0. Contact your administrator.")
 	})
 
 	t.Run("should create new operation if there is unassigned quota", func(t *testing.T) {
@@ -3355,7 +3355,7 @@ func TestQuotaLimitCheck(t *testing.T) {
 		t.Logf("%+v\n", *provisionEndpoint)
 
 		// then
-		assert.EqualError(t, err, "Failed to get assigned quota: error message.")
+		assert.EqualError(t, err, "Failed to get assigned quota for plan azure: error message.")
 	})
 
 	t.Run("should create new operation if there is no unassigned quota but whitelisted subaccount", func(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- validate during update that the assigned quota for the subaccount is not exceeded.

**Related issue(s)**
See also [#7375](https://github.tools.sap/kyma/backlog/issues/7375), [comment](https://github.tools.sap/kyma/backlog/issues/7375#issuecomment-13343469)
