### PR TITLE
Use CredentialsBinding during update

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -694,6 +694,7 @@ func createAPI(router *httputil.Router, schemaService *broker.SchemaService, ser
 
 	if r, _ := cfg.GardenerSubscriptionResource(); r == gardener.CredentialsBindingResource {
 		kymaEnvBroker.ProvisionEndpoint.UseCredentialsBindings()
+		kymaEnvBroker.UpdateEndpoint.UseCredentialsBindings()
 	}
 
 	prefixes := []string{"/{region}", ""}

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -3787,3 +3787,92 @@ func TestUpdateClusterName(t *testing.T) {
 	gotInstance = suite.GetInstance(iid)
 	assert.Equal(t, "updated-name", gotInstance.Parameters.Parameters.Name)
 }
+
+func TestUpdate_CredentialsBinding(t *testing.T) {
+	// given
+	cfg := fixConfig()
+	cfg.ProvidersConfigurationFilePath = providersZonesDiscovery
+	cfg.SubscriptionGardenerResource = "CredentialsBinding"
+
+	suite := NewBrokerSuiteTestWithConfig(t, cfg)
+	defer suite.TearDown()
+	iid := uuid.New().String()
+
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true&plan_id=361c511f-f939-4621-b228-d0fb79a1fe15&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
+		`{
+				   		"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+				   		"plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15",
+				   		"context": {
+					   		"globalaccount_id": "g-account-id",
+					   		"subaccount_id": "sub-id",
+					   		"user_id": "john.smith@email.com"
+				   		},
+						"parameters": {
+							"name": "testing-cluster",
+							"region": "us-east-1",
+							"additionalWorkerNodePools": [
+								{
+									"name": "name-1",
+									"machineType": "m6i.large",
+									"haZones": true,
+									"autoScalerMin": 3,
+									"autoScalerMax": 20
+								}
+							]
+						}
+   			}`)
+	opID := suite.DecodeOperationID(resp)
+	suite.waitForRuntimeAndMakeItReady(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
+
+	runtime := suite.GetRuntimeResourceByInstanceID(iid)
+	assert.Len(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers, 1)
+	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-1", 3, "zone-d", "zone-e", "zone-f", "zone-g")
+
+	// when
+	// OSB update:
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+       					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+       					"plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15",
+       					"context": {
+           					"globalaccount_id": "g-account-id",
+           					"user_id": "john.smith@email.com"
+       					},
+						"parameters": {
+							"additionalWorkerNodePools": [
+								{
+									"name": "name-1",
+									"machineType": "m6i.large",
+									"haZones": true,
+									"autoScalerMin": 3,
+									"autoScalerMax": 20
+								},
+								{
+									"name": "name-2",
+									"machineType": "m5.xlarge",
+									"haZones": true,
+									"autoScalerMin": 3,
+									"autoScalerMax": 20
+								},
+								{
+									"name": "name-3",
+									"machineType": "c7i.large",
+									"haZones": false,
+									"autoScalerMin": 1,
+									"autoScalerMax": 1
+								}
+							]
+						}
+   			}`)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	upgradeOperationID := suite.DecodeOperationID(resp)
+
+	// then
+	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	runtime = suite.GetRuntimeResourceByInstanceID(iid)
+	assert.Len(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers, 3)
+	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-1", 3, "zone-d", "zone-e", "zone-f", "zone-g")
+	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-2", 3, "zone-h", "zone-i", "zone-j", "zone-k")
+	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-3", 1, "zone-l", "zone-m")
+}

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -409,7 +409,7 @@ func (b *ProvisionEndpoint) validate(ctx context.Context, details domain.Provisi
 			discoveredZones[additionalWorkerNodePool.MachineType] = 0
 		}
 
-		// todo: simplify it, remove "if" when all KCP insdtances are migrated to use credentials bindings
+		// todo: simplify it, remove "if" when all KCP instances are migrated to use credentials bindings
 		var awsClient aws.Client
 		if b.useCredentialsBindings {
 			awsClient, err = newAWSClientUsingCredentialsBinding(ctx, l, b.rulesService, b.gardenerClient, b.awsClientFactory, provisioningParameters, values)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- create the AWS client using `CredentialsBinding` in the update endpoint,
- use `CredentialsBinding` in the `DiscoverAvailableZones` step of the update processing queue.

**Related issue(s)**
See also #2677
