### PR TITLE
Fix sync update response - additional worker nodes config nil equals …

### DIFF
--- a/internal/broker/instance_update.go
+++ b/internal/broker/instance_update.go
@@ -484,7 +484,8 @@ func (b *UpdateEndpoint) shouldSkipNewOperation(previousInstance, currentInstanc
 	}
 	// do not compare "Active" field
 	previousInstance.Parameters.ErsContext.Active = currentInstance.Parameters.ErsContext.Active
-	if !reflect.DeepEqual(previousInstance.Parameters, currentInstance.Parameters) {
+
+	if !previousInstance.Parameters.IsEqual(currentInstance.Parameters) {
 		logger.Info("Parameters changed, cannot skip new operation")
 
 		if !reflect.DeepEqual(previousInstance.Parameters.ErsContext, currentInstance.Parameters.ErsContext) {

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -2442,6 +2442,16 @@ func TestUpdateWithoutOperation(t *testing.T) {
 			updateParameters:  `{"machineType":"m5.xlarge", "foo":"bar"}`,
 			expectedSync:      true,
 		},
+		"Update with additional worker node pool change": {
+			initialParameters: `{"machineType":"m5.xlarge","region":"eu-west-1", "additionalWorkerNodePools": []}`,
+			updateParameters:  `{                                                "additionalWorkerNodePools": []}`,
+			expectedSync:      true,
+		},
+		"Update with oidc": {
+			initialParameters: `{"machineType":"m5.xlarge","region":"eu-west-1", "oidc.list": []}`,
+			updateParameters:  `{                                                "oidc.list": []}`,
+			expectedSync:      true,
+		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			initialParams := pkg.ProvisioningParametersDTO{}

--- a/internal/dto.go
+++ b/internal/dto.go
@@ -34,6 +34,11 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 		return false
 	}
 
+	// empty list and nil does not make any difference
+	if (p.Parameters.AdditionalWorkerNodePools == nil && len(input.Parameters.AdditionalWorkerNodePools) == 0) ||
+		(input.Parameters.AdditionalWorkerNodePools == nil && len(p.Parameters.AdditionalWorkerNodePools) == 0) {
+		p.Parameters.AdditionalWorkerNodePools = input.Parameters.AdditionalWorkerNodePools
+	}
 	p.Parameters.TargetSecret = nil
 
 	if !reflect.DeepEqual(p.Parameters, input.Parameters) {


### PR DESCRIPTION
…empty list

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- AdditionalWorkerNodelPools nil and as empty list is the same (when the object is read from DB it is nil, not empty list, and must be equal to empty list in the parameter list from a request)

This change is needed for a code which decides if parameters has changed (and we have to create new update operation) or not.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
