### PR TITLE
Update zones count in provider values

### DIFF
--- a/internal/provider/aws.go
+++ b/internal/provider/aws.go
@@ -70,9 +70,6 @@ func (p *AWSInputProvider) Provide() internal.ProviderValues {
 		region = *p.ProvisioningParameters.Parameters.Region
 	}
 	zones := AWSZones(region, p.ZonesProvider.RandomZones(pkg.AWS, region, zonesCount))
-	if len(zones) < zonesCount {
-		zonesCount = len(zones)
-	}
 	return internal.ProviderValues{
 		DefaultAutoScalerMax: 20,
 		DefaultAutoScalerMin: 3,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove check since **zonesCount** is always set to 0 when **zonesDiscovery** is enabled and zones are removed from the configuration.

**Related issue(s)**
See also [#7745](https://github.tools.sap/kyma/backlog/issues/7745)
