### PR TITLE
Runtime operation errors are often <nil>

### DIFF
--- a/internal/process/operation_manager.go
+++ b/internal/process/operation_manager.go
@@ -83,7 +83,7 @@ func (om *OperationManager) OperationFailed(operation internal.Operation, descri
 	}
 
 	log.Error(fmt.Sprintf("Step execution failed: %v", retErr))
-	operation.EventErrorf(err, "operation failed")
+	operation.EventErrorf(retErr, "operation failed")
 
 	return op, 0, retErr
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix error reporting by passing the wrapped error (`retErr`) to `operation.EventErrorf`, ensuring error details are preserved even when the original err is nil.

Local test:
```
➜  kyma-environment-broker git:(runtime-operation-errors-are-often-nil) ✗ kcp rt --events
GLOBALACCOUNT ID                       SUBACCOUNT ID                          SHOOT     REGION        PLAN    CREATED AT            STATE                EU ACCESS
2f5011af-2fd3-44ba-ac60-eeb1148c2995   8b9a0db4-9aef-4da2-a856-61a4420b66fd   bcb3035   northeurope   azure   2026/01/16 08:16:58   failed (provision)   No
 ˫provision operation 9e34a43f-71bb-4090-b5dc-0ee3828ed428: failed
  ˫info    14s   processing step: Starting
  ˫info    14s   processing step: Init_Kyma_Template
  ˫info    14s   processing step: Override_Kyma_Modules
  ˫info    14s   processing step: Resolve_Subscription_Secret
  ˫info    14s   processing step: Discover_Available_Zones
  ˫info    14s   processing step: Generate_Runtime_ID
  ˫info    14s   processing step: Create_Resource_Names
  ˫info    14s   processing step: Create_Runtime_Resource
  ˫info    14s   processing step: Check_RuntimeResource_Provisioning
  ˫info    14s   step Check_RuntimeResource_Provisioning sleeping for 10s
  ˫error   4s    operation failed: Runtime resource not in Ready state
  ˪info    4s    operation processing failed
```

**Related issue(s)**
See also [#8447](https://github.tools.sap/kyma/backlog/issues/8447)
