### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/build-e2e-provisioning-test-image.yaml
+++ b/.github/workflows/build-e2e-provisioning-test-image.yaml
@@ -24,4 +24,3 @@ jobs:
       name: e2e-provisioning-test
       dockerfile: Dockerfile
       context: testing/e2e/provisioning
-      build-engine: buildx

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -91,7 +91,6 @@ jobs:
       dockerfile: Dockerfile.keb
       context: .
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-archiver-image:
     needs: [validate-release]
@@ -102,7 +101,6 @@ jobs:
       context: .
       build-args: BIN=archiver
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-environments-cleanup-image:
     needs: [validate-release]
@@ -113,7 +111,6 @@ jobs:
       context: .
       build-args: BIN=environmentscleanup
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-deprovision-retrigger-image:
     needs: [validate-release]
@@ -124,7 +121,6 @@ jobs:
       context: .
       build-args: BIN=deprovisionretrigger
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-expirator-image:
     needs: [validate-release]
@@ -135,7 +131,6 @@ jobs:
       context: .
       build-args: BIN=expirator
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-runtime-reconciler-image:
     needs: [validate-release]
@@ -146,7 +141,6 @@ jobs:
       context: .
       build-args: BIN=runtime-reconciler
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-subaccount-cleanup-image:
     needs: [validate-release]
@@ -157,7 +151,6 @@ jobs:
       context: .
       build-args: BIN=accountcleanup
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-subaccount-sync-image:
     needs: [validate-release]
@@ -168,7 +161,6 @@ jobs:
       context: .
       build-args: BIN=subaccount-sync
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-globalaccounts-image:
       needs: [validate-release]
@@ -179,7 +171,6 @@ jobs:
          context: .
          build-args: BIN=globalaccounts
          tags: ${{ inputs.name }}
-         build-engine: buildx
 
   build-schema-migrator-image:
     needs: [ validate-release ]
@@ -189,7 +180,6 @@ jobs:
       dockerfile: Dockerfile.schemamigrator
       context: .
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   build-service-binding-cleanup-image:
     needs: [ validate-release ]
@@ -200,7 +190,6 @@ jobs:
       context: .
       build-args: BIN=servicebindingcleanup
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   run-keb-chart-integration-tests:
     name: Validate KEB chart 

--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -17,7 +17,6 @@ jobs:
       name:  kyma-environment-broker
       dockerfile: Dockerfile.keb
       context: .
-      build-engine: buildx
 
    archiver-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -26,7 +25,6 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=archiver
-         build-engine: buildx
 
    environments-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -35,7 +33,6 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=environmentscleanup
-         build-engine: buildx
 
    deprovision-retrigger-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -44,7 +41,6 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=deprovisionretrigger
-         build-engine: buildx
 
    expirator-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -53,7 +49,6 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=expirator
-         build-engine: buildx
 
    runtime-reconciler-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -62,7 +57,6 @@ jobs:
          dockerfile: Dockerfile.runtimereconciler
          context: .
          build-args: BIN=runtime-reconciler
-         build-engine: buildx
 
    subaccount-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -71,7 +65,6 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=accountcleanup
-         build-engine: buildx
 
    subaccount-sync-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -80,7 +73,6 @@ jobs:
          dockerfile: Dockerfile.subaccountsync
          context: .
          build-args: BIN=subaccount-sync
-         build-engine: buildx
 
    globalaccounts-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -89,7 +81,6 @@ jobs:
          dockerfile: Dockerfile.globalaccounts
          context: .
          build-args: BIN=globalaccounts
-         build-engine: buildx
 
    schema-migrator-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -97,7 +88,6 @@ jobs:
          name: kyma-environment-broker-schema-migrator
          dockerfile: Dockerfile.schemamigrator
          context: .
-         build-engine: buildx
 
    service-binding-cleanup-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
@@ -106,4 +96,3 @@ jobs:
          dockerfile: Dockerfile.job
          context: .
          build-args: BIN=servicebindingcleanup
-         build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.