### PR TITLE
Safer handling for AES mode column

### DIFF
--- a/internal/storage/encrypt.go
+++ b/internal/storage/encrypt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/kyma-project/kyma-environment-broker/internal"
 )
@@ -178,7 +179,7 @@ func (e *Encrypter) decryptGCM(ciphertext []byte) ([]byte, error) {
 }
 
 func (e *Encrypter) DecryptUsingMode(data []byte, encryptionMode string) ([]byte, error) {
-	switch encryptionMode {
+	switch strings.ToUpper(encryptionMode) {
 	case EncryptionModeCFB:
 		return e.decryptCFB(data)
 	case EncryptionModeGCM:
@@ -190,7 +191,7 @@ func (e *Encrypter) DecryptUsingMode(data []byte, encryptionMode string) ([]byte
 
 func (e *Encrypter) DecryptSMCredentialsUsingMode(provisioningParameters *internal.ProvisioningParameters, encryptionMode string) error {
 	var err error
-	switch encryptionMode {
+	switch strings.ToUpper(encryptionMode) {
 	case EncryptionModeCFB:
 		err = e.decryptSMCredentials(provisioningParameters, e.decryptCFB)
 	case EncryptionModeGCM:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

It is properly handled now by default branch in case/switch - but this is safer.

Changes proposed in this pull request:

- default in database is lowercase, KEB writes uppercase so we can encounter `AES-CFB` and `aes-cfb`


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
