### PR TITLE
Decrease cluster name max length

### DIFF
--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -3608,8 +3608,8 @@ func TestClusterName(t *testing.T) {
 			expectedError: fmt.Errorf("while validating input parameters: at '/name': minLength: got 0, want 1"),
 		},
 		"Long name": {
-			parameters:    fmt.Sprintf(`{"name": "%s", "region": "eu-central-1"}`, strings.Repeat("A", 257)),
-			expectedError: fmt.Errorf("while validating input parameters: at '/name': maxLength: got 257, want 256"),
+			parameters:    fmt.Sprintf(`{"name": "%s", "region": "eu-central-1"}`, strings.Repeat("A", 65)),
+			expectedError: fmt.Errorf("while validating input parameters: at '/name': maxLength: got 65, want 64"),
 		},
 		"Valid name": {
 			parameters:    `{"name": "cluster-testing", "region": "eu-central-1"}`,

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -2359,8 +2359,8 @@ func TestUpdateClusterName(t *testing.T) {
 			expectedError: fmt.Errorf("while validating update parameters: at '/name': minLength: got 0, want 1"),
 		},
 		"Long name": {
-			parameters:    fmt.Sprintf(`{"name": "%s"}`, strings.Repeat("A", 257)),
-			expectedError: fmt.Errorf("while validating update parameters: at '/name': maxLength: got 257, want 256"),
+			parameters:    fmt.Sprintf(`{"name": "%s"}`, strings.Repeat("A", 65)),
+			expectedError: fmt.Errorf("while validating update parameters: at '/name': maxLength: got 65, want 64"),
 		},
 		"Valid name": {
 			parameters:    `{"name": "cluster-testing"}`,

--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -533,7 +533,7 @@ func NameProperty(update bool) NameType {
 			// Allows for all alphanumeric characters and '-'
 			Pattern:   "^[a-zA-Z0-9-]*$",
 			MinLength: 1,
-			MaxLength: 256,
+			MaxLength: 64,
 		},
 	}
 

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -264,7 +264,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -264,7 +264,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/aws/free-aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/free-aws-schema-additional-params-ingress-eu.json
@@ -118,7 +118,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/aws/free-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/free-aws-schema-additional-params-ingress.json
@@ -118,7 +118,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -168,7 +168,7 @@
       "type": "string"
     },
     "name": {
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
@@ -200,7 +200,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
@@ -200,7 +200,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -268,7 +268,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -268,7 +268,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/azure-trial-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-trial-schema-additional-params-ingress.json
@@ -116,7 +116,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/free-azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/free-azure-schema-additional-params-ingress-eu.json
@@ -118,7 +118,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/free-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/free-azure-schema-additional-params-ingress.json
@@ -118,7 +118,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -104,7 +104,7 @@
       "type":"string"
     },
     "name": {
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -172,7 +172,7 @@
       "type": "string"
     },
     "name": {
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -248,7 +248,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -152,7 +152,7 @@
       "type": "string"
     },
     "name": {
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -226,7 +226,7 @@
           "saSubdomain"
         ]
       },
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -130,7 +130,7 @@
       "type": "string"
     },
     "name": {
-      "maxLength": 256,
+      "maxLength": 64,
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9-]*$",
       "title": "Cluster Name",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- The longest cluster name is 59 characters in stage and 63 characters in production (see [comment](https://github.tools.sap/kyma/backlog/issues/7988#issuecomment-16987394)). Therefore, the maximum allowed length can be safely reduced to 64 characters.

**Related issue(s)**
See also [#7988](https://github.tools.sap/kyma/backlog/issues/7988#issuecomment-16622829)