### PR TITLE
Add Subscription cleanup job replacement for local python scripts

### DIFF
--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -1971,6 +1971,33 @@ func TestUpdateCustomAdminsOverwrittenWithOIDCUpdate(t *testing.T) {
 	assert.Equal(t, expectedAdmins, runtime.Spec.Security.Administrators)
 
 	suite.AssertInstanceRuntimeAdmins(id, expectedAdmins)
+
+	// when
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id),
+		`{
+       "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+       "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
+       "context": {
+           "globalaccount_id": "g-account-id",
+           "user_id": "john.smith@email.com"
+       },
+		"parameters": {
+			"oidc": {
+				"clientID": "id-ooo",
+				"signingAlgs": ["ES384"],
+				"issuerURL": "https://issuer.url.com",
+				"groupsClaim": "new-groups-claim"
+			},
+			"administrators":[]
+		}
+   }`)
+	defer func() { _ = resp.Body.Close() }()
+
+	// then
+	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+
+	fmt.Println("Runtime after empty admins update: ", runtime.Spec.Security.Administrators)
+
 }
 
 func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -1971,33 +1971,6 @@ func TestUpdateCustomAdminsOverwrittenWithOIDCUpdate(t *testing.T) {
 	assert.Equal(t, expectedAdmins, runtime.Spec.Security.Administrators)
 
 	suite.AssertInstanceRuntimeAdmins(id, expectedAdmins)
-
-	// when
-	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id),
-		`{
-       "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
-       "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
-       "context": {
-           "globalaccount_id": "g-account-id",
-           "user_id": "john.smith@email.com"
-       },
-		"parameters": {
-			"oidc": {
-				"clientID": "id-ooo",
-				"signingAlgs": ["ES384"],
-				"issuerURL": "https://issuer.url.com",
-				"groupsClaim": "new-groups-claim"
-			},
-			"administrators":[]
-		}
-   }`)
-	defer func() { _ = resp.Body.Close() }()
-
-	// then
-	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
-
-	fmt.Println("Runtime after empty admins update: ", runtime.Spec.Security.Administrators)
-
 }
 
 func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {

--- a/utils/scj.py
+++ b/utils/scj.py
@@ -1,0 +1,36 @@
+from kubernetes import client, config
+
+
+NAMESPACE = "garden-kyma-dev"
+RESOURCE = "credentialsbindings"
+GROUP = "security.gardener.cloud"
+VERSION = "v1alpha1"
+
+
+def run_subscription_cleanup():
+    config.load_kube_config()
+    api = client.CustomObjectsApi()
+
+    bindings = api.list_namespaced_custom_object(
+        group=GROUP,
+        version=VERSION,
+        namespace=NAMESPACE,
+        plural=RESOURCE,
+        label_selector="dirty=true",
+    )
+
+    for binding in bindings["items"]:
+        name = binding["metadata"]["name"]
+        print(f"Removing 'dirty' label from {name}...")
+        api.patch_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=NAMESPACE,
+            plural=RESOURCE,
+            name=name,
+            body={"metadata": {"labels": {"dirty": None, "tenantName": None}}},
+        )
+
+
+if __name__ == "__main__":
+    run_subscription_cleanup()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- add a python helper to simulate SCJ for local testing

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
