### PR TITLE
Fix `go-lint-install` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ go-lint: go-lint-install ## linter config in file at root of project -> '.golang
 	golangci-lint run --timeout=$(GOLINT_TIMEOUT)
 
 go-lint-install: ## linter config in file at root of project -> '.golangci.yaml'
-	@if [ "v$(shell command golangci-lint version --short)" != "$(GOLINT_VER)" ]; then \
+	@if [ "v$$(golangci-lint version --short 2>/dev/null)" != "$(GOLINT_VER)" ]; then \
   		echo golangci in version $(GOLINT_VER) not found. will be downloaded; \
 		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLINT_VER); \
-		echo golangci installed with version: $(shell command golangci-lint version --short); \
+		echo "golangci-lint installed with version: $$(golangci-lint version --short 2>/dev/null)"; \
 	fi;
 	
 ##@ Tests


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- the `golangci-lint version --short` command returns 2.8.0, while **GOLINT_VER** is set to v2.8.0. To make the comparison consistent, add the v prefix to the output of `golangci-lint version --short`.
- remove the `shell command` and use a more reliable approach to correctly display the installed version.
