### PR TITLE
reduce toYaml to avoid unnecessary argo-cd sync 

### DIFF
--- a/resources/keb/templates/app-config.yaml
+++ b/resources/keb/templates/app-config.yaml
@@ -31,9 +31,13 @@ data:
     rule:
 {{ toYaml .Values.hap.rule | indent 4  }}
   providersConfig.yaml: |-
-{{ toYaml .Values.providersConfiguration | indent 4 }}
+{{- with .Values.providersConfiguration }}
+{{ tpl . $ | indent 4 }}
+{{- end }}
   plansConfig.yaml: |-
-{{ toYaml .Values.plansConfiguration | indent 4 }}
+{{- with .Values.plansConfiguration }}
+{{ tpl . $ | indent 4 }}
+{{- end }}
   quotaWhitelistedSubaccountIds.yaml: |-
 {{- with .Values.quotaWhitelistedSubaccountIds }}
 {{ tpl . $ | indent 4 }}

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -363,13 +363,13 @@ metricsv2:
 # If true, generates kubeconfig files with multiple contexts (if possible) instead of a single context
 multipleContexts: false
 
-plansConfiguration: {}
+plansConfiguration: |-
 
 profiler:
   # Enables memory profiler (true/false)
   memory: false
 
-providersConfiguration: {}
+providersConfiguration: |-
 
 quotaLimitCheck:
   # If true, validates during provisioning that the assigned quota for the subaccount is not exceeded


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

currently, the `keb` argo-cd application gets synced whenever there is a change committed to the mp-config repo, which is causing many unnecessary syncs. this is because in the configmap `kcp-system/kcp-kyma-environment-broker` helm yaml, it uses `toYaml` to converts maps to YAML, and `toYaml` can't guarantee the order of the map keys, so the order of these keys varies whenever there is a change committed to the mp-config repo and then the chart gets rendered even though there is no change to the keb Application. 

so this is to change `providersConfiguration` and `plansConfiguration` from map to string, to keep the order unchanged.

details also found in https://github.tools.sap/kyma/backlog/issues/7319#issuecomment-14378334

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
