### PR TITLE
docs: remove tab name and group

### DIFF
--- a/docs/user/03-10-service-description.md
+++ b/docs/user/03-10-service-description.md
@@ -74,7 +74,7 @@ These are the provisioning parameters that you can configure:
 
 These are the provisioning parameters for Azure that you can configure:
 
-<div tabs name="azure-plans" group="azure-plans">
+<div>
   <details>
   <summary label="azure-plan">
   Azure
@@ -122,7 +122,7 @@ These are the provisioning parameters for Azure that you can configure:
  </div>
 
 These are the provisioning parameters for AWS that you can configure:
-<div tabs name="aws-plans" group="aws-plans">
+<div>
   <details>
   <summary label="aws-plan">
   AWS
@@ -149,7 +149,7 @@ These are the provisioning parameters for AWS that you can configure:
 
 These are the provisioning parameters for GCP that you can configure:
 
-<div tabs name="gcp-plans" group="gcp-plans">
+<div>
   <details>
   <summary label="gcp-plan">
   GCP
@@ -176,7 +176,7 @@ These are the provisioning parameters for GCP that you can configure:
 
 These are the provisioning parameters for SapConvergedCloud that you can configure:
 
-<div tabs name="sap-converged-cloud-plans" group="sap-converged-cloud-plans">
+<div>
   <details>
   <summary label="sap-converged-cloud-plan">
   SapConvergedCloud
@@ -212,7 +212,7 @@ The trial plan allows you to install Kyma runtime on Azure, AWS, or GCP. The pla
 
 These are the provisioning parameters for the Trial plan that you can configure:
 
-<div tabs name="trial-plan" group="trial-plan">
+<div>
   <details>
   <summary label="trial-plan">
   Trial plan
@@ -243,7 +243,7 @@ The mapping between the platform region and the provider region (Azure, AWS or G
 
 These are the provisioning parameters for the `own_cluster` plan that you configure:
 
-<div tabs name="own_cluster-plan" group="own_cluster-plan">
+<div>
   <details>
   <summary label="own_cluster-plan">
   Own cluster plan
@@ -266,7 +266,7 @@ The preview plan is designed for testing major changes in KEB's architecture.
 
 These are the provisioning parameters for the `preview` plan that you configure:
 
-<div tabs name="preview_cluster-plan" group="preview_cluster-plan">
+<div>
   <details>
   <summary label="preview_cluster-plan">
   Preview cluster plan


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Removed the tab name and group as it caused errors in the build for the NS2 documentation delivery in Help Portal

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
