### PR TITLE
Removal of leftover `-` in runtime reconciler chart

### DIFF
--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -200,13 +200,13 @@
 | oidc.issuers | - | `[]` |
 | oidc.keysURL | - | `https://kymatest.accounts400.ondemand.com/oauth2/certs` |
 | runtimeReconciler.<br>dryRun | If true, runs the reconciler in dry-run mode (no changes are made, only logs actions). | `False` |
-| runtimeReconciler.<br>enabled | Enables or disables the Runtime Reconciler deployment. | `True` |
+| runtimeReconciler.<br>enabled | Enables or disables the Runtime Reconciler deployment. | `False` |
 | runtimeReconciler.<br>jobEnabled | If true, enables the periodic reconciliation job. | `False` |
 | runtimeReconciler.<br>jobInterval | Interval (in minutes) between reconciliation job runs. | `1440` |
 | runtimeReconciler.<br>jobReconciliationDelay | Delay before starting reconciliation after job trigger. | `1s` |
 | runtimeReconciler.<br>metricsPort | Port on which the reconciler exposes Prometheus metrics. | `8081` |
 | serviceBindingCleanup.<br>dryRun | If true, the job only logs what would be deleted without actually removing any bindings. | `False` |
-| serviceBindingCleanup.<br>enabled | If true, enables the Service Binding Cleanup CronJob. | `True` |
+| serviceBindingCleanup.<br>enabled | If true, enables the Service Binding Cleanup CronJob. | `False` |
 | serviceBindingCleanup.<br>requestRetries | Number of times to retry a failed DELETE request for a binding. | `2` |
 | serviceBindingCleanup.<br>requestTimeout | Timeout for each DELETE request to the broker. | `2s` |
 | serviceBindingCleanup.<br>schedule | - | `0 2,14 * * *` |

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -558,7 +558,7 @@ runtimeReconciler:
   # If true, runs the reconciler in dry-run mode (no changes are made, only logs actions).
   dryRun: false
   # Enables or disables the Runtime Reconciler deployment.
-  enabled: true
+  enabled: false
   # If true, enables the periodic reconciliation job.
   jobEnabled: false
   # Interval (in minutes) between reconciliation job runs.
@@ -578,7 +578,7 @@ serviceBindingCleanup:
   # If true, the job only logs what would be deleted without actually removing any bindings.
   dryRun: false
   # If true, enables the Service Binding Cleanup CronJob.
-  enabled: true
+  enabled: false
   # Number of times to retry a failed DELETE request for a binding.
   requestRetries: 2
   # Timeout for each DELETE request to the broker.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Remove leftover dash that spoiled the yaml


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
