### PR TITLE
Change trigger for sync docs toc

### DIFF
--- a/.github/workflows/sync-docs-toc.yml
+++ b/.github/workflows/sync-docs-toc.yml
@@ -1,6 +1,6 @@
 name: Sync KEB docs structure to product-kyma-runtime
 
-# Triggered after a successful "Create and promote release" run (i.e. after every KEB release).
+# Triggered after a successful "Create and promote release" or "Promote KEB to dev" run.
 # Compares docs/ between the released KEB version and the previous one.
 # Only files with <!--{"metadata":{"publish":true}}--> are considered.
 #
@@ -21,7 +21,7 @@ env:
 
 on:
   workflow_run:
-    workflows: ["Create and promote release"]
+    workflows: ["Create and promote release", "Promote KEB to dev"]
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync-docs-toc.yml
+++ b/.github/workflows/sync-docs-toc.yml
@@ -1,6 +1,6 @@
 name: Sync KEB docs structure to product-kyma-runtime
 
-# Triggered after a successful "Promote KEB to DEV" run (i.e. after every KEB release).
+# Triggered after a successful "Create and promote release" run (i.e. after every KEB release).
 # Compares docs/ between the released KEB version and the previous one.
 # Only files with <!--{"metadata":{"publish":true}}--> are considered.
 #
@@ -21,7 +21,7 @@ env:
 
 on:
   workflow_run:
-    workflows: ["Promote KEB to dev"]
+    workflows: ["Create and promote release"]
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -93,7 +93,7 @@ The workflow performs the following steps:
 
 The [`sync-docs-toc`](/.github/workflows/sync-docs-toc.yml) workflow automatically opens a PR to the `product-kyma-runtime` repository whenever a new or renamed file in KEB's `docs/` directory contains the `<!--{"metadata":{"publish":true}}-->` metadata.
 These documents are published to the Restricted Markets documentation. Content edits to existing files require no action — `product-kyma-runtime` pulls the latest content automatically using a `fileTree` reference in its `manifest.yaml`.
-The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) workflow run.
+The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) or [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run.
 
 The workflow performs the following steps:
 

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -93,7 +93,7 @@ The workflow performs the following steps:
 
 The [`sync-docs-toc`](/.github/workflows/sync-docs-toc.yml) workflow automatically opens a PR to the `product-kyma-runtime` repository whenever a new or renamed file in KEB's `docs/` directory contains the `<!--{"metadata":{"publish":true}}-->` metadata.
 These documents are published to the Restricted Markets documentation. Content edits to existing files require no action — `product-kyma-runtime` pulls the latest content automatically using a `fileTree` reference in its `manifest.yaml`.
-The workflow is triggered after every successful [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run.
+The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) workflow run.
 
 The workflow performs the following steps:
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- After checking promote KEB to dev is used by create and promote release, but it is not reported on gh actions. For that reason trigger never works. We need to use Create and Promote release instead.
- We left Promote KEB to dev if someone would like to promote step by step.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
