### PR TITLE
Change jobs restart policy to onFailure

### DIFF
--- a/resources/keb/templates/deprovision-retrigger-job.yaml
+++ b/resources/keb/templates/deprovision-retrigger-job.yaml
@@ -16,7 +16,7 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           {{- if ne .Values.imagePullSecret "" }}
           imagePullSecrets:
             - name: {{ .Values.imagePullSecret }}

--- a/resources/keb/templates/free-cleanup-job.yaml
+++ b/resources/keb/templates/free-cleanup-job.yaml
@@ -16,7 +16,7 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           {{- if ne .Values.imagePullSecret "" }}
           imagePullSecrets:
             - name: {{ .Values.imagePullSecret }}

--- a/resources/keb/templates/migrator-job.yaml
+++ b/resources/keb/templates/migrator-job.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
       shareProcessNamespace: true
       {{- if ne .Values.imagePullSecret "" }}
       imagePullSecrets:

--- a/resources/keb/templates/service-binding-cleanup-job.yaml
+++ b/resources/keb/templates/service-binding-cleanup-job.yaml
@@ -17,7 +17,7 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           {{- if ne .Values.imagePullSecret "" }}
           imagePullSecrets:
             - name: {{ .Values.imagePullSecret }}

--- a/resources/keb/templates/subaccount-cleanup-job.yaml
+++ b/resources/keb/templates/subaccount-cleanup-job.yaml
@@ -23,7 +23,7 @@ spec:
           {{ end }}
         spec:
           serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           shareProcessNamespace: true
           {{- with .Values.deployment.securityContext }}
           securityContext:
@@ -166,7 +166,7 @@ spec:
             cronjob: subaccount-cleaner-v2.0
         spec:
           serviceAccountName: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           shareProcessNamespace: true
           {{- with .Values.deployment.securityContext }}
           securityContext:

--- a/resources/keb/templates/trial-cleanup-job.yaml
+++ b/resources/keb/templates/trial-cleanup-job.yaml
@@ -16,7 +16,7 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           {{- if ne .Values.imagePullSecret "" }}
           imagePullSecrets:
             - name: {{ .Values.imagePullSecret }}

--- a/utils/archiver/kyma-environment-broker-archiver.yaml
+++ b/utils/archiver/kyma-environment-broker-archiver.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: kcp-kyma-environment-broker
       securityContext:
         runAsUser: 2000
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: kyma-environments-broker-archiver
           command: ["/bin/main"]

--- a/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
+++ b/utils/kyma-environments-cleanup-job/kyma-environments-cleanup-job.yaml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: kcp-kyma-environment-broker
           securityContext:
             runAsUser: 2000
-          restartPolicy: Never
+          restartPolicy: OnFailure
           containers:
             - name: kyma-environments-cleanup
               command: ["/bin/main"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Our jobs sometimes encounter transient errors when a container exits with non 0 status code and the pod gets stuck in progress state. This blocks promotions. Changing restartPolicy to `onFailure` will restart the container up to 6 times (kubernetes default) before failing permanently.

Changes proposed in this pull request:
- Change jobs restart policy to onFailure

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #2194 