### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     labels:
       - "go"
-      - "skip-review"
       - "area/dependency"
+      - "kind/enhancement"
     schedule:
       interval: "daily"
     commit-message:
@@ -17,8 +16,20 @@ updates:
     labels:
       - "docker"
       - "area/dependency"
+      - "kind/enhancement"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "docker"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "github-actions"
+      - "area/dependency"
+      - "kind/enhancement"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "github-actions"
       include: "scope"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- enable dependabot for GitHub Actions,
- add `kind/enhancement` label to dependabot pull requests,
- remove a deprecated documentation link,
- remove the `skip-review` label (previously used by Tide to mark trusted PRs for auto-merge), as Tide is no longer in use.
