### PR TITLE
Wait for bump commit to be available via api

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -306,6 +306,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$PR_NUMBER" -gt 0 ]; then
+            # Sometimes the commit is not available immediately after merging the PR, so we wait a bit
+            sleep 5
             COMMIT_SHA=$(gh api repos/${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}/commits -q '.[1].sha')
             echo "Latest commit sha: $COMMIT_SHA"
             echo "Bump sha: ${{ github.sha }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Sometimes the GitHub api is not fast enough and doesn't show a new commit. This breaks one of the check in the release workflow where we check if a PR was merged during release. Example where the issue occured https://github.com/kyma-project/kyma-environment-broker/actions/runs/17062115727/job/48371887232

Changes proposed in this pull request:

- Wait a bit after merging the bump PR before calling API

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
