### PR TITLE
Order of arguments changed - linter issue

### DIFF
--- a/cmd/schemamigrator/main.go
+++ b/cmd/schemamigrator/main.go
@@ -208,16 +208,16 @@ func invokeMigration() error {
 		err = migrateInstance.Down()
 	}
 
-	if err != nil && !errors.Is(migrate.ErrNoChange, err) {
+	if err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("during migration: %w", err)
-	} else if errors.Is(migrate.ErrNoChange, err) {
+	} else if errors.Is(err, migrate.ErrNoChange) {
 		slog.Info("# NO CHANGES DETECTED #")
 	}
 
 	slog.Info("# MIGRATION DONE #")
 
 	currentMigrationVer, _, err := migrateInstance.Version()
-	if err == migrate.ErrNilVersion {
+	if errors.Is(err, migrate.ErrNilVersion) {
 		slog.Info("# NO ACTIVE MIGRATION VERSION #")
 	} else if err != nil {
 		return fmt.Errorf("during acquiring active migration version: %w", err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Wrong order reported by staticcheck as `SA1032: Wrong argument order in errors.Is() → Logic bug, wrong behavior`


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2802 