### PR TITLE
Include all subaccount IDs in metrics

### DIFF
--- a/internal/storage/driver/postsql/instance_test.go
+++ b/internal/storage/driver/postsql/instance_test.go
@@ -159,7 +159,7 @@ func TestInstance_UsingLastOperationID(t *testing.T) {
 		assert.Equal(t, internal.InstanceStats{
 			TotalNumberOfInstances: 3,
 			PerGlobalAccountID:     map[string]int{"A": 2, "C": 1},
-			PerSubAcocuntID:        map[string]int{"sub-01": 2},
+			PerSubAcocuntID:        map[string]int{"sub-01": 2, "sub-02": 1},
 		}, stats)
 		assert.Equal(t, 3, numberOfInstancesA)
 		assert.Equal(t, 1, numberOfInstancesC)

--- a/internal/storage/postsql/read.go
+++ b/internal/storage/postsql/read.go
@@ -510,8 +510,7 @@ func (r readSession) GetSubaccountsInstanceStats() ([]dbmodel.InstanceBySubAccou
 		Join(dbr.I(OperationTableName).As("o1"), fmt.Sprintf("%s.last_operation_id = o1.id", InstancesTableName)).
 		Where("deleted_at = '0001-01-01T00:00:00.000Z'").
 		Where(buildInstanceStateFilters("o1", filter)).
-		GroupBy(fmt.Sprintf("%s.sub_account_id", InstancesTableName)).
-		Having(fmt.Sprintf("count(*) > 1"))
+		GroupBy(fmt.Sprintf("%s.sub_account_id", InstancesTableName))
 
 	_, err := stmt.Load(&rows)
 	return rows, err


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- include all subaccount IDs in metrics, even those with only a single instance.

**Related issue(s)**
See also [#8534](https://github.tools.sap/kyma/backlog/issues/8534)
