### PR TITLE
OperationBlocklist validation hardened

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -551,7 +551,8 @@ func createAPI(router *httputil.Router, schemaService *broker.SchemaService, ser
 		operationBlocklist, err = blocklist.ReadFromFile(cfg.OperationBlocklistFilePath)
 		fatalOnError(err, logs)
 	}
-	operationBlocklist = operationBlocklist.WithPlanValidator(broker.AvailablePlans)
+	operationBlocklist, err = operationBlocklist.WithPlanValidator(broker.AvailablePlans)
+	fatalOnError(err, logs)
 
 	// create KymaEnvironmentBroker endpoints
 	kymaEnvBroker := &broker.KymaEnvironmentBroker{

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -83,4 +83,4 @@ A rule with no plan filter (`'"msg"'`) or an empty string rule (`''`) or an empt
 
 ## Plan Names
 
-Valid plan names are the same as those enabled via `broker.enablePlans`, for example: `aws`, `azure`, `gcp`, `trial`, `free`. A typo in a plan name (e.g. `trail` instead of `trial`) causes a startup error.
+Valid plan names are the same as those enabled using **broker.enablePlans**, for example, `aws`, `azure`, `gcp`, `trial`, `free`. A typo in a plan name (for example, `trail` instead of `trial`) causes a startup error.

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -20,7 +20,7 @@ operationBlocklist: |-
 
 The file is served from the existing `/config` volume through the `kcp-kyma-environment-broker` ConfigMap.
 
-If `operationBlocklist` is empty or not set, no operations are blocked.
+If you don't set **operationBlocklist** or leave it empty, no operations are blocked.
 
 ## Rule Format
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -31,6 +31,8 @@ Each rule is a compact string with up to two quoted tokens separated by a comma:
 '"<message>","plan=<plan1>,<plan2>"'
 ```
 
+Use the following rule components:
+
 - message — required, non-empty text string returned to the caller when the rule matches. Supports the `{plan}` placeholder, which is replaced with the actual plan name at runtime.
 - plan filter — required comma-separated list of plan names to match. A rule without a plan filter is a no-op.
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -79,7 +79,7 @@ KEB validates the blocklist at startup. The following configurations are rejecte
 | Unknown top-level key (for example, `planUpgarde`) | Typo detection |
 | Unknown plan name (for example, `trail`) | Caught by plan validator at startup |
 
-A rule with no plan filter (`'"msg"'`) or an empty string rule (`''`) or an empty key (e.g. `provision:`) is a no-op and does not cause an error.
+A rule with no plan filter (`'"msg"'`) or an empty string rule (`''`) or an empty key (for example, `provision:`) is a no-op and does not cause an error.
 
 ## Plan Names
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -18,7 +18,7 @@ operationBlocklist: |-
     - '"Deprovisioning of the trial plan is currently blocked","plan=trial"'
 ```
 
-The file is served from the existing `/config` volume via the `kcp-kyma-environment-broker` ConfigMap.
+The file is served from the existing `/config` volume through the `kcp-kyma-environment-broker` ConfigMap.
 
 If `operationBlocklist` is empty or not set, no operations are blocked.
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -61,10 +61,10 @@ deprovision: '"Deprovisioning is blocked for {plan}","plan=trial"'
 
 | Key | Operation blocked |
 |---|---|
-| `provision` | New instance provisioning |
-| `update` | Instance update |
-| `planUpgrade` | Plan upgrade |
-| `deprovision` | Instance deprovisioning |
+| **provision** | New instance provisioning |
+| **update** | Instance update |
+| **planUpgrade** | Plan upgrade |
+| **deprovision** | Instance deprovisioning |
 
 ## Validation
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -41,7 +41,8 @@ Each rule is a compact string with up to two quoted tokens separated by a comma:
 provision: '"Provisioning is temporarily disabled"'
 ```
 
-> **Note:** This rule has no plan filter and is therefore a no-op. A plan filter is required for a rule to take effect.
+> ### Note:
+> This rule has no plan filter and is therefore a no-op. A plan filter is required for a rule to take effect.
 
 ```yaml
 # Block provisioning for trial only

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -8,7 +8,7 @@ You can configure Kyma Environment Broker (KEB) to block specific operations (pr
 
 ## Configuration
 
-The blocklist is defined in a YAML file and pointed to by the `APP_OPERATION_BLOCKLIST_FILE_PATH` environment variable. In the Helm chart, set the `operationBlocklist` value:
+The **APP_OPERATION_BLOCKLIST_FILE_PATH** environment variable points to the blocklist defined in a YAML file. In the Helm chart, set the **operationBlocklist** value.
 
 ```yaml
 operationBlocklist: |-

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -31,8 +31,8 @@ Each rule is a compact string with up to two quoted tokens separated by a comma:
 '"<message>","plan=<plan1>,<plan2>"'
 ```
 
-- **message** — required, non-empty. Returned to the caller when the rule matches. Supports the `{plan}` placeholder, which is replaced with the actual plan name at runtime.
-- **plan filter** — required. A comma-separated list of plan names to match. A rule without a plan filter is a no-op.
+- message — required, non-empty text string returned to the caller when the rule matches. Supports the `{plan}` placeholder, which is replaced with the actual plan name at runtime.
+- plan filter — required comma-separated list of plan names to match. A rule without a plan filter is a no-op.
 
 ### Examples
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -1,0 +1,81 @@
+<!--{"metadata":{"publish":false}}-->
+
+# Operation Blocklist
+
+## Overview
+
+You can configure Kyma Environment Broker (KEB) to block specific operations (provisioning, deprovisioning, update, plan upgrade) for selected service plans. When a blocked operation is attempted, KEB rejects the request with an HTTP 400 error and the configured message.
+
+## Configuration
+
+The blocklist is defined in a YAML file and pointed to by the `APP_OPERATION_BLOCKLIST_FILE_PATH` environment variable. In the Helm chart, set the `operationBlocklist` value:
+
+```yaml
+operationBlocklist: |-
+  provision:
+    - '"Provisioning of the trial plan is currently blocked","plan=trial"'
+  deprovision:
+    - '"Deprovisioning of the trial plan is currently blocked","plan=trial"'
+```
+
+The file is served from the existing `/config` volume via the `kcp-kyma-environment-broker` ConfigMap.
+
+If `operationBlocklist` is empty or not set, no operations are blocked.
+
+## Rule Format
+
+Each rule is a compact string with up to two quoted tokens separated by a comma:
+
+```
+'"<message>"'
+'"<message>","plan=<plan1>,<plan2>"'
+```
+
+- **message** — required, non-empty. Returned to the caller when the rule matches. Supports the `{plan}` placeholder, which is replaced with the actual plan name at runtime.
+- **plan filter** — optional. A comma-separated list of plan names to match. If omitted, the rule matches all plans.
+
+### Examples
+
+```yaml
+# Block provisioning for all plans
+provision: '"Provisioning is temporarily disabled"'
+
+# Block provisioning for trial only
+provision: '"Provisioning of the {plan} plan is blocked","plan=trial"'
+
+# Block update for multiple plans
+update:
+  - '"Updates are blocked for {plan}","plan=trial,free"'
+
+# Block plan upgrade and deprovision for trial
+planUpgrade: '"Plan upgrade is not allowed for {plan}","plan=trial"'
+deprovision: '"Deprovisioning is blocked for {plan}","plan=trial"'
+```
+
+## Supported Operations
+
+| Key | Operation blocked |
+|---|---|
+| `provision` | New instance provisioning |
+| `update` | Instance update |
+| `planUpgrade` | Plan upgrade |
+| `deprovision` | Instance deprovisioning |
+
+## Validation
+
+KEB validates the blocklist at startup. The following configurations are rejected with an error:
+
+| Invalid input | Error |
+|---|---|
+| `'""'` | Empty message |
+| `'"msg","plan="'` | Empty plan filter |
+| `'"msg","plan=aws,,gcp"'` | Empty segment in plan list |
+| `'"msg",'` | Trailing comma |
+| Unknown top-level key (e.g. `planUpgarde`) | Typo detection |
+| Unknown plan name (e.g. `trail`) | Caught by plan validator at startup |
+
+An empty string rule `''` or an empty key (e.g. `provision:`) is a no-op and does not cause an error.
+
+## Plan Names
+
+Valid plan names are the same as those enabled via `broker.enablePlans`, for example: `aws`, `azure`, `gcp`, `trial`, `free`. A typo in a plan name (e.g. `trail` instead of `trial`) causes a startup error.

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -32,14 +32,18 @@ Each rule is a compact string with up to two quoted tokens separated by a comma:
 ```
 
 - **message** — required, non-empty. Returned to the caller when the rule matches. Supports the `{plan}` placeholder, which is replaced with the actual plan name at runtime.
-- **plan filter** — optional. A comma-separated list of plan names to match. If omitted, the rule matches all plans.
+- **plan filter** — required. A comma-separated list of plan names to match. A rule without a plan filter is a no-op.
 
 ### Examples
 
 ```yaml
 # Block provisioning for all plans
 provision: '"Provisioning is temporarily disabled"'
+```
 
+> **Note:** This rule has no plan filter and is therefore a no-op. A plan filter is required for a rule to take effect.
+
+```yaml
 # Block provisioning for trial only
 provision: '"Provisioning of the {plan} plan is blocked","plan=trial"'
 
@@ -74,7 +78,7 @@ KEB validates the blocklist at startup. The following configurations are rejecte
 | Unknown top-level key (e.g. `planUpgarde`) | Typo detection |
 | Unknown plan name (e.g. `trail`) | Caught by plan validator at startup |
 
-An empty string rule `''` or an empty key (e.g. `provision:`) is a no-op and does not cause an error.
+A rule with no plan filter (`'"msg"'`) or an empty string rule (`''`) or an empty key (e.g. `provision:`) is a no-op and does not cause an error.
 
 ## Plan Names
 

--- a/docs/contributor/03-46-operation-blocklist.md
+++ b/docs/contributor/03-46-operation-blocklist.md
@@ -76,8 +76,8 @@ KEB validates the blocklist at startup. The following configurations are rejecte
 | `'"msg","plan="'` | Empty plan filter |
 | `'"msg","plan=aws,,gcp"'` | Empty segment in plan list |
 | `'"msg",'` | Trailing comma |
-| Unknown top-level key (e.g. `planUpgarde`) | Typo detection |
-| Unknown plan name (e.g. `trail`) | Caught by plan validator at startup |
+| Unknown top-level key (for example, `planUpgarde`) | Typo detection |
+| Unknown plan name (for example, `trail`) | Caught by plan validator at startup |
 
 A rule with no plan filter (`'"msg"'`) or an empty string rule (`''`) or an empty key (e.g. `provision:`) is a no-op and does not cause an error.
 

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -63,6 +63,14 @@ func parseRule(s string) (Rule, error) {
 		if key != "plan" {
 			return Rule{}, fmt.Errorf("unknown key %q in rule %q (only \"plan\" is allowed)", key, s)
 		}
+		if val == "" {
+			return Rule{}, fmt.Errorf("empty plan filter in rule %q", s)
+		}
+		for _, p := range strings.Split(val, ",") {
+			if strings.TrimSpace(p) == "" {
+				return Rule{}, fmt.Errorf("empty plan segment in rule %q", s)
+			}
+		}
 		r.Plan = val
 	}
 	return r, nil
@@ -155,20 +163,24 @@ type OperationBlocklist struct {
 // for any unrecognised plan name (e.g. typos like "trail" instead of "trial").
 func (b OperationBlocklist) WithPlanValidator(v PlanValidator) (OperationBlocklist, error) {
 	b.planValidator = v
-	for op, rules := range map[string]ruleList{
-		"provision":   b.Provision,
-		"update":      b.Update,
-		"planUpgrade": b.PlanUpgrade,
-		"deprovision": b.Deprovision,
+	type opRules struct {
+		name  string
+		rules ruleList
+	}
+	for _, op := range []opRules{
+		{"provision", b.Provision},
+		{"update", b.Update},
+		{"planUpgrade", b.PlanUpgrade},
+		{"deprovision", b.Deprovision},
 	} {
-		for _, r := range rules {
+		for _, r := range op.rules {
 			if r.Plan == "" {
 				continue
 			}
 			for _, p := range strings.Split(r.Plan, ",") {
 				p = strings.TrimSpace(p)
 				if !v.IsPlanName(p) {
-					return OperationBlocklist{}, fmt.Errorf("unknown plan name %q in %s rule", p, op)
+					return OperationBlocklist{}, fmt.Errorf("unknown plan name %q in %s rule", p, op.name)
 				}
 			}
 		}

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -53,6 +53,9 @@ func parseRule(s string) (Rule, error) {
 	}
 
 	r := Rule{Message: tokens[0]}
+	if len(tokens) == 1 {
+		return Rule{}, nil // no plan filter — no-op, caller must skip
+	}
 	for _, tok := range tokens[1:] {
 		idx := strings.IndexByte(tok, '=')
 		if idx == -1 {
@@ -123,8 +126,8 @@ func (rl *ruleList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if err != nil {
 				return err
 			}
-			if strings.TrimSpace(s) == "" {
-				continue // empty string entry is a no-op
+			if r.Message == "" {
+				continue // empty string or message-only rule is a no-op
 			}
 			rules = append(rules, r)
 		}
@@ -136,13 +139,13 @@ func (rl *ruleList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&single); err != nil {
 		return fmt.Errorf("blocklist rule must be a string or list of strings: %w", err)
 	}
-	if strings.TrimSpace(single) == "" {
-		*rl = nil
-		return nil // empty string is a no-op
-	}
 	r, err := parseRule(single)
 	if err != nil {
 		return err
+	}
+	if r.Message == "" {
+		*rl = nil
+		return nil // empty string or message-only rule is a no-op
 	}
 	*rl = []Rule{r}
 	return nil

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -38,12 +38,18 @@ type Rule struct {
 //	'"message","plan=aws"'
 //	'"message","plan=aws,gcp"'
 func parseRule(s string) (Rule, error) {
+	if strings.TrimSpace(s) == "" {
+		return Rule{}, nil // empty string is a no-op, caller must skip
+	}
 	tokens, err := splitQuotedTokens(s)
 	if err != nil {
 		return Rule{}, fmt.Errorf("invalid rule %q: %w", s, err)
 	}
 	if len(tokens) == 0 {
 		return Rule{}, fmt.Errorf("empty rule")
+	}
+	if tokens[0] == "" {
+		return Rule{}, fmt.Errorf("empty message in rule %q", s)
 	}
 
 	r := Rule{Message: tokens[0]}
@@ -109,6 +115,9 @@ func (rl *ruleList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if err != nil {
 				return err
 			}
+			if strings.TrimSpace(s) == "" {
+				continue // empty string entry is a no-op
+			}
 			rules = append(rules, r)
 		}
 		*rl = rules
@@ -118,6 +127,10 @@ func (rl *ruleList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var single string
 	if err := unmarshal(&single); err != nil {
 		return fmt.Errorf("blocklist rule must be a string or list of strings: %w", err)
+	}
+	if strings.TrimSpace(single) == "" {
+		*rl = nil
+		return nil // empty string is a no-op
 	}
 	r, err := parseRule(single)
 	if err != nil {
@@ -138,9 +151,29 @@ type OperationBlocklist struct {
 }
 
 // WithPlanValidator returns a copy of the blocklist with the given PlanValidator set.
-func (b OperationBlocklist) WithPlanValidator(v PlanValidator) OperationBlocklist {
+// It also validates all plan names in rules against the validator, returning an error
+// for any unrecognised plan name (e.g. typos like "trail" instead of "trial").
+func (b OperationBlocklist) WithPlanValidator(v PlanValidator) (OperationBlocklist, error) {
 	b.planValidator = v
-	return b
+	for op, rules := range map[string]ruleList{
+		"provision":   b.Provision,
+		"update":      b.Update,
+		"planUpgrade": b.PlanUpgrade,
+		"deprovision": b.Deprovision,
+	} {
+		for _, r := range rules {
+			if r.Plan == "" {
+				continue
+			}
+			for _, p := range strings.Split(r.Plan, ",") {
+				p = strings.TrimSpace(p)
+				if !v.IsPlanName(p) {
+					return OperationBlocklist{}, fmt.Errorf("unknown plan name %q in %s rule", p, op)
+				}
+			}
+		}
+	}
+	return b, nil
 }
 
 // ReadFromFile loads an OperationBlocklist from a YAML file.

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -317,3 +317,17 @@ func TestParseRule_EmptyToken(t *testing.T) {
 	_, err := blocklist.ReadFromFile(path)
 	assert.Error(t, err)
 }
+
+func TestParseRule_EmptyPlanFilter(t *testing.T) {
+	// plan= with no value must be rejected — would silently match nothing but looks like a filter.
+	path := writeYAML(t, "provision: '\"msg\",\"plan=\"'\n")
+	_, err := blocklist.ReadFromFile(path)
+	assert.Error(t, err)
+}
+
+func TestParseRule_EmptyPlanSegment(t *testing.T) {
+	// plan=aws,,gcp has an empty segment — must be rejected.
+	path := writeYAML(t, "provision: '\"msg\",\"plan=aws,,gcp\"'\n")
+	_, err := blocklist.ReadFromFile(path)
+	assert.Error(t, err)
+}

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -54,7 +54,7 @@ func parseInline(op string, rules ...string) (blocklist.OperationBlocklist, erro
 	if err != nil {
 		return blocklist.OperationBlocklist{}, err
 	}
-	return bl.WithPlanValidator(testPlans), nil
+	return bl.WithPlanValidator(testPlans)
 }
 
 // --- parser ---
@@ -119,19 +119,22 @@ func TestCheckRules_EmptyBlocklist(t *testing.T) {
 	assert.NoError(t, bl.CheckDeprovision("aws"))
 }
 
-// --- PlanValidator ---
+// --- PlanValidator: unknown plan names are rejected at validation time ---
 
-func TestMatchesPlan_UnknownPlanInRuleDoesNotMatch(t *testing.T) {
-	bl, err := parseInline("provision", `"blocked","plan=notaplan"`)
+func TestMatchesPlan_UnknownPlanInRuleIsError(t *testing.T) {
+	path := writeYAML(t, "provision:\n  - '\"blocked\",\"plan=notaplan\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
 	require.NoError(t, err)
-	assert.NoError(t, bl.CheckProvision("notaplan"))
+	_, err = bl.WithPlanValidator(testPlans)
+	assert.ErrorContains(t, err, "notaplan")
 }
 
-func TestMatchesPlan_UnknownPlanInListDoesNotMatch(t *testing.T) {
-	bl, err := parseInline("provision", `"blocked","plan=aws,notaplan"`)
+func TestMatchesPlan_UnknownPlanInListIsError(t *testing.T) {
+	path := writeYAML(t, "provision:\n  - '\"blocked\",\"plan=aws,notaplan\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
 	require.NoError(t, err)
-	assert.EqualError(t, bl.CheckProvision("aws"), "blocked")
-	assert.NoError(t, bl.CheckProvision("notaplan"))
+	_, err = bl.WithPlanValidator(testPlans)
+	assert.ErrorContains(t, err, "notaplan")
 }
 
 // --- YAML: single string vs list ---
@@ -148,7 +151,8 @@ deprovision: '"deprovisioning is blocked for {plan}","plan=gcp"'
 	path := writeYAML(t, yaml)
 	bl, err := blocklist.ReadFromFile(path)
 	require.NoError(t, err)
-	bl = bl.WithPlanValidator(testPlans)
+	bl, err = bl.WithPlanValidator(testPlans)
+	require.NoError(t, err)
 
 	assert.EqualError(t, bl.CheckProvision("aws"), "provisioning is blocked for aws plan")
 	assert.EqualError(t, bl.CheckProvision("gcp"), "provisioning is blocked for gcp plan")
@@ -164,7 +168,10 @@ deprovision: '"deprovisioning is blocked for {plan}","plan=gcp"'
 	assert.NoError(t, bl.CheckDeprovision("aws"))
 }
 
+// --- hardening: empty/blank string rules are no-ops ---
+
 func TestReadFromFile_EmptyFile(t *testing.T) {
+	// Empty file → no-op blocklist, no error.
 	path := writeYAML(t, "")
 	bl, err := blocklist.ReadFromFile(path)
 	require.NoError(t, err)
@@ -172,6 +179,83 @@ func TestReadFromFile_EmptyFile(t *testing.T) {
 	assert.NoError(t, bl.CheckUpdate("trial"))
 	assert.NoError(t, bl.CheckPlanUpgrade("trial"))
 	assert.NoError(t, bl.CheckDeprovision("trial"))
+}
+
+func TestReadFromFile_EmptyKeysAreNoOp(t *testing.T) {
+	// Keys present but with no rules → no-op.
+	path := writeYAML(t, "provision:\ndeprovision:\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	assert.NoError(t, bl.CheckProvision("trial"))
+	assert.NoError(t, bl.CheckDeprovision("trial"))
+}
+
+func TestParseRule_EmptyStringSingleIsNoOp(t *testing.T) {
+	// provision: '' → no rules loaded, no error.
+	path := writeYAML(t, "provision: ''\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	assert.NoError(t, bl.CheckProvision("trial"))
+}
+
+func TestParseRule_EmptyStringInListIsNoOp(t *testing.T) {
+	// Empty string entry in a list is skipped; valid rule still works.
+	path := writeYAML(t, "provision:\n  - ''\n  - '\"blocked\",\"plan=trial\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	bl, err = bl.WithPlanValidator(testPlans)
+	require.NoError(t, err)
+	assert.EqualError(t, bl.CheckProvision("trial"), "blocked")
+	assert.NoError(t, bl.CheckProvision("aws"))
+}
+
+// --- hardening: empty message is a parse error ---
+
+func TestParseRule_EmptyMessageSingleIsError(t *testing.T) {
+	// provision: '""' → empty message, must fail loading.
+	path := writeYAML(t, "provision: '\"\"'\n")
+	_, err := blocklist.ReadFromFile(path)
+	assert.Error(t, err)
+}
+
+func TestParseRule_EmptyMessageWithPlanIsError(t *testing.T) {
+	// provision: '"","plan=trial"' → empty message, must fail loading.
+	path := writeYAML(t, "provision: '\"\",\"plan=trial\"'\n")
+	_, err := blocklist.ReadFromFile(path)
+	assert.Error(t, err)
+}
+
+// --- hardening: message only (no plan filter) triggers for all operations ---
+
+func TestParseRule_MessageOnlyTriggersAlways(t *testing.T) {
+	// provision: '"msg"' → no plan filter, triggers for every plan.
+	path := writeYAML(t, "provision: '\"blocked\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	bl, err = bl.WithPlanValidator(testPlans)
+	require.NoError(t, err)
+	assert.EqualError(t, bl.CheckProvision("trial"), "blocked")
+	assert.EqualError(t, bl.CheckProvision("aws"), "blocked")
+	assert.EqualError(t, bl.CheckProvision("gcp"), "blocked")
+}
+
+// --- hardening: WithPlanValidator rejects unknown plan names ---
+
+func TestWithPlanValidator_UnknownPlanNameIsError(t *testing.T) {
+	// "trail" is a typo for "trial" — must be rejected at validation time.
+	path := writeYAML(t, "provision: '\"blocked\",\"plan=trail\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	_, err = bl.WithPlanValidator(testPlans)
+	assert.ErrorContains(t, err, "trail")
+}
+
+func TestWithPlanValidator_KnownPlanNameIsAccepted(t *testing.T) {
+	path := writeYAML(t, "provision: '\"blocked\",\"plan=trial\"'\n")
+	bl, err := blocklist.ReadFromFile(path)
+	require.NoError(t, err)
+	_, err = bl.WithPlanValidator(testPlans)
+	assert.NoError(t, err)
 }
 
 // --- error cases ---
@@ -216,6 +300,13 @@ func TestParseRule_TrailingComma(t *testing.T) {
 	// A trailing comma would silently drop the incomplete token, turning a
 	// scoped rule into a global "match all plans" rule — must be a parse error.
 	path := writeYAML(t, "provision:\n  - '\"msg\",'\n")
+	_, err := blocklist.ReadFromFile(path)
+	assert.Error(t, err)
+}
+
+func TestParseRule_TrailingCommaAfterMessageIsError(t *testing.T) {
+	// provision: '"msg",' → trailing comma, must fail loading.
+	path := writeYAML(t, "provision: '\"msg\",'\n")
 	_, err := blocklist.ReadFromFile(path)
 	assert.Error(t, err)
 }

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -60,9 +60,10 @@ func parseInline(op string, rules ...string) (blocklist.OperationBlocklist, erro
 // --- parser ---
 
 func TestParseRule_MessageOnly(t *testing.T) {
+	// A rule with no plan filter is a no-op — plan filter is required to block.
 	bl, err := parseInline("provision", `"always blocked"`)
 	require.NoError(t, err)
-	assert.EqualError(t, bl.CheckProvision("any"), "always blocked")
+	assert.NoError(t, bl.CheckProvision("any"))
 }
 
 func TestParseRule_WithPlan(t *testing.T) {
@@ -227,16 +228,16 @@ func TestParseRule_EmptyMessageWithPlanIsError(t *testing.T) {
 
 // --- hardening: message only (no plan filter) triggers for all operations ---
 
-func TestParseRule_MessageOnlyTriggersAlways(t *testing.T) {
-	// provision: '"msg"' → no plan filter, triggers for every plan.
+func TestParseRule_MessageOnlyIsNoOp(t *testing.T) {
+	// No plan filter → no-op, does not block any plan.
 	path := writeYAML(t, "provision: '\"blocked\"'\n")
 	bl, err := blocklist.ReadFromFile(path)
 	require.NoError(t, err)
 	bl, err = bl.WithPlanValidator(testPlans)
 	require.NoError(t, err)
-	assert.EqualError(t, bl.CheckProvision("trial"), "blocked")
-	assert.EqualError(t, bl.CheckProvision("aws"), "blocked")
-	assert.EqualError(t, bl.CheckProvision("gcp"), "blocked")
+	assert.NoError(t, bl.CheckProvision("trial"))
+	assert.NoError(t, bl.CheckProvision("aws"))
+	assert.NoError(t, bl.CheckProvision("gcp"))
 }
 
 // --- hardening: WithPlanValidator rejects unknown plan names ---

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -3356,7 +3356,8 @@ func TestProvisionBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `provision: '"azure provisioning is blocked","plan=azure"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(broker.AvailablePlans)
+		bl, err = bl.WithPlanValidator(broker.AvailablePlans)
+		require.NoError(t, err)
 
 		provisionEndpoint := broker.NewFakeProvisionEndpointBuilder().
 			WithConfig(broker.Config{EnablePlans: []string{"azure"}, URL: brokerURL}).
@@ -3400,7 +3401,8 @@ func TestProvisionBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `provision: '"blocked","plan=gcp"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(broker.AvailablePlans)
+		bl, err = bl.WithPlanValidator(broker.AvailablePlans)
+		require.NoError(t, err)
 
 		provisionEndpoint := broker.NewFakeProvisionEndpointBuilder().
 			WithConfig(broker.Config{EnablePlans: []string{"azure"}, URL: brokerURL}).

--- a/internal/broker/instance_deprovision_test.go
+++ b/internal/broker/instance_deprovision_test.go
@@ -156,7 +156,8 @@ func TestDeprovisionBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `deprovision: '"azure deprovisioning is blocked","plan=azure"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(AvailablePlans)
+		bl, err = bl.WithPlanValidator(AvailablePlans)
+		require.NoError(t, err)
 
 		svc := NewDeprovision(memoryStorage.Instances(), memoryStorage.Operations(), queue, fixLogger(), bl)
 
@@ -181,7 +182,8 @@ func TestDeprovisionBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `deprovision: '"blocked","plan=gcp"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(AvailablePlans)
+		bl, err = bl.WithPlanValidator(AvailablePlans)
+		require.NoError(t, err)
 
 		svc := NewDeprovision(memoryStorage.Instances(), memoryStorage.Operations(), queue, fixLogger(), bl)
 

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -2840,7 +2840,8 @@ func TestUpdateBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `update: '"aws updates are blocked","plan=aws"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(broker.AvailablePlans)
+		bl, err = bl.WithPlanValidator(broker.AvailablePlans)
+		require.NoError(t, err)
 
 		svc := newUpdateSvc(t, st, bl)
 
@@ -2870,7 +2871,8 @@ func TestUpdateBlocklist(t *testing.T) {
 		path := writeBlocklistYAML(t, `update: '"blocked","plan=gcp"'`)
 		bl, err := blocklist.ReadFromFile(path)
 		require.NoError(t, err)
-		bl = bl.WithPlanValidator(broker.AvailablePlans)
+		bl, err = bl.WithPlanValidator(broker.AvailablePlans)
+		require.NoError(t, err)
 
 		svc := newUpdateSvc(t, st, bl)
 


### PR DESCRIPTION
## Summary

- Empty string `''` rule is a no-op
- Empty message `'""'` fails loading with a parse error
- Message-only rule with no plan filter (e.g. `'"msg"'`) is a no-op — plan filter is required for a rule to take effect
- Empty plan filter `plan=` and empty plan segments `plan=aws,,gcp` fail loading with a parse error
- Unknown plan names (e.g. typo `trail` instead of `trial`) are rejected at startup by `WithPlanValidator`, which now returns an error
- `WithPlanValidator` iterates operations in fixed order for deterministic error messages
- Empty file and empty keys are treated as no-op blocklists
- Added `docs/contributor/03-46-operation-blocklist.md`

## Test plan

- [ ] `go test ./internal/blocklist/...` — all 31 tests pass
- [ ] `go build ./cmd/broker/...` — broker compiles