### PR TITLE
Switch from Provisioning to Entitlements Service

### DIFF
--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -92,8 +92,8 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_PROVISIONING_&#x200b;MAX_STEP_PROCESSING_&#x200b;TIME** | <code>2m</code> | Maximum time a worker is allowed to process a step before it must return to the provisioning queue |
 | **APP_PROVISIONING_&#x200b;WORKERS_AMOUNT** | <code>20</code> | Number of workers in provisioning queue |
 | **APP_QUOTA_AUTH_URL** | <code>TBD</code> | The OAuth2 token endpoint (authorization URL) used to obtain access tokens for authenticating requests to the CIS Entitlements API |
-| **APP_QUOTA_CLIENT_ID** | None | Specifies the client ID for the OAuth2 authentication in CIS v2. |
-| **APP_QUOTA_CLIENT_&#x200b;SECRET** | None | Specifies the client secret for the OAuth2 authentication in CIS v2. |
+| **APP_QUOTA_CLIENT_ID** | None | Specifies the client ID for the OAuth2 authentication in CIS Entitlements API. |
+| **APP_QUOTA_CLIENT_&#x200b;SECRET** | None | Specifies the client secret for the OAuth2 authentication in CIS Entitlements API. |
 | **APP_QUOTA_INTERVAL** | <code>1s</code> | The interval between requests to the Entitlements API in case of errors |
 | **APP_QUOTA_RETRIES** | <code>5</code> | The number of retry attempts made when the Entitlements API request fails |
 | **APP_QUOTA_SERVICE_&#x200b;URL** | <code>TBD</code> | The base URL of the CIS Entitlements API endpoint, used for fetching quota assignments |

--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -91,12 +91,12 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_PROVIDERS_&#x200b;CONFIGURATION_FILE_&#x200b;PATH** | <code>/config/providersConfig.yaml</code> | Path to the providers configuration file, which defines hyperscaler/provider settings |
 | **APP_PROVISIONING_&#x200b;MAX_STEP_PROCESSING_&#x200b;TIME** | <code>2m</code> | Maximum time a worker is allowed to process a step before it must return to the provisioning queue |
 | **APP_PROVISIONING_&#x200b;WORKERS_AMOUNT** | <code>20</code> | Number of workers in provisioning queue |
-| **APP_QUOTA_AUTH_URL** | <code>TBD</code> | The OAuth2 token endpoint (authorization URL) for CIS v2, used to obtain access tokens for authenticating requests |
+| **APP_QUOTA_AUTH_URL** | <code>TBD</code> | The OAuth2 token endpoint (authorization URL) used to obtain access tokens for authenticating requests to the CIS Entitlements API |
 | **APP_QUOTA_CLIENT_ID** | None | Specifies the client ID for the OAuth2 authentication in CIS v2. |
 | **APP_QUOTA_CLIENT_&#x200b;SECRET** | None | Specifies the client secret for the OAuth2 authentication in CIS v2. |
-| **APP_QUOTA_INTERVAL** | <code>1s</code> | The interval between requests to the Quota Assignments API in case of errors |
-| **APP_QUOTA_RETRIES** | <code>5</code> | The number of retry attempts made when the Quota Assignments API request fails |
-| **APP_QUOTA_SERVICE_&#x200b;URL** | <code>TBD</code> | The endpoint URL for the CIS v2 provisioning service, used to fetch quota assignments |
+| **APP_QUOTA_INTERVAL** | <code>1s</code> | The interval between requests to the Entitlements API in case of errors |
+| **APP_QUOTA_RETRIES** | <code>5</code> | The number of retry attempts made when the Entitlements API request fails |
+| **APP_QUOTA_SERVICE_&#x200b;URL** | <code>TBD</code> | The base URL of the CIS Entitlements API endpoint, used for fetching quota assignments |
 | **APP_QUOTA_&#x200b;WHITELISTED_&#x200b;SUBACCOUNTS_FILE_&#x200b;PATH** | <code>/config/quotaWhitelistedSubaccountIds.yaml</code> | Path to the list of subaccount IDs that are allowed to bypass quota restrictions |
 | **APP_REGIONS_&#x200b;SUPPORTING_MACHINE_&#x200b;FILE_PATH** | <code>/config/regionsSupportingMachine.yaml</code> | Path to the list of regions that support machine-type selection |
 | **APP_RUNTIME_&#x200b;CONFIGURATION_&#x200b;CONFIG_MAP_NAME** | None | Name of the ConfigMap with the default KymaCR template |

--- a/docs/contributor/02-50-external-validations.md
+++ b/docs/contributor/02-50-external-validations.md
@@ -1,20 +1,24 @@
 # External Validations: Kyma Instances Quota
 
 Each service or environment is responsible for managing its own quota usage. During provisioning requests, Kyma Environment Broker (KEB) initiates a call 
-to the Provisioning Service to retrieve the assigned quota for the target subaccount and plan. These calls are also made during update requests if the plan changes.
+to the Entitlements Service to retrieve the assigned quota for the target subaccount and plan. These calls are also made during update requests if the plan changes.
 If the assigned quota is less than or equal to the number of instances stored in the database, the request fails. 
 
 The quota check is only performed when there is more than one Kyma environment per subaccount and the subaccount ID is not whitelisted. If the request to 
-the Provisioning Service fails, it is retried at configured intervals. If the retries are unsuccessful, the provisioning or update request is rejected.
+the Entitlements Service fails, it is retried at configured intervals. If the retries are unsuccessful, the provisioning or update request is rejected.
 
 The following configuration enables quota limit checks and specifies the required URLs, credentials, and retry behavior. 
 Whitelisted subaccount IDs are excluded from quota validation.
 ```yaml
 cis:
-  v2:
+  entitlements:
     authURL: "https://authentication-service.com"
-    secretName: "cis-creds-v2"
-    provisioningServiceURL: "https://provisioning-service.com"
+    id: "client-id"
+    secret: "client-secret"
+    secretName: "cis-creds-entitlements"
+    serviceURL: "https://entitlements-service.com"
+    clientIdKey: id
+    secretKey: secret
 quotaLimitCheck:
   enabled: true
   interval: 1s

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -275,25 +275,25 @@ spec:
             - name: APP_PROVISIONING_WORKERS_AMOUNT
               value: "{{ .Values.provisioning.workersAmount }}"
             - name: APP_QUOTA_AUTH_URL
-              value: "{{ .Values.cis.v2.authURL }}"
+              value: "{{ .Values.cis.entitlements.authURL }}"
           {{- if .Values.quotaLimitCheck.enabled }}
             - name: APP_QUOTA_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.cis.v2.secretName }}"
-                  key: {{ .Values.cis.v2.clientIdKey }}
+                  name: "{{ .Values.cis.entitlements.secretName }}"
+                  key: {{ .Values.cis.entitlements.clientIdKey }}
             - name: APP_QUOTA_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.cis.v2.secretName }}"
-                  key: {{ .Values.cis.v2.secretKey }}
+                  name: "{{ .Values.cis.entitlements.secretName }}"
+                  key: {{ .Values.cis.entitlements.secretKey }}
           {{- end }}
             - name: APP_QUOTA_INTERVAL
               value: "{{ .Values.quotaLimitCheck.interval }}"
             - name: APP_QUOTA_RETRIES
               value: "{{ .Values.quotaLimitCheck.retries }}"
             - name: APP_QUOTA_SERVICE_URL
-              value: "{{ .Values.cis.v2.provisioningServiceURL }}"
+              value: "{{ .Values.cis.entitlements.serviceURL }}"
             - name: APP_QUOTA_WHITELISTED_SUBACCOUNTS_FILE_PATH
               value: {{ .Values.configPaths.quotaWhitelistedSubaccountIds }}
             - name: APP_REGIONS_SUPPORTING_MACHINE_FILE_PATH

--- a/resources/keb/templates/secrets.yaml
+++ b/resources/keb/templates/secrets.yaml
@@ -38,5 +38,15 @@ type: Opaque
 data:
   id: {{ .Values.cis.accounts.id | required "please specify .Values.cis.accounts.id" | b64enc | quote }}
   secret: {{ .Values.cis.accounts.secret | required "please specify .Values.cis.accounts.secret " | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.cis.entitlements.secretName | required "please specify .Values.cis.entitlements.secretName" | quote }}
+  labels: {{ include "kyma-env-broker.labels" . | nindent 4 }}
+type: Opaque
+data:
+  id: {{ .Values.cis.entitlements.id | required "please specify .Values.cis.entitlements.id" | b64enc | quote }}
+  secret: {{ .Values.cis.entitlements.secret | required "please specify .Values.cis.entitlements.secret " | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -374,9 +374,9 @@ providersConfiguration: {}
 quotaLimitCheck:
   # If true, validates during provisioning that the assigned quota for the subaccount is not exceeded
   enabled: false
-  # The interval between requests to the Quota Assignments API in case of errors
+  # The interval between requests to the Entitlements API in case of errors
   interval: 1s
-  # The number of retry attempts made when the Quota Assignments API request fails
+  # The number of retry attempts made when the Entitlements API request fails
   retries: 5
 
 # List of subaccount IDs that have unlimited quota for Kyma runtimes.
@@ -496,13 +496,26 @@ cis:
     maxRequestRetries: "3"
     # The minimum interval between requests to the CIS v2 API in case of errors
     rateLimitingInterval: "2s"
-    # The endpoint URL for the CIS v2 provisioning service, used to fetch quota assignments
-    provisioningServiceURL: "TBD"
     # The interval between requests to the CIS v2 API
     requestInterval: "200ms"
     # The key in the Kubernetes Secret that contains the CIS v2 client ID
     clientIdKey: id
     # The key in the Kubernetes Secret that contains the CIS v2 client secret
+    secretKey: secret
+  entitlements:
+    # The OAuth2 token endpoint (authorization URL) used to obtain access tokens for authenticating requests to the CIS Entitlements API
+    authURL: "TBD"
+    # The OAuth2 client ID used for authenticating requests to the CIS Entitlements API
+    id: "TBD"
+    # The OAuth2 client secret used together with the client ID for authentication with the CIS Entitlements API
+    secret: "TBD"
+    # The name of the Kubernetes Secret containing the CIS Entitlements client ID and secret
+    secretName: "cis-creds-entitlements"
+    # The base URL of the CIS Entitlements API endpoint, used for fetching quota assignments
+    serviceURL: "TBD"
+    # The key in the Kubernetes Secret that contains the CIS Entitlements client ID
+    clientIdKey: id
+    # The key in the Kubernetes Secret that contains the CIS Entitlements client secret
     secretKey: secret
 # =================================================
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fetch numer of assigned quota from CIS `entitlements-service` instead of `provisioning-service`,
- adjust configuration to `entitlement-service`,
- update docs.

**Related issue(s)**
See also [#7375](https://github.tools.sap/kyma/backlog/issues/7375)
