### PR TITLE
Use latest cluster name in response labels

### DIFF
--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -303,7 +303,7 @@ func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, de
 		OperationData: operation.ID,
 		DashboardURL:  dashboardURL,
 		Metadata: domain.InstanceMetadata{
-			Labels: ResponseLabels(operation, instance, b.config.URL, b.kcBuilder),
+			Labels: ResponseLabels(instance, b.config.URL, b.kcBuilder),
 		},
 	}, nil
 }
@@ -803,7 +803,7 @@ func (b *ProvisionEndpoint) handleExistingOperation(operation *internal.Provisio
 		OperationData: operation.ID,
 		DashboardURL:  operation.DashboardURL,
 		Metadata: domain.InstanceMetadata{
-			Labels: ResponseLabels(*operation, *instance, b.config.URL, b.kcBuilder),
+			Labels: ResponseLabels(*instance, b.config.URL, b.kcBuilder),
 		},
 	}, nil
 }

--- a/internal/broker/instance_get.go
+++ b/internal/broker/instance_get.go
@@ -77,16 +77,16 @@ func (b *GetInstanceEndpoint) GetInstance(_ context.Context, instanceID string, 
 		DashboardURL: instance.DashboardURL,
 		Parameters:   parameters,
 		Metadata: domain.InstanceMetadata{
-			Labels: ResponseLabels(*op, *instance, b.config.URL, b.kcBuilder),
+			Labels: ResponseLabels(*instance, b.config.URL, b.kcBuilder),
 		},
 	}
 
 	if instance.ServicePlanID == TrialPlanID {
-		spec.Metadata.Labels = ResponseLabelsWithExpirationInfo(*op, *instance, b.config.URL, b.config.TrialDocsURL, trialDocsKey, trialExpireDuration, trialExpiryDetailsKey, trialExpiredInfoFormat, b.kcBuilder)
+		spec.Metadata.Labels = ResponseLabelsWithExpirationInfo(*instance, b.config.URL, b.config.TrialDocsURL, trialDocsKey, trialExpireDuration, trialExpiryDetailsKey, trialExpiredInfoFormat, b.kcBuilder)
 	}
 
 	if instance.ServicePlanID == FreemiumPlanID {
-		spec.Metadata.Labels = ResponseLabelsWithExpirationInfo(*op, *instance, b.config.URL, b.config.FreeDocsURL, freeDocsKey, b.config.FreeExpirationPeriod, freeExpiryDetailsKey, freeExpiredInfoFormat, b.kcBuilder)
+		spec.Metadata.Labels = ResponseLabelsWithExpirationInfo(*instance, b.config.URL, b.config.FreeDocsURL, freeDocsKey, b.config.FreeExpirationPeriod, freeExpiryDetailsKey, freeExpiredInfoFormat, b.kcBuilder)
 	}
 
 	return spec, nil

--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -213,7 +213,7 @@ func (b *UpdateEndpoint) Update(ctx context.Context, instanceID string, details 
 		DashboardURL:  dashboardURL,
 		OperationData: "",
 		Metadata: domain.InstanceMetadata{
-			Labels: ResponseLabels(*lastProvisioningOperation, *instance, b.config.URL, b.kcBuilder),
+			Labels: ResponseLabels(*instance, b.config.URL, b.kcBuilder),
 		},
 	}, nil
 }
@@ -253,7 +253,7 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 			DashboardURL:  instance.DashboardURL,
 			OperationData: "",
 			Metadata: domain.InstanceMetadata{
-				Labels: ResponseLabels(*lastProvisioningOperation, *instance, b.config.URL, b.kcBuilder),
+				Labels: ResponseLabels(*instance, b.config.URL, b.kcBuilder),
 			},
 		}, nil
 	}
@@ -512,7 +512,7 @@ func (b *UpdateEndpoint) processUpdateParameters(ctx context.Context, instance *
 		DashboardURL:  instance.DashboardURL,
 		OperationData: operation.ID,
 		Metadata: domain.InstanceMetadata{
-			Labels: ResponseLabels(*lastProvisioningOperation, *instance, b.config.URL, b.kcBuilder),
+			Labels: ResponseLabels(*instance, b.config.URL, b.kcBuilder),
 		},
 	}, nil
 }

--- a/internal/broker/response_labels.go
+++ b/internal/broker/response_labels.go
@@ -27,12 +27,12 @@ const (
 	apiServerURLErrorFormat = "while getting APIServerURL: %s"
 )
 
-func ResponseLabels(op internal.ProvisioningOperation, instance internal.Instance, brokerURL string, kubeconfigBuilder kubeconfig.KcBuilder) map[string]any {
+func ResponseLabels(instance internal.Instance, brokerURL string, kubeconfigBuilder kubeconfig.KcBuilder) map[string]any {
 	brokerURL = strings.TrimLeft(brokerURL, "https://")
 	brokerURL = strings.TrimLeft(brokerURL, "http://")
 
 	responseLabels := make(map[string]any, 0)
-	responseLabels["Name"] = op.ProvisioningParameters.Parameters.Name
+	responseLabels["Name"] = instance.Parameters.Parameters.Name
 	if !IsOwnClusterPlan(instance.ServicePlanID) && instance.RuntimeID != "" {
 		responseLabels[kubeconfigURLKey] = fmt.Sprintf("https://%s/kubeconfig/%s", brokerURL, instance.InstanceID)
 		apiServerUrl, err := kubeconfigBuilder.GetServerURL(instance.RuntimeID)
@@ -50,7 +50,6 @@ func ResponseLabels(op internal.ProvisioningOperation, instance internal.Instanc
 }
 
 func ResponseLabelsWithExpirationInfo(
-	op internal.ProvisioningOperation,
 	instance internal.Instance,
 	brokerURL string,
 	docsURL string,
@@ -60,7 +59,7 @@ func ResponseLabelsWithExpirationInfo(
 	expiredInfoFormat string,
 	kubeconfigBuilder kubeconfig.KcBuilder,
 ) map[string]any {
-	labels := ResponseLabels(op, instance, brokerURL, kubeconfigBuilder)
+	labels := ResponseLabels(instance, brokerURL, kubeconfigBuilder)
 
 	expireTime := instance.CreatedAt.Add(expireDuration)
 	hoursLeft := calculateHoursLeft(expireTime)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Since the cluster name can now be updated, use the latest cluster name from the instance instead of the one from the provisioning operation.

**Related issue(s)**
See also [#7988](https://github.tools.sap/kyma/backlog/issues/7988#issuecomment-16622829)