### PR TITLE
Set machineType parameter to nil for trials

### DIFF
--- a/internal/provider/provider_values.go
+++ b/internal/provider/provider_values.go
@@ -121,6 +121,7 @@ func (s *PlanSpecificValuesProvider) ValuesForPlanAndParameters(provisioningPara
 		} else {
 			trialProvider = *provisioningParameters.Parameters.Provider
 		}
+		provisioningParameters.Parameters.MachineType = nil // reset machine type to default for trial plans
 		switch trialProvider {
 		case pkg.AWS:
 			p = &AWSTrialInputProvider{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- For trial plans we use hard-wired machine type, so we should ignore `machineType` parameter.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
