### PR TITLE
Remove `enableShootAndSeedSameRegion` feature flag

### DIFF
--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -20,7 +20,6 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_BROKER_ENABLE_&#x200b;JWKS** | <code>false</code> | If true, enables the handling of the encoded JWKS array, temporary feature flag |
 | **APP_BROKER_ENABLE_&#x200b;PLANS** | <code>azure,gcp,azure_lite,trial,aws</code> | Comma-separated list of plan names enabled and available for provisioning in KEB |
 | **APP_BROKER_ENABLE_&#x200b;PLAN_UPGRADES** | <code>false</code> | If true, allows users to upgrade their plans (if a plan supports upgrades) |
-| **APP_BROKER_ENABLE_&#x200b;SHOOT_AND_SEED_SAME_&#x200b;REGION** | <code>false</code> | If true, enforces that the Gardener seed is placed in the same region as the shoot region selected during provisioning |
 | **APP_BROKER_FREE_&#x200b;DOCS_URL** | <code>https://help.sap.com/docs/</code> | URL to the documentation of free Kyma runtimes. Used in API responses and UI labels to direct users to help or documentation about free plans |
 | **APP_BROKER_FREE_&#x200b;EXPIRATION_PERIOD** | <code>720h</code> | Determines when to show expiration info to users |
 | **APP_BROKER_GARDENER_&#x200b;SEEDS_CACHE_CONFIG_&#x200b;MAP_NAME** | <code>gardener-seeds-cache</code> | Name of the Kubernetes ConfigMap used as a cache for Gardener seeds |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -42,7 +42,6 @@ type Config struct {
 	FreeExpirationPeriod                    time.Duration `envconfig:"default=720h"` // 30 days
 	SubaccountsIdsToShowTrialExpirationInfo string        `envconfig:"default="`
 	TrialDocsURL                            string        `envconfig:"default="`
-	EnableShootAndSeedSameRegion            bool          `envconfig:"default=false"`
 	AllowUpdateExpiredInstanceWithContext   bool          `envconfig:"default=false"`
 	DefaultRequestRegion                    string        `envconfig:"default=cf-eu10"`
 	// OperationTimeout is used to check on a top-level if any operation didn't exceed the time for processing.

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -3494,7 +3494,6 @@ func newSchemaService(t *testing.T) *broker.SchemaService {
 
 	schemaService := broker.NewSchemaService(provider, plans, nil, broker.Config{
 		IncludeAdditionalParamsInSchema: true,
-		EnableShootAndSeedSameRegion:    true,
 		UseAdditionalOIDCSchema:         true,
 	}, broker.EnablePlans{broker.TrialPlanName, broker.AzurePlanName, broker.AzureLitePlanName, broker.AWSPlanName,
 		broker.GCPPlanName, broker.SapConvergedCloudPlanName, broker.FreemiumPlanName})

--- a/internal/broker/plans.go
+++ b/internal/broker/plans.go
@@ -71,17 +71,15 @@ var PlanIDsMapping = map[string]string{
 type ControlFlagsObject struct {
 	includeAdditionalParameters bool
 	useAdditionalOIDCSchema     bool
-	shootAndSeedFeatureEnabled  bool
 	ingressFilteringEnabled     bool
 	rejectUnsupportedParameters bool
 	enableJwks                  bool
 }
 
-func NewControlFlagsObject(includeAdditionalParameters, useAdditionalOIDC, shootAndSeedEnabled, ingressFilteringEnabled, rejectUnsupportedParameters, enableJwks bool) ControlFlagsObject {
+func NewControlFlagsObject(includeAdditionalParameters, useAdditionalOIDC, ingressFilteringEnabled, rejectUnsupportedParameters, enableJwks bool) ControlFlagsObject {
 	return ControlFlagsObject{
 		includeAdditionalParameters: includeAdditionalParameters,
 		useAdditionalOIDCSchema:     useAdditionalOIDC,
-		shootAndSeedFeatureEnabled:  shootAndSeedEnabled,
 		ingressFilteringEnabled:     ingressFilteringEnabled,
 		rejectUnsupportedParameters: rejectUnsupportedParameters,
 		enableJwks:                  enableJwks,
@@ -152,9 +150,6 @@ func createSchemaWithProperties(properties ProvisioningProperties,
 			properties.OIDC = NewOIDCSchema(flags.rejectUnsupportedParameters, flags.enableJwks)
 		}
 		properties.Administrators = AdministratorsProperty()
-		if flags.shootAndSeedFeatureEnabled {
-			properties.ColocateControlPlane = ColocateControlPlaneProperty()
-		}
 		if flags.ingressFilteringEnabled {
 			properties.IngressFiltering = IngressFilteringProperty()
 		}

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -623,8 +623,9 @@ func NewProvisioningProperties(machineTypesDisplay, additionalMachineTypesDispla
 			EnumDisplayName: regionsDisplay,
 			MinLength:       1,
 		},
-		Networking: NewNetworkingSchema(rejectUnsupportedParameters),
-		Modules:    NewModulesSchema(rejectUnsupportedParameters),
+		Networking:           NewNetworkingSchema(rejectUnsupportedParameters),
+		Modules:              NewModulesSchema(rejectUnsupportedParameters),
+		ColocateControlPlane: ColocateControlPlaneProperty(),
 	}
 
 	if update {

--- a/internal/broker/plans_test.go
+++ b/internal/broker/plans_test.go
@@ -156,7 +156,6 @@ func createSchemaService(t *testing.T) *SchemaService {
 
 	schemaService := NewSchemaService(provider, plans, nil, Config{
 		IncludeAdditionalParamsInSchema: true,
-		EnableShootAndSeedSameRegion:    true,
 		UseAdditionalOIDCSchema:         false,
 		RejectUnsupportedParameters:     true,
 		EnablePlanUpgrades:              true,

--- a/internal/broker/schemas.go
+++ b/internal/broker/schemas.go
@@ -255,7 +255,6 @@ func (s *SchemaService) FreeSchema(provider pkg.CloudProvider, platformRegion st
 		regionsDisplayNames = s.providerSpec.RegionDisplayNames(pkg.AWS, regions)
 	}
 	flags := s.createFlags(FreemiumPlanName)
-	flags.shootAndSeedFeatureEnabled = false
 
 	properties := ProvisioningProperties{
 		Name: NameProperty(),
@@ -282,7 +281,6 @@ func (s *SchemaService) FreeSchemas(provider pkg.CloudProvider, platformRegion s
 
 func (s *SchemaService) TrialSchema(update bool) *map[string]interface{} {
 	flags := s.createFlags(TrialPlanName)
-	flags.shootAndSeedFeatureEnabled = false
 
 	properties := ProvisioningProperties{
 		Name: NameProperty(),
@@ -321,7 +319,6 @@ func (s *SchemaService) createFlags(planName string) ControlFlagsObject {
 	return NewControlFlagsObject(
 		s.cfg.IncludeAdditionalParamsInSchema,
 		s.cfg.UseAdditionalOIDCSchema,
-		s.cfg.EnableShootAndSeedSameRegion,
 		s.ingressFilteringPlans.Contains(planName),
 		s.cfg.RejectUnsupportedParameters,
 		s.cfg.EnableJwks,

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -107,8 +107,6 @@ spec:
               value: "{{ .Values.broker.enablePlans }}"
             - name: APP_BROKER_ENABLE_PLAN_UPGRADES
               value: "{{ .Values.broker.enablePlanUpgrades }}"
-            - name: APP_BROKER_ENABLE_SHOOT_AND_SEED_SAME_REGION
-              value: "{{ .Values.broker.enableShootAndSeedSameRegion }}"
             - name: APP_BROKER_FREE_DOCS_URL
               value: "{{ .Values.broker.freeDocsURL }}"
             - name: APP_BROKER_FREE_EXPIRATION_PERIOD

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -166,8 +166,6 @@ broker:
   enablePlans: "azure,gcp,azure_lite,trial,aws"
   # If true, allows users to upgrade their plans (if a plan supports upgrades)
   enablePlanUpgrades: "false"
-  # If true, enforces that the Gardener seed is placed in the same region as the shoot region selected during provisioning
-  enableShootAndSeedSameRegion: "false"
   # URL to the documentation of free Kyma runtimes. Used in API responses and UI labels to direct users to help or documentation about free plans
   freeDocsURL: "https://help.sap.com/docs/"
   # Determines when to show expiration info to users


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- the `enableShootAndSeedSameRegion` flag is enabled in all environments, so it can be safely removed from the code.
