### PR TITLE
Bump go to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker
 
-go 1.24.5
+go 1.25.0
 
 require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible

--- a/testing/e2e/provisioning/Dockerfile
+++ b/testing/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.5-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0-alpine3.22 AS builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/kyma-environment-broker/tests/e2e/provisioning
 

--- a/testing/e2e/provisioning/go.mod
+++ b/testing/e2e/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/provisioning
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/testing/e2e/skr/provisioning-service-test/go.mod
+++ b/testing/e2e/skr/provisioning-service-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/skr/provisioning-service-test
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump go to [1.25.0](https://go.dev/doc/go1.25)
