### PR TITLE
Remove `clusterNameInKubeconfig` feature flag

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -141,8 +141,6 @@ type Config struct {
 	HoldHapSteps bool
 
 	MachinesAvailabilityEndpoint bool
-
-	ClusterNameInKubeconfig bool
 }
 
 type ProfilerConfig struct {
@@ -359,7 +357,7 @@ func main() {
 	fatalOnError(err, log)
 
 	// create kubeconfig builder
-	kcBuilder := kubeconfig.NewBuilder(kcpK8sClient, skrK8sClientProvider, cfg.ClusterNameInKubeconfig)
+	kcBuilder := kubeconfig.NewBuilder(kcpK8sClient, skrK8sClientProvider)
 
 	// create server
 	router := httputil.NewRouter()
@@ -498,8 +496,8 @@ func createAPI(router *httputil.Router, schemaService *broker.SchemaService, ser
 			rulesService, gardenerClient, awsClientFactory),
 		GetInstanceEndpoint:          broker.NewGetInstance(cfg.Broker, db.Instances(), db.Operations(), kcBuilder, logs),
 		LastOperationEndpoint:        broker.NewLastOperation(db.Operations(), db.InstancesArchived(), logs),
-		BindEndpoint:                 broker.NewBind(cfg.Broker.Binding, db, logs, clientProvider, kubeconfigProvider, publisher, cfg.ClusterNameInKubeconfig),
-		UnbindEndpoint:               broker.NewUnbind(logs, db, brokerBindings.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider, cfg.ClusterNameInKubeconfig), publisher),
+		BindEndpoint:                 broker.NewBind(cfg.Broker.Binding, db, logs, clientProvider, kubeconfigProvider, publisher),
+		UnbindEndpoint:               broker.NewUnbind(logs, db, brokerBindings.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider), publisher),
 		GetBindingEndpoint:           broker.NewGetBinding(logs, db),
 		LastBindingOperationEndpoint: broker.NewLastBindingOperation(logs),
 	}

--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -31,7 +31,6 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_BROKER_UPDATE_&#x200b;CUSTOM_RESOURCES_&#x200b;LABELS_ON_ACCOUNT_&#x200b;MOVE** | <code>false</code> | If true, updates runtimeCR labels when moving subaccounts. |
 | **APP_BROKER_URL** | <code>kyma-env-broker.localhost</code> | - |
 | **APP_CATALOG_FILE_&#x200b;PATH** | <code>/config/catalog.yaml</code> | Path to the service catalog configuration file. |
-| **APP_CLUSTER_NAME_IN_&#x200b;KUBECONFIG** | <code>false</code> | If true, the cluster name is used as the context name when generating the kubeconfig. |
 | **APP_DATABASE_HOST** | None | Specifies the host of the database. |
 | **APP_DATABASE_NAME** | None | Specifies the name of the database. |
 | **APP_DATABASE_&#x200b;PASSWORD** | None | Specifies the user password for the database. |

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -142,7 +142,6 @@
 | holdHAPSteps | If true, the broker holds any operation with HAP assignments. It is designed for migration (SecretBinding to CredentialBinding). | `false` |
 | subscriptionGardenerResource | Name of the Gardener resource, which the broker uses to look up for hyperscaler assignment. Allowed values: SecretBinding or CredentialsBinding. | `SecretBinding` |
 | machinesAvailabilityEndpoint | If true, the broker exposes the API endpoint that returns the availability of machine types. | `False` |
-| clusterNameInKubeconfig | If true, the cluster name is used as the context name when generating the kubeconfig. | `False` |
 | cis.accounts.authURL | The OAuth2 token endpoint (authorization URL) used to obtain access tokens for authenticating requests to the CIS Accounts API. | None |
 | cis.accounts.id | The OAuth2 client ID used for authenticating requests to the CIS Accounts API. | None |
 | cis.accounts.secret | The OAuth2 client secret used together with the client ID for authentication with the CIS Accounts API. | None |

--- a/internal/broker/bind_create.go
+++ b/internal/broker/bind_create.go
@@ -70,14 +70,14 @@ type Credentials struct {
 }
 
 func NewBind(cfg BindingConfig, db storage.BrokerStorage, log *slog.Logger, clientProvider broker.ClientProvider, kubeconfigProvider broker.KubeconfigProvider,
-	publisher event.Publisher, clusterNameInKubeconfig bool) *BindEndpoint {
+	publisher event.Publisher) *BindEndpoint {
 	return &BindEndpoint{config: cfg,
 		instancesStorage:             db.Instances(),
 		bindingsStorage:              db.Bindings(),
 		publisher:                    publisher,
 		operationsStorage:            db.Operations(),
 		log:                          log.With("service", "BindEndpoint"),
-		serviceAccountBindingManager: broker.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider, clusterNameInKubeconfig),
+		serviceAccountBindingManager: broker.NewServiceAccountBindingsManager(clientProvider, kubeconfigProvider),
 	}
 }
 

--- a/internal/broker/bind_create_test.go
+++ b/internal/broker/bind_create_test.go
@@ -93,7 +93,7 @@ func TestCreateBindingEndpoint_dbInsertionInCaseOfError(t *testing.T) {
 	publisher := event.NewPubSub(log)
 
 	//// api handler
-	bindEndpoint := NewBind(*bindingCfg, db, fixLogger(), &dummyProvider{}, &dummyProvider{}, publisher, true)
+	bindEndpoint := NewBind(*bindingCfg, db, fixLogger(), &dummyProvider{}, &dummyProvider{}, publisher)
 
 	// test relies on checking if got nil on kubeconfig dummyProvider but the instance got inserted either way
 	t.Run("should INSERT binding despite error on k8s api call", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestCreateSecondBindingWithTheSameIdButDifferentParams(t *testing.T) {
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, true)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
 	params := BindingParams{
 		ExpirationSeconds: 601,
 	}
@@ -394,7 +394,7 @@ func TestCreateSecondBindingWithTheSameIdAndParams(t *testing.T) {
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, true)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -446,7 +446,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForExpired(t *testing.T) {
 	// event publisher
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, true)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -500,7 +500,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsForBindingInProgress(t *testin
 	// event publisher
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, true)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
 	params := BindingParams{
 		ExpirationSeconds: 600,
 	}
@@ -551,7 +551,7 @@ func TestCreateSecondBindingWithTheSameIdAndParamsNotExplicitlyDefined(t *testin
 
 	publisher := event.NewPubSub(log)
 
-	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher, true)
+	svc := NewBind(*bindingCfg, brokerStorage, fixLogger(), nil, nil, publisher)
 
 	// when
 	resp, err := svc.Bind(context.Background(), instanceID, bindingID, domain.BindDetails{}, false)
@@ -577,5 +577,5 @@ func prepareBindingEndpoint(t *testing.T, cfg BindingConfig) (*BindEndpoint, sto
 	err = db.Operations().InsertOperation(operation)
 	require.NoError(t, err)
 
-	return NewBind(cfg, db, log, k8sClientProvider, k8sClientProvider, event.NewPubSub(log), true), db
+	return NewBind(cfg, db, log, k8sClientProvider, k8sClientProvider, event.NewPubSub(log)), db
 }

--- a/internal/broker/bind_envtest_test.go
+++ b/internal/broker/bind_envtest_test.go
@@ -105,8 +105,8 @@ func TestCreateBinding(t *testing.T) {
 		Level: slog.LevelDebug,
 	}))
 	publisher := event.NewPubSub(log)
-	svc := NewBind(bindingCfg, db, log, skrK8sClientProvider, skrK8sClientProvider, publisher, true)
-	unbindSvc := NewUnbind(log, db, brokerBindings.NewServiceAccountBindingsManager(skrK8sClientProvider, skrK8sClientProvider, true), publisher)
+	svc := NewBind(bindingCfg, db, log, skrK8sClientProvider, skrK8sClientProvider, publisher)
+	unbindSvc := NewUnbind(log, db, brokerBindings.NewServiceAccountBindingsManager(skrK8sClientProvider, skrK8sClientProvider), publisher)
 
 	t.Run("should create a new service binding without error", func(t *testing.T) {
 		// When

--- a/internal/broker/bindings/bindings_manager.go
+++ b/internal/broker/bindings/bindings_manager.go
@@ -44,10 +44,10 @@ type ServiceAccountBindingsManager struct {
 	kubeconfigBuilder *kubeconfig.Builder
 }
 
-func NewServiceAccountBindingsManager(clientProvider ClientProvider, kubeconfigProvider KubeconfigProvider, clusterNameInKubeconfig bool) *ServiceAccountBindingsManager {
+func NewServiceAccountBindingsManager(clientProvider ClientProvider, kubeconfigProvider KubeconfigProvider) *ServiceAccountBindingsManager {
 	return &ServiceAccountBindingsManager{
 		clientProvider:    clientProvider,
-		kubeconfigBuilder: kubeconfig.NewBuilder(nil, kubeconfigProvider, clusterNameInKubeconfig),
+		kubeconfigBuilder: kubeconfig.NewBuilder(nil, kubeconfigProvider),
 	}
 }
 

--- a/internal/kubeconfig/builder_test.go
+++ b/internal/kubeconfig/builder_test.go
@@ -40,7 +40,7 @@ func TestBuilder_BuildFromRuntimeResource_NilAdditionalOIDC(t *testing.T) {
 
 	t.Run("new kubeconfig was built properly", func(t *testing.T) {
 		// given
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -73,7 +73,7 @@ func TestBuilder_BuildFromRuntimeResource_EmptyAdditionalOIDC(t *testing.T) {
 
 	t.Run("new kubeconfig was built properly", func(t *testing.T) {
 		// given
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -114,7 +114,7 @@ func TestBuilder_BuildFromRuntimeResource(t *testing.T) {
 
 	t.Run("new kubeconfig was built properly", func(t *testing.T) {
 		// given
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -161,7 +161,7 @@ func TestBuilder_BuildFromRuntimeResource_MultipleAdditionalOIDC(t *testing.T) {
 
 	t.Run("new kubeconfig was built properly", func(t *testing.T) {
 		// given
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -195,7 +195,7 @@ func TestBuilder_BuildFromAdminKubeconfig_NilAdditionalOIDC(t *testing.T) {
 	t.Run("new kubeconfig was build properly", func(t *testing.T) {
 		// given
 
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -228,7 +228,7 @@ func TestBuilder_BuildFromAdminKubeconfig_EmptyAdditionalOIDC(t *testing.T) {
 	t.Run("new kubeconfig was build properly", func(t *testing.T) {
 		// given
 
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -269,7 +269,7 @@ func TestBuilder_BuildFromAdminKubeconfig(t *testing.T) {
 	t.Run("new kubeconfig was build properly", func(t *testing.T) {
 		// given
 
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -316,7 +316,7 @@ func TestBuilder_BuildFromAdminKubeconfig_MultipleAdditionalOIDC(t *testing.T) {
 	t.Run("new kubeconfig was build properly", func(t *testing.T) {
 		// given
 
-		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()), true)
+		builder := NewBuilder(kcpClient, NewFakeKubeconfigProvider(skrKubeconfig()))
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -125,8 +125,6 @@ spec:
               value: {{ .Values.host }}.{{ .Values.global.ingress.domainName }}
             - name: APP_CATALOG_FILE_PATH
               value: {{ .Values.configPaths.catalog }}
-            - name: APP_CLUSTER_NAME_IN_KUBECONFIG
-              value: "{{ .Values.clusterNameInKubeconfig }}"
             - name: APP_DATABASE_HOST
               valueFrom:
                 secretKeyRef:

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -391,9 +391,6 @@ subscriptionGardenerResource: SecretBinding
 # If true, the broker exposes the API endpoint that returns the availability of machine types.
 machinesAvailabilityEndpoint: false
 
-# If true, the cluster name is used as the context name when generating the kubeconfig.
-clusterNameInKubeconfig: false
-
 # =================================================
 # CIS Related Settings
 # =================================================


### PR DESCRIPTION
**Description**

Since `clusterNameInKubeconfig` is enabled in all environments, the feature flag can be removed.

Changes proposed in this pull request:

- remove `clusterNameInKubeconfig` feature flag. 

**Related issue(s)**
See also [#7988](https://github.tools.sap/kyma/backlog/issues/7988#issuecomment-16622829)