### PR TITLE
Introduce ZonesDiscovery feature flag

### DIFF
--- a/internal/broker/schemas.go
+++ b/internal/broker/schemas.go
@@ -42,7 +42,7 @@ func (s *SchemaService) Validate() error {
 			continue
 		}
 		for _, region := range regions {
-			err := s.providerSpec.Validate(provider, region)
+			err := s.providerSpec.Validate(provider, planName, region)
 			if err != nil {
 				return err
 			}

--- a/internal/broker/schemas_test.go
+++ b/internal/broker/schemas_test.go
@@ -1,6 +1,8 @@
 package broker
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -104,6 +106,113 @@ gcp:
 	assert.Error(t, err)
 }
 
+func TestNewSchemaService_validation_ZonesDiscoveryEnabledForNotAWSProvider(t *testing.T) {
+	// Given
+	plans, err := configuration.NewPlanSpecifications(strings.NewReader(`
+gcp,build-runtime-gcp:
+        regions:
+            default:
+                - europe-west3
+`))
+	require.NoError(t, err)
+	providers, err := configuration.NewProviderSpec(strings.NewReader(`
+gcp:
+  zonesDiscovery: true
+  regions:
+    europe-west3:
+      displayName: europe-west3 (Europe, Frankfurt)
+`))
+	require.NoError(t, err)
+	svc := NewSchemaService(providers, plans, nil, Config{}, EnablePlans{"aws"})
+
+	// When
+	err = svc.Validate()
+
+	// then
+	assert.EqualError(t, err, "zone discovery is not yet supported for the GCP provider")
+}
+
+func TestNewSchemaService_validation_ZonesDiscoveryEnabled(t *testing.T) {
+	// Given
+	plans, err := configuration.NewPlanSpecifications(strings.NewReader(`
+aws,build-runtime-aws:
+        regions:
+            cf-eu11:
+                - eu-central-1
+            default:
+                - eu-west-1
+`))
+	require.NoError(t, err)
+	providers, err := configuration.NewProviderSpec(strings.NewReader(`
+aws:
+  zonesDiscovery: true
+  regions:
+    eu-central-1:
+      displayName: "eu-central-1"
+    eu-west-1:
+      displayName: "eu-west-1"
+  regionsSupportingMachine:
+    g6:
+      eu-central-1:
+`))
+	require.NoError(t, err)
+	svc := NewSchemaService(providers, plans, nil, Config{}, EnablePlans{"gcp"})
+
+	// When
+	err = svc.Validate()
+
+	// then
+	assert.NoError(t, err)
+}
+
+func TestNewSchemaService_validation_ZonesDiscoveryEnabledAndStaticZonesDefined(t *testing.T) {
+	cw := &captureWriter{buf: &bytes.Buffer{}}
+	handler := slog.NewTextHandler(cw, nil)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	// Given
+	plans, err := configuration.NewPlanSpecifications(strings.NewReader(`
+aws,build-runtime-aws:
+        regions:
+            cf-eu11:
+                - eu-central-1
+            default:
+                - eu-west-1
+`))
+	require.NoError(t, err)
+	providers, err := configuration.NewProviderSpec(strings.NewReader(`
+aws:
+  zonesDiscovery: true
+  regions:
+    eu-central-1:
+      displayName: "eu-central-1"
+      zones: ["a", "b"]
+    eu-west-1:
+      displayName: "eu-west-1"
+      zones: ["a", "b", "c"]
+  regionsSupportingMachine:
+    g6:
+      eu-central-1: ["a", "b", "c", "d"]
+`))
+	require.NoError(t, err)
+	svc := NewSchemaService(providers, plans, nil, Config{}, EnablePlans{"aws"})
+
+	// When
+	err = svc.Validate()
+
+	// then
+	assert.NoError(t, err)
+
+	logContents := cw.buf.String()
+	assert.Contains(t, logContents, "Provider AWS (plan aws) has zones discovery enabled, but region eu-central-1 is configured with 2 static zones, which will be ignored.")
+	assert.Contains(t, logContents, "Provider AWS (plan aws) has zones discovery enabled, but region eu-west-1 is configured with 3 static zones, which will be ignored.")
+	assert.Contains(t, logContents, "Provider AWS (plan aws) has zones discovery enabled, but machine type g6 in region eu-central-1 is configured with 4 static zones, which will be ignored.")
+	assert.Contains(t, logContents, "Provider AWS (plan build-runtime-aws) has zones discovery enabled, but region eu-central-1 is configured with 2 static zones, which will be ignored.")
+	assert.Contains(t, logContents, "Provider AWS (plan build-runtime-aws) has zones discovery enabled, but region eu-west-1 is configured with 3 static zones, which will be ignored.")
+	assert.Contains(t, logContents, "Provider AWS (plan build-runtime-aws) has zones discovery enabled, but machine type g6 in region eu-central-1 is configured with 4 static zones, which will be ignored.")
+}
+
 func TestSchemaPlans(t *testing.T) {
 	// Given
 	schemaService := createSchemaService(t)
@@ -141,4 +250,12 @@ aws,build-runtime-aws:
 
 	require.NoError(t, err)
 	assert.False(t, plansSpec.IsUpgradable("aws"))
+}
+
+type captureWriter struct {
+	buf *bytes.Buffer
+}
+
+func (c *captureWriter) Write(p []byte) (n int, err error) {
+	return c.buf.Write(p)
 }

--- a/internal/provider/configuration/provider.go
+++ b/internal/provider/configuration/provider.go
@@ -3,6 +3,7 @@ package configuration
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"strings"
@@ -26,6 +27,7 @@ type providerDTO struct {
 	Regions             map[string]regionDTO     `yaml:"regions"`
 	MachineDisplayNames map[string]string        `yaml:"machines"`
 	SupportingMachines  RegionsSupportingMachine `yaml:"regionsSupportingMachine,omitempty"`
+	ZonesDiscovery      bool                     `yaml:"zonesDiscovery"`
 }
 
 type dto map[runtime.CloudProvider]providerDTO
@@ -137,13 +139,28 @@ func (p *ProviderSpec) findProviderDTO(cp runtime.CloudProvider) *providerDTO {
 	return nil
 }
 
-func (p *ProviderSpec) Validate(provider runtime.CloudProvider, region string) error {
+func (p *ProviderSpec) Validate(provider runtime.CloudProvider, planName, region string) error {
 	if dto := p.findRegion(provider, region); dto != nil {
-		if dto.Zones == nil || len(dto.Zones) == 0 {
+		providerDTO := p.findProviderDTO(provider)
+		if providerDTO.ZonesDiscovery && provider != runtime.AWS {
+			return fmt.Errorf("zone discovery is not yet supported for the %s provider", provider)
+		}
+		if !providerDTO.ZonesDiscovery && (dto.Zones == nil || len(dto.Zones) == 0) {
 			return fmt.Errorf("region %s for provider %s has no zones defined", region, provider)
 		}
 		if dto.DisplayName == "" {
 			return fmt.Errorf("region %s for provider %s has no display name defined", region, provider)
+		}
+		if providerDTO.ZonesDiscovery {
+			if len(dto.Zones) > 0 {
+				slog.Warn(fmt.Sprintf("Provider %s (plan %s) has zones discovery enabled, but region %s is configured with %d static zones, which will be ignored.", provider, planName, region, len(dto.Zones)))
+			}
+			for machineType, regionZones := range providerDTO.SupportingMachines {
+				zones := regionZones[region]
+				if len(zones) > 0 {
+					slog.Warn(fmt.Sprintf("Provider %s (plan %s) has zones discovery enabled, but machine type %s in region %s is configured with %d static zones, which will be ignored.", provider, planName, machineType, region, len(zones)))
+				}
+			}
 		}
 		return nil
 	}

--- a/internal/provider/configuration/provider.go
+++ b/internal/provider/configuration/provider.go
@@ -195,3 +195,11 @@ func (p *ProviderSpec) RegionSupportingMachine(providerType string) (internal.Re
 	}
 	return providerData.SupportingMachines, nil
 }
+
+func (p *ProviderSpec) ZonesDiscovery(cp runtime.CloudProvider) bool {
+	providerData := p.findProviderDTO(cp)
+	if providerData == nil {
+		return false
+	}
+	return providerData.ZonesDiscovery
+}

--- a/internal/provider/configuration/provider_test.go
+++ b/internal/provider/configuration/provider_test.go
@@ -83,8 +83,8 @@ func TestProviderSpec_Validation(t *testing.T) {
 
 	// when / then
 
-	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "eu-central-1"), "region eu-central-1 for provider aws has no zones defined")
-	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "eu-west-2"), "region eu-west-2 for provider aws has no zones defined")
-	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "eu-west-1"), "region eu-west-1 for provider aws has no display name defined")
-	assert.NoError(t, providerSpec.Validate(runtime.AWS, "us-east-1"))
+	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "aws", "eu-central-1"), "region eu-central-1 for provider aws has no zones defined")
+	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "aws", "eu-west-2"), "region eu-west-2 for provider aws has no zones defined")
+	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "aws", "eu-west-1"), "region eu-west-1 for provider aws has no display name defined")
+	assert.NoError(t, providerSpec.Validate(runtime.AWS, "aws", "us-east-1"))
 }

--- a/internal/provider/configuration/provider_test.go
+++ b/internal/provider/configuration/provider_test.go
@@ -88,3 +88,101 @@ func TestProviderSpec_Validation(t *testing.T) {
 	assert.Errorf(t, providerSpec.Validate(runtime.AWS, "aws", "eu-west-1"), "region eu-west-1 for provider aws has no display name defined")
 	assert.NoError(t, providerSpec.Validate(runtime.AWS, "aws", "us-east-1"))
 }
+
+func TestProviderSpec_ZonesDiscovery(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputYAML  string
+		provider   runtime.CloudProvider
+		wantResult bool
+	}{
+		{
+			name: "zonesDiscovery true",
+			inputYAML: `
+  aws:
+    zonesDiscovery: true
+    regions:
+      eu-central-1:
+        displayName: "eu-central-1 (Europe, Frankfurt)"
+        zones: []
+      eu-west-2:
+        displayName: "eu-west-2 (Europe, London)"
+      eu-west-1: 
+        zones: [ "a", "b", "c" ]
+      us-east-1:
+        displayName: "us-east-1 (US, Virginia)"
+        zones: [ "a", "b", "c" ]
+`,
+			provider:   runtime.AWS,
+			wantResult: true,
+		},
+		{
+			name: "zonesDiscovery false",
+			inputYAML: `
+  aws:
+    zonesDiscovery: false
+    regions:
+      eu-central-1:
+        displayName: "eu-central-1 (Europe, Frankfurt)"
+        zones: []
+      eu-west-2:
+        displayName: "eu-west-2 (Europe, London)"
+      eu-west-1: 
+        zones: [ "a", "b", "c" ]
+      us-east-1:
+        displayName: "us-east-1 (US, Virginia)"
+        zones: [ "a", "b", "c" ]
+`,
+			provider:   runtime.AWS,
+			wantResult: false,
+		},
+		{
+			name: "zonesDiscovery missing field",
+			inputYAML: `
+  aws:
+    regions:
+      eu-central-1:
+        displayName: "eu-central-1 (Europe, Frankfurt)"
+        zones: []
+      eu-west-2:
+        displayName: "eu-west-2 (Europe, London)"
+      eu-west-1: 
+        zones: [ "a", "b", "c" ]
+      us-east-1:
+        displayName: "us-east-1 (US, Virginia)"
+        zones: [ "a", "b", "c" ]
+`,
+			provider:   runtime.AWS,
+			wantResult: false,
+		},
+		{
+			name: "zonesDiscovery missing provider",
+			inputYAML: `
+  aws:
+    regions:
+      eu-central-1:
+        displayName: "eu-central-1 (Europe, Frankfurt)"
+        zones: []
+      eu-west-2:
+        displayName: "eu-west-2 (Europe, London)"
+      eu-west-1: 
+        zones: [ "a", "b", "c" ]
+      us-east-1:
+        displayName: "us-east-1 (US, Virginia)"
+        zones: [ "a", "b", "c" ]
+`,
+			provider:   runtime.GCP,
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerSpec, err := NewProviderSpec(strings.NewReader(tt.inputYAML))
+			require.NoError(t, err)
+
+			got := providerSpec.ZonesDiscovery(tt.provider)
+			assert.Equal(t, tt.wantResult, got)
+		})
+	}
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add a `zonesDiscovery` feature flag,
- prevent KEB from starting when `zonesDiscovery` is enabled on providers other than AWS,
- log a warning if `zonesDiscovery` is enabled while static zones are still defined.

**Related issue(s)**
See also [#7745](https://github.tools.sap/kyma/backlog/issues/7745)
