### PR TITLE
Fix file handle leak in periodicProfile

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -212,6 +212,7 @@ func periodicProfile(logger *slog.Logger, profiler ProfilerConfig) {
 		if err != nil {
 			logger.Error(fmt.Sprintf("Failed to write periodic memory profile to %v file: %v", profName, err))
 		}
+		profFile.Close()
 		gruntime.GC()
 		time.Sleep(profiler.Sampling)
 	}

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -212,7 +212,9 @@ func periodicProfile(logger *slog.Logger, profiler ProfilerConfig) {
 		if err != nil {
 			logger.Error(fmt.Sprintf("Failed to write periodic memory profile to %v file: %v", profName, err))
 		}
-		profFile.Close()
+		if err = profFile.Close(); err != nil {
+			logger.Error(fmt.Sprintf("Failed to close periodic memory profile file %v: %v", profName, err))
+		}
 		gruntime.GC()
 		time.Sleep(profiler.Sampling)
 	}


### PR DESCRIPTION
## Summary

- `os.Create()` in `periodicProfile` was never followed by `Close()`, causing file handles to accumulate on every loop iteration
- Added explicit `profFile.Close()` after writing the memory profile
- `defer` is intentionally avoided here — defers in an infinite loop don't execute until the function returns (which never happens), so an explicit close is the correct approach

## Test plan

- [x] Verify `cmd/broker` compiles: `go build ./cmd/broker/`
- [x] Run existing tests: `make test`