### PR TITLE
Handle nil and empty AdditionalWorkerNodePools array during provisioning

### DIFF
--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -220,14 +220,12 @@ func (s *CreateRuntimeResourceStep) createShootProvider(operation *internal.Oper
 		}
 	}
 
-	if operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools != nil {
-		additionalWorkers, err := s.workersProvider.CreateAdditionalWorkers(values, nil, operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools,
-			values.Zones, operation.ProvisioningParameters.PlanID)
-		if err != nil {
-			return imv1.Provider{}, fmt.Errorf("while creating additional workers: %w", err)
-		}
-		provider.AdditionalWorkers = &additionalWorkers
+	additionalWorkers, err := s.workersProvider.CreateAdditionalWorkers(values, nil, operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools,
+		values.Zones, operation.ProvisioningParameters.PlanID)
+	if err != nil {
+		return imv1.Provider{}, fmt.Errorf("while creating additional workers: %w", err)
 	}
+	provider.AdditionalWorkers = &additionalWorkers
 
 	return provider, nil
 }

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -1213,7 +1213,8 @@ func TestCreateRuntimeResourceStep_AdditionalWorkersNilHandling(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, runtime.Name, operation.RuntimeID)
 
-	assert.Nil(t, runtime.Spec.Shoot.Provider.AdditionalWorkers)
+	assert.NotNil(t, runtime.Spec.Shoot.Provider.AdditionalWorkers)
+	assert.Empty(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers)
 }
 
 func TestCreateRuntimeResourceStep_AdditionalWorkersEmptyHandling(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Handle nil and empty AdditionalWorkerNodePools array during provisioning the same as during updating. When nil always insert empty array to RuntimeCR

Changes proposed in this pull request:

- Change handling
- Add tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #2327