### PR TITLE
Fix panic when updating an empty oidc list

### DIFF
--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -171,6 +171,12 @@ func (o *OIDCConnectDTO) IsProvided() bool {
 	return o != nil && (o.OIDCConfigDTO != nil || o.List != nil)
 }
 
+func (o *OIDCConfigDTO) IsEmpty() bool {
+	return o.ClientID == "" && o.IssuerURL == "" && o.GroupsClaim == "" &&
+		o.UsernamePrefix == "" && o.UsernameClaim == "" && len(o.SigningAlgs) == 0 &&
+		len(o.RequiredClaims) == 0 && o.GroupsPrefix == "" && o.EncodedJwksArray == ""
+}
+
 func (o *OIDCConnectDTO) Validate(instanceOidcConfig *OIDCConnectDTO) error {
 	if o.List != nil && o.OIDCConfigDTO != nil {
 		return fmt.Errorf("both list and object OIDC cannot be set")
@@ -196,10 +202,7 @@ func (o *OIDCConnectDTO) validateSingleOIDC(instanceOidcConfig *OIDCConnectDTO, 
 	if instanceOidcConfig != nil && instanceOidcConfig.List != nil {
 		return fmt.Errorf("an object OIDC cannot be used because the instance OIDC configuration uses a list")
 	}
-	if o.OIDCConfigDTO.ClientID == "" && o.OIDCConfigDTO.IssuerURL == "" && o.OIDCConfigDTO.GroupsClaim == "" &&
-		o.OIDCConfigDTO.UsernamePrefix == "" && o.OIDCConfigDTO.UsernameClaim == "" && len(o.OIDCConfigDTO.SigningAlgs) == 0 &&
-		len(o.OIDCConfigDTO.RequiredClaims) == 0 && o.OIDCConfigDTO.GroupsPrefix == "" && o.OIDCConfigDTO.EncodedJwksArray == "" {
-
+	if o.OIDCConfigDTO.IsEmpty() {
 		return nil
 	}
 	if len(o.OIDCConfigDTO.ClientID) == 0 {

--- a/common/runtime/model.go
+++ b/common/runtime/model.go
@@ -168,13 +168,7 @@ type OIDCConfigDTO struct {
 const oidcValidSigningAlgs = "RS256,RS384,RS512,ES256,ES384,ES512,PS256,PS384,PS512"
 
 func (o *OIDCConnectDTO) IsProvided() bool {
-	if o == nil {
-		return false
-	}
-	if o.OIDCConfigDTO != nil && (o.OIDCConfigDTO.ClientID != "" || o.OIDCConfigDTO.IssuerURL != "" || o.OIDCConfigDTO.GroupsClaim != "" || o.OIDCConfigDTO.UsernamePrefix != "" || o.OIDCConfigDTO.UsernameClaim != "" || len(o.OIDCConfigDTO.SigningAlgs) > 0 || len(o.OIDCConfigDTO.RequiredClaims) > 0 || o.OIDCConfigDTO.GroupsPrefix != "" || o.OIDCConfigDTO.EncodedJwksArray != "") {
-		return true
-	}
-	return o.List != nil
+	return o != nil && (o.OIDCConfigDTO != nil || o.List != nil)
 }
 
 func (o *OIDCConnectDTO) Validate(instanceOidcConfig *OIDCConnectDTO) error {
@@ -201,6 +195,12 @@ func (o *OIDCConnectDTO) Validate(instanceOidcConfig *OIDCConnectDTO) error {
 func (o *OIDCConnectDTO) validateSingleOIDC(instanceOidcConfig *OIDCConnectDTO, errs *[]string) error {
 	if instanceOidcConfig != nil && instanceOidcConfig.List != nil {
 		return fmt.Errorf("an object OIDC cannot be used because the instance OIDC configuration uses a list")
+	}
+	if o.OIDCConfigDTO.ClientID == "" && o.OIDCConfigDTO.IssuerURL == "" && o.OIDCConfigDTO.GroupsClaim == "" &&
+		o.OIDCConfigDTO.UsernamePrefix == "" && o.OIDCConfigDTO.UsernameClaim == "" && len(o.OIDCConfigDTO.SigningAlgs) == 0 &&
+		len(o.OIDCConfigDTO.RequiredClaims) == 0 && o.OIDCConfigDTO.GroupsPrefix == "" && o.OIDCConfigDTO.EncodedJwksArray == "" {
+
+		return nil
 	}
 	if len(o.OIDCConfigDTO.ClientID) == 0 {
 		*errs = append(*errs, "clientID must not be empty")

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -368,8 +368,13 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 	}
 
 	if params.OIDC.IsProvided() {
-		instance.Parameters.Parameters.OIDC = params.OIDC
-		updateStorage = append(updateStorage, "OIDC")
+		if params.OIDC.OIDCConfigDTO.ClientID != "" || params.OIDC.OIDCConfigDTO.IssuerURL != "" || params.OIDC.OIDCConfigDTO.GroupsClaim != "" ||
+			params.OIDC.OIDCConfigDTO.UsernamePrefix != "" || params.OIDC.OIDCConfigDTO.UsernameClaim != "" || len(params.OIDC.OIDCConfigDTO.SigningAlgs) > 0 ||
+			len(params.OIDC.OIDCConfigDTO.RequiredClaims) > 0 || params.OIDC.OIDCConfigDTO.GroupsPrefix != "" || params.OIDC.OIDCConfigDTO.EncodedJwksArray != "" {
+
+			instance.Parameters.Parameters.OIDC = params.OIDC
+			updateStorage = append(updateStorage, "OIDC")
+		}
 	}
 
 	if params.IngressFiltering != nil {

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -368,9 +368,9 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 	}
 
 	if params.OIDC.IsProvided() {
-		if params.OIDC.OIDCConfigDTO.ClientID != "" || params.OIDC.OIDCConfigDTO.IssuerURL != "" || params.OIDC.OIDCConfigDTO.GroupsClaim != "" ||
+		if params.OIDC.List != nil || (params.OIDC.OIDCConfigDTO.ClientID != "" || params.OIDC.OIDCConfigDTO.IssuerURL != "" || params.OIDC.OIDCConfigDTO.GroupsClaim != "" ||
 			params.OIDC.OIDCConfigDTO.UsernamePrefix != "" || params.OIDC.OIDCConfigDTO.UsernameClaim != "" || len(params.OIDC.OIDCConfigDTO.SigningAlgs) > 0 ||
-			len(params.OIDC.OIDCConfigDTO.RequiredClaims) > 0 || params.OIDC.OIDCConfigDTO.GroupsPrefix != "" || params.OIDC.OIDCConfigDTO.EncodedJwksArray != "" {
+			len(params.OIDC.OIDCConfigDTO.RequiredClaims) > 0 || params.OIDC.OIDCConfigDTO.GroupsPrefix != "" || params.OIDC.OIDCConfigDTO.EncodedJwksArray != "") {
 
 			instance.Parameters.Parameters.OIDC = params.OIDC
 			updateStorage = append(updateStorage, "OIDC")

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -368,10 +368,7 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 	}
 
 	if params.OIDC.IsProvided() {
-		if params.OIDC.List != nil || (params.OIDC.OIDCConfigDTO.ClientID != "" || params.OIDC.OIDCConfigDTO.IssuerURL != "" || params.OIDC.OIDCConfigDTO.GroupsClaim != "" ||
-			params.OIDC.OIDCConfigDTO.UsernamePrefix != "" || params.OIDC.OIDCConfigDTO.UsernameClaim != "" || len(params.OIDC.OIDCConfigDTO.SigningAlgs) > 0 ||
-			len(params.OIDC.OIDCConfigDTO.RequiredClaims) > 0 || params.OIDC.OIDCConfigDTO.GroupsPrefix != "" || params.OIDC.OIDCConfigDTO.EncodedJwksArray != "") {
-
+		if params.OIDC.List != nil || (params.OIDC.OIDCConfigDTO != nil && !params.OIDC.OIDCConfigDTO.IsEmpty()) {
 			instance.Parameters.Parameters.OIDC = params.OIDC
 			updateStorage = append(updateStorage, "OIDC")
 		}

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -283,7 +283,7 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 	if params.OIDC.IsProvided() {
 		if err := params.OIDC.Validate(instance.Parameters.Parameters.OIDC); err != nil {
 			logger.Error(fmt.Sprintf("invalid OIDC parameters: %s", err.Error()))
-			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusUnprocessableEntity, err.Error())
+			return domain.UpdateServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
 		}
 	}
 

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -136,7 +136,7 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 			if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
 				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]imv1.OIDCConfig{{}}
 			}
-			config := &(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0]
+			config := &(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0] //panic
 			if len(dto.SigningAlgs) > 0 {
 				config.SigningAlgs = dto.SigningAlgs
 			}

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -136,7 +136,7 @@ func (s *UpdateRuntimeStep) Run(operation internal.Operation, log *slog.Logger) 
 			if runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig == nil {
 				runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig = &[]imv1.OIDCConfig{{}}
 			}
-			config := &(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0] //panic
+			config := &(*runtime.Spec.Shoot.Kubernetes.KubeAPIServer.AdditionalOidcConfig)[0]
 			if len(dto.SigningAlgs) > 0 {
 				config.SigningAlgs = dto.SigningAlgs
 			}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

When the user tries to update an empty oidc list (list with 0 element) with and oidc object, which all fields are empty, the validation handles it as "oidc not provided" and tries just to update the first element of the additionalOidc list in runtimeCR. But that element doesn't exists as this list is empty and KEB panics.

This PR expand the input parameters validation, where any oidc value is handled as "oidc provided". This mitigates the scenarios as described above.

Changes proposed in this pull request:

- More strict validation
- Change oidc validation HTTP error code from 422 to 400

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
