### PR TITLE
Runtimes info metric

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -513,7 +513,7 @@ func createAPI(router *httputil.Router, schemaService *broker.SchemaService, ser
 	router.Handle("/oauth/", http.StripPrefix("/oauth", subRouter))
 
 	respWriter := httputil.NewResponseWriter(logs, cfg.DevelopmentMode)
-	runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(db.Instances(), db.Operations(), defaultPlansConfig, cfg.Broker.DefaultRequestRegion, respWriter)
+	runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(db.Instances(), db.Operations(), defaultPlansConfig, cfg.Broker.DefaultRequestRegion, respWriter, publisher)
 	router.Handle("/info/runtimes", runtimesInfoHandler)
 	router.Handle("/events", eventshandler.NewHandler(db.Events(), db.Instances()))
 }

--- a/internal/metricsv2/metrics.go
+++ b/internal/metricsv2/metrics.go
@@ -6,12 +6,13 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/kyma-project/kyma-environment-broker/internal/broker"
-
 	"github.com/kyma-project/kyma-environment-broker/internal"
+	"github.com/kyma-project/kyma-environment-broker/internal/appinfo"
+	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/kyma-environment-broker/internal/event"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -72,6 +73,9 @@ func Register(ctx context.Context, sub event.Subscriber, db storage.BrokerStorag
 	bindCrestedCollector := NewBindingCreationCollector()
 	prometheus.MustRegister(bindCrestedCollector)
 
+	runtimesInfoRequestsCollector := NewRuntimesInfoRequestsCollector()
+	prometheus.MustRegister(runtimesInfoRequestsCollector)
+
 	sub.Subscribe(process.ProvisioningSucceeded{}, opDurationCollector.OnProvisioningSucceeded)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opDurationCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.OperationSucceeded{}, opDurationCollector.OnOperationSucceeded)
@@ -82,6 +86,8 @@ func Register(ctx context.Context, sub event.Subscriber, db storage.BrokerStorag
 	sub.Subscribe(broker.BindRequestProcessed{}, bindDurationCollector.OnBindingExecuted)
 	sub.Subscribe(broker.UnbindRequestProcessed{}, bindDurationCollector.OnUnbindingExecuted)
 	sub.Subscribe(broker.BindingCreated{}, bindCrestedCollector.OnBindingCreated)
+
+	sub.Subscribe(appinfo.RuntimesInfoRequest{}, runtimesInfoRequestsCollector.OnRequest)
 
 	logger.Info(fmt.Sprintf("%s -> enabled", logPrefix))
 

--- a/internal/metricsv2/runtimes_info.go
+++ b/internal/metricsv2/runtimes_info.go
@@ -1,0 +1,37 @@
+package metricsv2
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// RuntimesInfoRequestsCollector provides a counter that tracks the total number of requests to the runtimes info endpoint:
+// - kcp_keb_v2_runtimes_info_requests_total
+type RuntimesInfoRequestsCollector struct {
+	requestTotal *prometheus.CounterVec
+}
+
+func NewRuntimesInfoRequestsCollector() *RuntimesInfoRequestsCollector {
+	return &RuntimesInfoRequestsCollector{
+		requestTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: prometheusNamespacev2,
+			Subsystem: prometheusSubsystemv2,
+			Name:      "runtimes_info_requests_total",
+			Help:      "Total number of requests to the runtimes info endpoint",
+		}, nil),
+	}
+}
+
+func (c *RuntimesInfoRequestsCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.requestTotal.Describe(ch)
+}
+
+func (c *RuntimesInfoRequestsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.requestTotal.Collect(ch)
+}
+
+func (c *RuntimesInfoRequestsCollector) OnRequest(ctx context.Context, ev interface{}) error {
+	c.requestTotal.WithLabelValues().Inc()
+	return nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- create a metric to track the total number of requests to the runtimes info endpoint.

**Related issue(s)**
See also #2566
