### PR TITLE
Fix non-deterministic TestStateReconciler failures due to container name conflict

### DIFF
--- a/internal/subaccountsync/state_reconciler_test.go
+++ b/internal/subaccountsync/state_reconciler_test.go
@@ -40,7 +40,19 @@ var logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 var useInMemoryStorage, _ = strconv.ParseBool(os.Getenv("DB_IN_MEMORY_FOR_E2E_TESTS"))
 
-var tearDownFunc func()
+func TestMain(m *testing.M) {
+	exitVal := 0
+	defer func() {
+		os.Exit(exitVal)
+	}()
+
+	if !useInMemoryStorage {
+		cleanup := setupStorageContainer()
+		defer cleanup()
+	}
+
+	exitVal = m.Run()
+}
 
 func setupSuite(t testing.TB) func(t testing.TB) {
 	logger.Info("setup suite")
@@ -48,15 +60,11 @@ func setupSuite(t testing.TB) func(t testing.TB) {
 		logger.Info("using in-memory storage")
 	} else {
 		logger.Info("using real storage")
-		tearDownFunc = setupStorageContainer()
 	}
 
 	return func(t testing.TB) {
 		r := recover()
 		logger.Info("teardown suite")
-		if tearDownFunc != nil {
-			tearDownFunc()
-		}
 		if r != nil {
 			panic(r)
 		}
@@ -68,9 +76,6 @@ func setupTestNilStorage(t testing.TB) (func(t testing.TB), storage.BrokerStorag
 
 	return func(t testing.TB) {
 		if r := recover(); r != nil {
-			if tearDownFunc != nil {
-				tearDownFunc()
-			}
 			panic(r)
 		}
 		logger.Info("teardown test")
@@ -85,9 +90,6 @@ func setupTestWithStorage(t testing.TB) (func(t testing.TB), storage.BrokerStora
 
 	return func(t testing.TB) {
 		if r := recover(); r != nil {
-			if tearDownFunc != nil {
-				tearDownFunc()
-			}
 			panic(r)
 		}
 		if storageCleanup != nil {

--- a/internal/subaccountsync/state_reconciler_test.go
+++ b/internal/subaccountsync/state_reconciler_test.go
@@ -40,17 +40,19 @@ var logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 var useInMemoryStorage, _ = strconv.ParseBool(os.Getenv("DB_IN_MEMORY_FOR_E2E_TESTS"))
 
+var (
+	containerOnce    sync.Once
+	containerCleanup func()
+)
+
 func TestMain(m *testing.M) {
 	exitVal := 0
 	defer func() {
+		if containerCleanup != nil {
+			containerCleanup()
+		}
 		os.Exit(exitVal)
 	}()
-
-	if !useInMemoryStorage {
-		cleanup := setupStorageContainer()
-		defer cleanup()
-	}
-
 	exitVal = m.Run()
 }
 
@@ -1596,6 +1598,9 @@ func getStorageForTests() (func() error, storage.BrokerStorage, error) {
 	if useInMemoryStorage {
 		return nil, storage.NewMemoryStorage(), nil
 	}
+	containerOnce.Do(func() {
+		containerCleanup = setupStorageContainer()
+	})
 	return storage.GetStorageForTests(brokerStorageTestConfig())
 }
 


### PR DESCRIPTION
Ref: #3110

## Root cause

`TestStateReconcilerWithFakeCisServer` and `TestStateReconciler` both called `setupSuite`, which each tried to create a Docker container named `"subaccount-sync-tests"`. When run sequentially, the second call races with the first container's cleanup and fails with:

```
Error response from daemon: Conflict. The container name "/subaccount-sync-tests" is already in use
```

This manifests as `timeout waiting for database access` in subtests and causes non-deterministic failures, especially with `-count=3`.

## Fix

Move the Docker container lifecycle into `TestMain` so the postgres container is created once per test binary run — the same pattern used by `cmd/broker/storage_test.go`. Remove the now-unused `tearDownFunc` global and the dead `tearDownFunc` calls in the per-test teardown functions.

## Test Plan
- [ ] `go test -count=3 -run DB_IN_MEMORY_FOR_E2E_TESTS=false ./internal/subaccountsync/...` passes consistently
- [ ] `make go-lint` passes