### PR TITLE
Use toYamlPretty to render nested configs

### DIFF
--- a/resources/keb/templates/app-config.yaml
+++ b/resources/keb/templates/app-config.yaml
@@ -29,11 +29,11 @@ data:
 {{- end }}
   hapRule.yaml: |-
     rule:
-{{ toYaml .Values.hap.rule | indent 4  }}
+{{ toYamlPretty .Values.hap.rule | indent 4  }}
   providersConfig.yaml: |-
-{{ toYaml .Values.providersConfiguration | indent 4 }}
+{{ toYamlPretty .Values.providersConfiguration | indent 4 }}
   plansConfig.yaml: |-
-{{ toYaml .Values.plansConfiguration | indent 4 }}
+{{ toYamlPretty .Values.plansConfiguration | indent 4 }}
   quotaWhitelistedSubaccountIds.yaml: |-
 {{- with .Values.quotaWhitelistedSubaccountIds }}
 {{ tpl . $ | indent 4 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

The Helm `toYaml` template functuion doesn't produce consistent output for nested maps: https://github.com/helm/helm/issues/12537
After some research, it turned out that `toYamlPretty` produces consistent output regardless of the aphabetical order of map keys in input.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.tools.sap/kyma/backlog/issues/7870