### PR TITLE
Initialize provider values

### DIFF
--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/common/hyperscaler/rules"
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/config"
 	"github.com/kyma-project/kyma-environment-broker/internal/hyperscalers/aws"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
@@ -31,7 +32,7 @@ const (
 func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *process.StagedManager, workersAmount int, cfg *Config,
 	db storage.BrokerStorage, configProvider config.Provider,
 	k8sClientProvider provisioning.K8sClientProvider, k8sClient client.Client, gardenerClient *gardener.Client, defaultOIDC pkg.OIDCConfigDTO, logs *slog.Logger, rulesService *rules.RulesService,
-	workersProvider *workers.Provider, providerSpec *configuration.ProviderSpec, awsClientFactory aws.ClientFactory) *process.Queue {
+	workersProvider *workers.Provider, providerSpec *configuration.ProviderSpec, awsClientFactory aws.ClientFactory, valuesProvider broker.ValuesProvider) *process.Queue {
 
 	provisionManager.DefineStages([]string{startStageName, createRuntimeStageName,
 		checkKymaStageName, createKymaResourceStageName})
@@ -72,7 +73,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 		},
 		{
 			stage:     createRuntimeStageName,
-			step:      steps.NewDiscoverAvailableZonesStep(db, providerSpec, gardenerClient, awsClientFactory),
+			step:      steps.NewDiscoverAvailableZonesStep(db, valuesProvider, providerSpec, gardenerClient, awsClientFactory),
 			condition: provisioning.SkipForOwnClusterPlan,
 		},
 		{

--- a/cmd/broker/update.go
+++ b/cmd/broker/update.go
@@ -45,7 +45,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManage
 		},
 		{
 			stage:     "runtime_resource",
-			step:      steps.NewDiscoverAvailableZonesStep(db, providerSpec, gardenerClient, awsClientFactory),
+			step:      steps.NewDiscoverAvailableZonesStep(db, valuesProvider, providerSpec, gardenerClient, awsClientFactory),
 			condition: update.SkipForOwnClusterPlan,
 		},
 		{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- ensure `ProviderValues` is initialized in the `discoverAvailableZones` step when it is nil.

**Related issue(s)**
See also [#7806](https://github.tools.sap/kyma/backlog/issues/7806)
