### PR TITLE
Change kubeconfig context names

### DIFF
--- a/internal/kubeconfig/builder.go
+++ b/internal/kubeconfig/builder.go
@@ -177,6 +177,7 @@ func (b *Builder) getOidcDataFromRuntimeResource(id string, currentContext strin
 	if additionalConfigs == nil {
 		return nil, fmt.Errorf("Runtime Resource contains no additional OIDC config")
 	}
+	count := len(*additionalConfigs)
 	for i, config := range *additionalConfigs {
 		if config.IssuerURL == nil {
 			return nil, fmt.Errorf("Runtime Resource contains an empty OIDC issuer URL")
@@ -185,8 +186,8 @@ func (b *Builder) getOidcDataFromRuntimeResource(id string, currentContext strin
 			return nil, fmt.Errorf("Runtime Resource contains an empty OIDC client ID")
 		}
 		name := currentContext
-		if i > 0 {
-			name = fmt.Sprintf("%s-%d", currentContext, i+1)
+		if b.multipleContexts && count > 1 {
+			name = fmt.Sprintf("%s-%d", currentContext, i)
 		}
 		oidcConfigs = append(oidcConfigs, OIDCConfig{
 			Name:      name,

--- a/internal/kubeconfig/builder_test.go
+++ b/internal/kubeconfig/builder_test.go
@@ -428,16 +428,16 @@ clusters:
     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURUSUZJQ0FURS0tLS0tCg==
     server: https://api.ac0d8d9.kyma-dev.shoot.canary.k8s-hana.ondemand.com
 contexts:
-- name: shoot--kyma-dev--ac0d8d9
+- name: shoot--kyma-dev--ac0d8d9-0
   context:
     cluster: shoot--kyma-dev--ac0d8d9
-    user: shoot--kyma-dev--ac0d8d9
-- name: shoot--kyma-dev--ac0d8d9-2
+    user: shoot--kyma-dev--ac0d8d9-0
+- name: shoot--kyma-dev--ac0d8d9-1
   context:
     cluster: shoot--kyma-dev--ac0d8d9
-    user: shoot--kyma-dev--ac0d8d9-2
+    user: shoot--kyma-dev--ac0d8d9-1
 users:
-- name: shoot--kyma-dev--ac0d8d9
+- name: shoot--kyma-dev--ac0d8d9-0
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
@@ -458,7 +458,7 @@ users:
 
         # Chocolatey (Windows)
         choco install kubelogin
-- name: shoot--kyma-dev--ac0d8d9-2
+- name: shoot--kyma-dev--ac0d8d9-1
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
@@ -555,16 +555,16 @@ clusters:
     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURUSUZJQ0FURS0tLS0tCg==
     server: https://api.ac0d8d9.kyma-dev.shoot.canary.k8s-hana.ondemand.com
 contexts:
-- name: shoot--kyma-dev--admin
+- name: shoot--kyma-dev--admin-0
   context:
     cluster: shoot--kyma-dev--admin
-    user: shoot--kyma-dev--admin
-- name: shoot--kyma-dev--admin-2
+    user: shoot--kyma-dev--admin-0
+- name: shoot--kyma-dev--admin-1
   context:
     cluster: shoot--kyma-dev--admin
-    user: shoot--kyma-dev--admin-2
+    user: shoot--kyma-dev--admin-1
 users:
-- name: shoot--kyma-dev--admin
+- name: shoot--kyma-dev--admin-0
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
@@ -585,7 +585,7 @@ users:
 
         # Chocolatey (Windows)
         choco install kubelogin
-- name: shoot--kyma-dev--admin-2
+- name: shoot--kyma-dev--admin-1
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Add suffixes starting from 0 to kubeconfig context if there are more than 1 OIDC configs
- Add no suffix if there is only one OIDC config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
