### PR TITLE
Adjust all plan list settings validation

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -285,6 +285,8 @@ func main() {
 
 	err = cfg.Broker.Validate()
 	fatalOnError(err, log)
+	err = cfg.InfrastructureManager.Validate()
+	fatalOnError(err, log)
 
 	log.Info("Starting Kyma Environment Broker")
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	KymaServiceID   = "47c9dcbf-ff30-448e-ab36-d3bad66ba281"
-	KymaServiceName = "kymaruntime"
-	KcpNamespace    = "kcp-system"
+	KymaServiceID       = "47c9dcbf-ff30-448e-ab36-d3bad66ba281"
+	KymaServiceName     = "kymaruntime"
+	KcpNamespace        = "kcp-system"
+	AllPlansSpecialName = "all"
+	NoPlanSpecialName   = "no-plan"
 )
 
 type KymaEnvironmentBroker struct {
@@ -72,17 +74,43 @@ type Config struct {
 
 type ServicesConfig map[string]Service
 
-func (cfg *Config) Validate() error {
-	for _, name := range cfg.EnablePlans {
-		if _, exists := AvailablePlans.GetPlanIDByName(PlanNameType(name)); !exists {
-			return fmt.Errorf("unrecognized %v plan name", name)
+func validatePlanList(plans StringList, fieldName string, allowedSpecialNames ...string) error {
+	for _, name := range plans {
+		isSpecial := false
+		for _, special := range allowedSpecialNames {
+			if strings.EqualFold(name, special) {
+				isSpecial = true
+				break
+			}
+		}
+		if !isSpecial {
+			if _, exists := AvailablePlans.GetPlanIDByName(PlanNameType(name)); !exists {
+				return fmt.Errorf("unrecognized %v plan name in %v", name, fieldName)
+			}
 		}
 	}
 	return nil
 }
 
+func (cfg *Config) Validate() error {
+	if err := validatePlanList(cfg.EnablePlans, "EnablePlans"); err != nil {
+		return err
+	}
+	if err := validatePlanList(cfg.ACLEnabledPlans, "ACLEnabledPlans", NoPlanSpecialName, AllPlansSpecialName); err != nil {
+		return err
+	}
+	if err := validatePlanList(cfg.Binding.BindablePlans, "BindablePlans"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cfg *InfrastructureManager) Validate() error {
+	return validatePlanList(cfg.IngressFilteringPlans, "IngressFilteringPlans", NoPlanSpecialName)
+}
+
 func (cfg *Config) IsACLEnabledForPlanName(planName string) bool {
-	if cfg.ACLEnabledPlans.Contains("all") {
+	if cfg.ACLEnabledPlans.Contains(AllPlansSpecialName) {
 		return true
 	}
 	return cfg.ACLEnabledPlans.Contains(planName)

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -104,3 +104,51 @@ func TestConfigValidate_ErrorMessageContainsUnrecognizedPlanName(t *testing.T) {
 	err := cfg.Validate()
 	assert.ErrorContains(t, err, "no-such-plan")
 }
+
+func TestConfigValidate_ACLEnabledPlans_AllowsSpecialNameNoPlan(t *testing.T) {
+	cfg := Config{ACLEnabledPlans: StringList{NoPlanSpecialName}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_ACLEnabledPlans_AllowsSpecialNameAll(t *testing.T) {
+	cfg := Config{ACLEnabledPlans: StringList{AllPlansSpecialName}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_ACLEnabledPlans_AllowsValidPlanNames(t *testing.T) {
+	cfg := Config{ACLEnabledPlans: StringList{AWSPlanName, AzurePlanName}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_ACLEnabledPlans_ReturnsErrorForUnknownPlan(t *testing.T) {
+	cfg := Config{ACLEnabledPlans: StringList{"unknown-plan"}}
+	err := cfg.Validate()
+	assert.ErrorContains(t, err, "unknown-plan")
+}
+
+func TestConfigValidate_BindablePlans_AllowsValidPlanNames(t *testing.T) {
+	cfg := Config{Binding: BindingConfig{BindablePlans: StringList{AWSPlanName, AzurePlanName}}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidate_BindablePlans_ReturnsErrorForUnknownPlan(t *testing.T) {
+	cfg := Config{Binding: BindingConfig{BindablePlans: StringList{"unknown-plan"}}}
+	err := cfg.Validate()
+	assert.ErrorContains(t, err, "unknown-plan")
+}
+
+func TestInfrastructureManagerValidate_AllowsSpecialNameNoPlan(t *testing.T) {
+	cfg := InfrastructureManager{IngressFilteringPlans: StringList{NoPlanSpecialName}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestInfrastructureManagerValidate_AllowsValidPlanNames(t *testing.T) {
+	cfg := InfrastructureManager{IngressFilteringPlans: StringList{AWSPlanName, AzurePlanName}}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestInfrastructureManagerValidate_ReturnsErrorForUnknownPlan(t *testing.T) {
+	cfg := InfrastructureManager{IngressFilteringPlans: StringList{"unknown-plan"}}
+	err := cfg.Validate()
+	assert.ErrorContains(t, err, "unknown-plan")
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extend `Config.Validate()` to also validate `ACLEnabledPlans` (supporting `all` and `no-plan` as special values) and `Binding.BindablePlans`.                                                                   
- Add `InfrastructureManager.Validate()` to validate `IngressFilteringPlans` (supporting `no-plan` as special value)  and wired it into broker startup.                                                                                                 
- Extract a shared `validatePlanList` helper to avoid duplicated validation logic.             

**Related issue(s)**
See also #3030, https://github.com/kyma-project/kyma-environment-broker/issues/3030#issuecomment-4288195139
