### PR TITLE
Remove number of additional files from notable changes metadata

### DIFF
--- a/docs/assets/notable-change-template.md
+++ b/docs/assets/notable-change-template.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"MANDATORY | RECOMMENDED","type":"EXTERNAL | INTERNAL","category":"CONFIGURATION | FEATURE | MIGRATION","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"MANDATORY | RECOMMENDED","type":"EXTERNAL | INTERNAL","category":"CONFIGURATION | FEATURE | MIGRATION"}}-->
 
 # Updating Kyma Environment Broker
 

--- a/docs/contributor/04-30-notable-changes.md
+++ b/docs/contributor/04-30-notable-changes.md
@@ -31,7 +31,6 @@ When introducing a KEB change that requires operator action, perform the followi
          - `requirement`: **MANDATORY** or **RECOMMENDED**
          - `type`: **EXTERNAL** or **INTERNAL**
          - `category`: **CONFIGURATION**, **FEATURE**, or **MIGRATION**
-         - `additionalFiles`: number of supporting files, such as migration scripts
         
       - Example:
      
@@ -40,8 +39,7 @@ When introducing a KEB change that requires operator action, perform the followi
           "metadata": {
             "requirement": "RECOMMENDED",
             "type": "INTERNAL",
-            "category": "CONFIGURATION",
-            "additionalFiles": 0
+            "category": "CONFIGURATION"
           }
         }
         ```

--- a/notable-changes/1.22.1/notable-change.md
+++ b/notable-changes/1.22.1/notable-change.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"RECOMMENDED","type":"INTERNAL","category":"CONFIGURATION","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"RECOMMENDED","type":"INTERNAL","category":"CONFIGURATION"}}-->
 
 # Updating Kyma Environment Broker: Zones Discovery
 

--- a/notable-changes/1.22.7/notable-change.md
+++ b/notable-changes/1.22.7/notable-change.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"RECOMMENDED","type":"INTERNAL","category":"CONFIGURATION","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"RECOMMENDED","type":"INTERNAL","category":"CONFIGURATION"}}-->
 
 # Updating Kyma Environment Broker: Removal of Archiving and Cleaning Flags
 

--- a/notable-changes/1.23.0/notable-change.md
+++ b/notable-changes/1.23.0/notable-change.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE"}}-->
 
 # Updating Kyma Environment Broker: Updatable Cluster Name
 

--- a/notable-changes/1.24.0/notable-change.md
+++ b/notable-changes/1.24.0/notable-change.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE"}}-->
 
 # Updating Kyma Environment Broker: Dual-Stack Networking Support
 

--- a/notable-changes/1.25.0/notable-change.md
+++ b/notable-changes/1.25.0/notable-change.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE","additionalFiles":0}}-->
+<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"FEATURE"}}-->
 
 # Updating Kyma Environment Broker
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove the number of additional files field from the notable changes metadata because it is redundant.

**Related issue(s)**
See also [#7935](https://github.tools.sap/kyma/backlog/issues/7935)
