### PR TITLE
Add provider label to kcp_keb_v2_operation_result metric

### DIFF
--- a/docs/user/06-10-metrics.md
+++ b/docs/user/06-10-metrics.md
@@ -21,7 +21,7 @@ Then, the Prometheus server pulls the metrics stored in KEB's memory and persist
 | kcp_keb_v2_instances_total                             | gauge     | -                                                                                                       | database          |
 | kcp_keb_v2_deprovisioning_duration_minutes             | histogram | plan_id                                                                                                 | event             |
 | kcp_keb_v2_provisioning_duration_minutes               | histogram | plan_id                                                                                                 | event             |
-| kcp_keb_v2_operation_result                            | gauge     | operation_id, instance_id, global_account_id, plan_id, type, state, error_category, error_reason, error | event             |
+| kcp_keb_v2_operation_result                            | gauge     | operation_id, instance_id, global_account_id, plan_id, type, state, error_category, error_reason, error, provider | event             |
 | kcp_keb_v2_operations_provisioning_failed_total        | counter   | plan_id                                                                                                 | event + database  |
 | kcp_keb_v2_operations_provisioning_in_progress_total   | gauge     | plan_id                                                                                                 | event + database  |
 | kcp_keb_v2_operations_provisioning_succeeded_total     | counter   | plan_id                                                                                                 | event + database  |

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -118,6 +118,27 @@ func GetLabels(op internal.Operation) map[string]string {
 	labels["error_category"] = string(op.LastError.GetComponent())
 	labels["error_reason"] = string(op.LastError.GetReason())
 	labels["error"] = op.LastError.Error()
-	labels["provider"] = op.CloudProvider
+	labels["provider"] = normalizeProvider(op.CloudProvider)
 	return labels
+}
+
+// normalizeProvider maps CloudProvider constant values to lowercase canonical names
+// for use as Prometheus label values. Unknown or empty values map to providerUnknown.
+const providerUnknown = "unknown"
+
+func normalizeProvider(p string) string {
+	switch p {
+	case "AWS":
+		return "aws"
+	case "Azure":
+		return "azure"
+	case "GCP":
+		return "gcp"
+	case "SapConvergedCloud":
+		return "sap-converged-cloud"
+	case "Alicloud":
+		return "alicloud"
+	default:
+		return providerUnknown
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -118,5 +118,6 @@ func GetLabels(op internal.Operation) map[string]string {
 	labels["error_category"] = string(op.LastError.GetComponent())
 	labels["error_reason"] = string(op.LastError.GetReason())
 	labels["error"] = op.LastError.Error()
+	labels["provider"] = op.CloudProvider
 	return labels
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -58,7 +58,7 @@ func TestGetLabels(t *testing.T) {
 		assert.Equal(t, "", labels["error_category"])
 		assert.Equal(t, "", labels["error_reason"])
 		assert.Equal(t, "", labels["error"])
-		assert.Equal(t, "", labels["provider"])
+		assert.Equal(t, "unknown", labels["provider"])
 	})
 
 	t.Run("returns map with exactly 12 keys", func(t *testing.T) {
@@ -68,4 +68,22 @@ func TestGetLabels(t *testing.T) {
 
 		assert.Len(t, labels, 12)
 	})
+}
+
+func TestNormalizeProvider(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected string
+	}{
+		{"AWS", "aws"},
+		{"Azure", "azure"},
+		{"GCP", "gcp"},
+		{"SapConvergedCloud", "sap-converged-cloud"},
+		{"Alicloud", "alicloud"},
+		{"unknown", "unknown"},
+		{"", "unknown"},
+		{"something-unexpected", "unknown"},
+	} {
+		assert.Equal(t, tc.expected, normalizeProvider(tc.input), "input: %q", tc.input)
+	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -41,6 +41,7 @@ func TestGetLabels(t *testing.T) {
 		assert.Contains(t, labels, "error_category")
 		assert.Contains(t, labels, "error_reason")
 		assert.Contains(t, labels, "error")
+		assert.Contains(t, labels, "provider")
 	})
 
 	t.Run("returns empty strings for zero-value fields", func(t *testing.T) {
@@ -57,13 +58,14 @@ func TestGetLabels(t *testing.T) {
 		assert.Equal(t, "", labels["error_category"])
 		assert.Equal(t, "", labels["error_reason"])
 		assert.Equal(t, "", labels["error"])
+		assert.Equal(t, "", labels["provider"])
 	})
 
-	t.Run("returns map with exactly 11 keys", func(t *testing.T) {
+	t.Run("returns map with exactly 12 keys", func(t *testing.T) {
 		op := internal.Operation{}
 
 		labels := GetLabels(op)
 
-		assert.Len(t, labels, 11)
+		assert.Len(t, labels, 12)
 	})
 }

--- a/internal/metrics/operations_result.go
+++ b/internal/metrics/operations_result.go
@@ -44,7 +44,7 @@ func newResultsCollector(db storage.Operations, cfg Config, logger *slog.Logger)
 			Subsystem: prometheusSubsystemV2,
 			Name:      "operation_result",
 			Help:      "Metrics of operations results",
-		}, []string{"operation_id", "instance_id", "global_account_id", "runtime_id", "shoot_name", "plan_id", "type", "state", "error_category", "error_reason", "error"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "runtime_id", "shoot_name", "plan_id", "type", "state", "error_category", "error_reason", "error", "provider"}),
 		pollingInterval:                  cfg.OperationResultPollingInterval,
 		finishedOperationRetentionPeriod: cfg.OperationResultFinishedOperationRetentionPeriod,
 	}


### PR DESCRIPTION
## Summary

- Add a `provider` label to the `kcp_keb_v2_operation_result` metric
- The value is the normalized cloud provider name: `aws`, `azure`, `gcp`, `sap-converged-cloud`, `alicloud`, or `unknown`
- Update metrics documentation to reflect the new label

## Motivation

When a RuntimeCR fails to reach Ready state, `error_reason` is always `"Runtime resource not in Ready state"` regardless of the actual root cause. This makes SLO burn-rate alerts fire on transient cloud provider outages that are indistinguishable from KEB-internal failures.

With a `provider` label, alert expressions can filter or group by hyperscaler:
```promql
kcp_keb_v2_operation_result{type=~"provision|deprovision", state="failed", provider!="aws"}
```

## Breaking Change

Adding a label changes the time series identity of `kcp_keb_v2_operation_result`. Existing dashboards and alert expressions that aggregate this metric without explicitly listing labels must be updated:

- Aggregations using `sum(kcp_keb_v2_operation_result)` will now produce separate series per provider — change to `sum without(provider)(...)` or add `by(...)` to preserve the previous behavior.
- Alert expressions that use `increase(kcp_keb_v2_operation_result{...}[...])` are unaffected if they match on specific label values, but aggregations across the full metric need review.

## Test Plan
- [ ] `go test ./internal/metrics/...` passes
- [ ] `make go-lint` passes