### PR TITLE
Remove Global Accounts job from `pull-build-images`

### DIFF
--- a/.github/workflows/pull-build-images.yaml
+++ b/.github/workflows/pull-build-images.yaml
@@ -67,14 +67,6 @@ jobs:
          context: .
          build-args: BIN=subaccount-sync
 
-   globalaccounts-image:
-      uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
-      with: 
-         name: kyma-environment-globalaccounts
-         dockerfile: Dockerfile.globalaccounts
-         context: .
-         build-args: BIN=globalaccounts
-
    schema-migrator-image:
       uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
       with:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove Global Accounts job from `pull-build-images`.

**Related issue(s)**
See also #2747
