### PR TITLE
Enhance validation of zones discovery

### DIFF
--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -407,6 +407,14 @@ func (f *fakeAWSClient) AvailableZones(ctx context.Context, machineType string) 
 	return f.zones[machineType], nil
 }
 
+func (f *fakeAWSClient) AvailableZonesCount(ctx context.Context, machineType string) (int, error) {
+	zones, err := f.AvailableZones(ctx, machineType)
+	if err != nil {
+		return 0, err
+	}
+	return len(zones), nil
+}
+
 func CreateGardenerClient() *gardener.Client {
 	const (
 		namespace   = "test"

--- a/internal/hyperscalers/aws/client.go
+++ b/internal/hyperscalers/aws/client.go
@@ -25,6 +25,7 @@ type ClientFactory interface {
 
 type Client interface {
 	AvailableZones(ctx context.Context, machineType string) ([]string, error)
+	AvailableZonesCount(ctx context.Context, machineType string) (int, error)
 }
 
 type EC2API interface {
@@ -86,6 +87,14 @@ func (c *AWSClient) AvailableZones(ctx context.Context, machineType string) ([]s
 	}
 
 	return zones, nil
+}
+
+func (c *AWSClient) AvailableZonesCount(ctx context.Context, machineType string) (int, error) {
+	zones, err := c.AvailableZones(ctx, machineType)
+	if err != nil {
+		return 0, err
+	}
+	return len(zones), nil
 }
 
 func ExtractCredentials(secret *unstructured.Unstructured) (string, string, error) {

--- a/internal/process/provisioning/resolve_subscription_secret.go
+++ b/internal/process/provisioning/resolve_subscription_secret.go
@@ -57,7 +57,7 @@ func (s *ResolveSubscriptionSecretStep) Run(operation internal.Operation, log *s
 	if targetSecretName == "" {
 		return s.operationManager.OperationFailed(operation, "failed to determine secret name", fmt.Errorf("target secret name is empty"), log)
 	}
-	log.Info(fmt.Sprintf("resolved secret name: %s", targetSecretName))
+	log.Info(fmt.Sprintf("resolved secret binding name: %s", targetSecretName))
 
 	err = s.updateInstance(operation.InstanceID, targetSecretName)
 	if err != nil {

--- a/internal/process/steps/discover_available_zones.go
+++ b/internal/process/steps/discover_available_zones.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"time"
 
 	"github.com/kyma-project/kyma-environment-broker/common/gardener"
@@ -100,6 +101,7 @@ func (s *DiscoverAvailableZonesStep) Run(operation internal.Operation, log *slog
 		if err != nil {
 			return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to get available zones for machine type %s", machineType), err, 10*time.Second, time.Minute, log)
 		}
+		rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
 		log.Info(fmt.Sprintf("Available zones for machine type %s: %v", machineType, zones))
 		operation.DiscoveredZones[machineType] = zones
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- reorder validation: first verify if the machine type is supported in `regionsSupportingMachine`, then validate the number of zones,
- add a map for discovered zone counts to prevent duplicate AWS calls,
- extract validation messages into a dedicated variable for reuse,
- introduce a helper function to return the number of available zones, removing reliance on fetched zones during validation,
- randomize zones in the `discover_available_zones step` to avoid always selecting the same ones,
- improve logging for better visibility and troubleshooting.

**Related issue(s)**
See also [#7745](https://github.tools.sap/kyma/backlog/issues/7745)