### PR TITLE
Fix race condition in HaltCloudSqlProxy when reading /proc files

### DIFF
--- a/internal/schemamigrator/cleaner/halt.go
+++ b/internal/schemamigrator/cleaner/halt.go
@@ -38,6 +38,10 @@ func HaltCloudSqlProxy() error {
 
 		target, err := os.ReadFile(file)
 		if err != nil {
+			// Process may have exited between Glob and ReadFile - this is normal in /proc
+			if os.IsNotExist(err) {
+				continue
+			}
 			return fmt.Errorf("while reading process file: %s", err)
 		}
 


### PR DESCRIPTION
## Summary
- Fixes race condition error when reading `/proc/*/comm` files in `HaltCloudSqlProxy` function
- Handles `os.IsNotExist` errors gracefully when processes exit between glob and read operations

## Problem
The free-cleanup job was logging errors like:
```
{"time":"2026-02-08T01:40:07.273338017Z","level":"ERROR","msg":"while reading process file: open /proc/21/comm: no such file or directory"}
```

This occurred because processes can exit between the `filepath.Glob("/proc/*/comm")` call and subsequent `os.ReadFile(file)` calls, causing the file to no longer exist.

## Solution
Skip processes that have exited by checking `os.IsNotExist(err)` and continuing to the next process. This is a minimal change that only addresses the race condition without modifying any other behavior.

## Test plan
- Deploy the updated job to staging environment
- Monitor job logs to confirm no more "no such file or directory" errors
- Verify cloud-sql-proxy is still properly terminated when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)