### PR TITLE
Fix sync docs toc

### DIFF
--- a/.github/workflows/sync-docs-toc.yml
+++ b/.github/workflows/sync-docs-toc.yml
@@ -1,7 +1,7 @@
 name: Sync KEB docs structure to product-kyma-runtime
 
 # Triggered after a successful "Create and promote release" or "Promote KEB to dev" run.
-# Compares docs/ between the released KEB version and the previous one.
+# Compares docs/ between the two most recent KEB releases (via gh release list).
 # Only files with <!--{"metadata":{"publish":true}}--> are considered.
 #
 # Two structural changes are handled:
@@ -25,13 +25,13 @@ on:
     types: [completed]
   workflow_dispatch:
     inputs:
-      keb_version:
-        description: "KEB version tag for chart lookup (e.g. 1.29.0) — required"
-        required: true
-      base_sha:
-        description: "Base SHA to diff against HEAD (for branch testing). Leave empty to diff real tags."
+      current_tag:
+        description: "Newer tag to compare (default: latest release)"
         required: false
         default: ''
+      prev_tag:
+        description: "Older tag to compare against — required"
+        required: true
 
 jobs:
   sync-toc:
@@ -56,45 +56,65 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          # For workflow_run: pin to the exact commit that triggered the upstream workflow.
-          # For workflow_dispatch: empty string → checkout the default branch HEAD.
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+          ref: ''
 
       - name: Resolve diff range
         id: versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "should_continue=true" >> "$GITHUB_OUTPUT"
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            KEB_TAG="${{ inputs.keb_version }}"
-            if [ -n "${{ inputs.base_sha }}" ]; then
-              # Branch testing mode: diff base_sha..HEAD, use keb_version for chart lookup only
-              echo "PREV_SHA=${{ inputs.base_sha }}" >> "$GITHUB_OUTPUT"
-              echo "CURRENT_SHA=HEAD"                >> "$GITHUB_OUTPUT"
-              echo "KEB_TAG=${KEB_TAG}"              >> "$GITHUB_OUTPUT"
-              echo "Branch test mode: ${{ inputs.base_sha }}..HEAD  chart lookup: ${KEB_TAG}"
+            PREV_TAG="${{ inputs.prev_tag }}"
+            if [ -n "${{ inputs.current_tag }}" ]; then
+              CURRENT_TAG="${{ inputs.current_tag }}"
             else
-              # Pure tag mode: diff two real KEB tags
-              PREV_TAG=$(git describe --tags --abbrev=0 "${KEB_TAG}^")
-              echo "PREV_SHA=${PREV_TAG}"   >> "$GITHUB_OUTPUT"
-              echo "CURRENT_SHA=${KEB_TAG}" >> "$GITHUB_OUTPUT"
-              echo "KEB_TAG=${KEB_TAG}"     >> "$GITHUB_OUTPUT"
-              echo "Tag mode: ${PREV_TAG}..${KEB_TAG}"
+              CURRENT_TAG=$(gh release list \
+                --repo "$GITHUB_REPOSITORY" \
+                --limit 1 \
+                --json tagName \
+                --jq '.[0].tagName')
+              if [ -z "$CURRENT_TAG" ]; then
+                echo "ERROR: current_tag not provided and no releases found."
+                exit 1
+              fi
             fi
-          else
-            # workflow_run mode: resolve tag from head_sha
-            CURRENT_TAG=$(git describe --tags --exact-match "${{ github.event.workflow_run.head_sha }}" 2>/dev/null || true)
-            if [ -z "$CURRENT_TAG" ]; then
-              echo "No exact tag found on head_sha – nothing to sync."
-              exit 0
-            fi
-            PREV_TAG=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^")
             echo "PREV_SHA=${PREV_TAG}"       >> "$GITHUB_OUTPUT"
             echo "CURRENT_SHA=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
             echo "KEB_TAG=${CURRENT_TAG}"     >> "$GITHUB_OUTPUT"
             echo "Tag mode: ${PREV_TAG}..${CURRENT_TAG}"
+          else
+            # workflow_run mode: find the two most recent GH releases
+            CURRENT_TAG=$(gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 1 \
+              --json tagName \
+              --jq '.[0].tagName')
+            if [ -z "$CURRENT_TAG" ]; then
+              echo "No releases found – nothing to sync."
+              echo "should_continue=false" >> "$GITHUB_OUTPUT"
+            else
+              PREV_TAG=$(gh release list \
+                --repo "$GITHUB_REPOSITORY" \
+                --limit 2 \
+                --json tagName \
+                --jq '.[1].tagName')
+              if [ -z "$PREV_TAG" ]; then
+                echo "Only one release found – nothing to diff against."
+                echo "should_continue=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "PREV_SHA=${PREV_TAG}"       >> "$GITHUB_OUTPUT"
+                echo "CURRENT_SHA=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
+                echo "KEB_TAG=${CURRENT_TAG}"     >> "$GITHUB_OUTPUT"
+                echo "Tag mode: ${PREV_TAG}..${CURRENT_TAG}"
+              fi
+            fi
           fi
 
       - name: Detect structural changes in docs/
         id: detect
+        if: steps.versions.outputs.should_continue == 'true'
         run: |
           PREV="${{ steps.versions.outputs.PREV_SHA }}"
           CURRENT="${{ steps.versions.outputs.CURRENT_SHA }}"
@@ -265,3 +285,13 @@ jobs:
             --body-file /tmp/pr_body.md)
 
           echo "${PR_URL}" | tee "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify slack channel about failure
+        if: ${{ !success() }}
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: kyma-gopher-private-alerts
+            text: "sync-docs-toc failed. Check: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -93,17 +93,26 @@ The workflow performs the following steps:
 
 The [`sync-docs-toc`](/.github/workflows/sync-docs-toc.yml) workflow automatically opens a PR to the `product-kyma-runtime` repository whenever a new or renamed file in KEB's `docs/` directory contains the `<!--{"metadata":{"publish":true}}-->` metadata.
 These documents are published to the Restricted Markets documentation. Content edits to existing files require no action — `product-kyma-runtime` pulls the latest content automatically using a `fileTree` reference in its `manifest.yaml`.
-The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) or [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run.
+The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) or [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run. It can also be triggered manually via `workflow_dispatch`.
 
 The workflow performs the following steps:
 
-1. Resolves the current and previous KEB release tags to determine the diff range
+1. Resolves the diff range using the two most recent GitHub releases (`gh release list`)
 2. Detects added or renamed `.md` files in `docs/` between the two releases, filtered by `publish:true` metadata
 3. Fetches the corresponding chart version from `management-plane-charts` (falls back to searching merged PRs if the release branch was already deleted)
 4. Updates `docs/toc.yaml` in `product-kyma-runtime` using the [`scripts/python/update_toc.py`](../../scripts/python/update_toc.py) script, which inserts new entries in numeric-prefix order and updates the renamed ones
 5. Opens a PR to `product-kyma-runtime` with the title `docs(keb): sync doc structure changes [chart@<version>]`
 
-If no relevant changes are detected, the workflow exits early and no PR is created.
+If no relevant changes are detected, the workflow exits early and no PR is created. On failure, a Slack notification is sent to `kyma-gopher-private-alerts`.
+
+### Manual trigger
+
+The workflow can be triggered manually with the following inputs:
+
+| Input | Required | Description |
+|-------|:--------:|-------------|
+| **`prev_tag`** | yes | Older release tag to use as the base of the diff (e.g. `1.29.13`) |
+| **`current_tag`** | no | Newer release tag to diff against. Defaults to the latest published release. |
 
 ## Reusable Workflows
 

--- a/docs/contributor/04-10-workflows.md
+++ b/docs/contributor/04-10-workflows.md
@@ -93,7 +93,7 @@ The workflow performs the following steps:
 
 The [`sync-docs-toc`](/.github/workflows/sync-docs-toc.yml) workflow automatically opens a PR to the `product-kyma-runtime` repository whenever a new or renamed file in KEB's `docs/` directory contains the `<!--{"metadata":{"publish":true}}-->` metadata.
 These documents are published to the Restricted Markets documentation. Content edits to existing files require no action — `product-kyma-runtime` pulls the latest content automatically using a `fileTree` reference in its `manifest.yaml`.
-The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) or [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run. It can also be triggered manually via `workflow_dispatch`.
+The workflow is triggered after every successful [Create and Promote Release](#create-and-promote-release-workflow) or [Promote KEB to DEV](#promote-keb-to-dev-workflow) workflow run. You can also trigger it manually using `workflow_dispatch`.
 
 The workflow performs the following steps:
 
@@ -105,14 +105,14 @@ The workflow performs the following steps:
 
 If no relevant changes are detected, the workflow exits early and no PR is created. On failure, a Slack notification is sent to `kyma-gopher-private-alerts`.
 
-### Manual trigger
+### Manual Trigger
 
-The workflow can be triggered manually with the following inputs:
+You can manually trigger the workflow with the following inputs:
 
 | Input | Required | Description |
 |-------|:--------:|-------------|
-| **`prev_tag`** | yes | Older release tag to use as the base of the diff (e.g. `1.29.13`) |
-| **`current_tag`** | no | Newer release tag to diff against. Defaults to the latest published release. |
+| `prev_tag` | yes | Older release tag to use as the base of the diff (for example, `1.29.13`) |
+| `current_tag` | no | Newer release tag to diff against. Defaults to the latest published release. |
 
 ## Reusable Workflows
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Switch from git describe --tags --exact-match head_sha to gh release list for resolving the diff range in workflow_run mode — the old approach failed because head_sha points to the commit that triggered the upstream workflow, not the bump commit that carries the release tag
- Add should_continue output to properly gate subsequent steps instead of exit 0 early exits that were silently swallowed by || true
- Simplify workflow_dispatch inputs to prev_tag (required) and current_tag (optional, defaults to latest release)
- Add Slack notification on failure
- Add fetch-tags: true to checkout step
- Remove ref: head_sha from checkout — no longer needed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
