### PR TITLE
Disable the internal checkout in govulncheck

### DIFF
--- a/.github/workflows/run-govulncheck.yaml
+++ b/.github/workflows/run-govulncheck.yaml
@@ -18,3 +18,4 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           go-version-file: 'go.mod'
+          repo-checkout: false


### PR DESCRIPTION
**Description**

The `govulncheck` action internally calls `actions/checkout` (currently v4) and reconfigures Git authentication. With the newer checkout behavior, this leads to two Authorization headers being set for Git, causing conflicts. To resolve the issue, disable the internal checkout step in `govulncheck`.