### PR TITLE
Improve Combined view semantics and analytics UI

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -277,8 +277,10 @@ func NewBrokerSuiteTestWithConfig(t *testing.T, cfg *Config, version ...string) 
 			plans, regionsByPlan := analytics.BuildPlanRegionIndex(provParams, planIDToName)
 			resp := analytics.StatsResponse{
 				TotalInstances: len(provParams),
+				TotalUpdates:   len(updateParams),
 				Provisioning:   analytics.AggregateProvisioning(provParams),
 				Updates:        analytics.AggregateUpdates(updateParams),
+				Combined:       analytics.AggregateCombined(provParams, updateParams),
 				Distributions:  analytics.BuildDistributions(provParams),
 				Plans:          plans,
 				RegionsByPlan:  regionsByPlan,

--- a/cmd/keb-analytics/main.go
+++ b/cmd/keb-analytics/main.go
@@ -15,7 +15,6 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/vrischmann/envconfig"
 
-	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/analytics"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 )
@@ -38,8 +37,8 @@ type Config struct {
 
 type cache struct {
 	resp          analytics.StatsResponse
-	provParams    []internal.ProvisioningParameters
-	updateParams  []internal.UpdatingParametersDTO
+	provParams    []analytics.ProvisioningParamsWithID
+	updateParams  []analytics.UpdateParamsWithID
 	plans         []string
 	regionsByPlan map[string][]string
 }
@@ -105,8 +104,10 @@ func main() {
 		plans, regionsByPlan := analytics.BuildPlanRegionIndex(provParams, planIDToName)
 		resp := analytics.StatsResponse{
 			TotalInstances: len(provParams),
+			TotalUpdates:   len(updateParams),
 			Provisioning:   analytics.AggregateProvisioning(provParams),
 			Updates:        analytics.AggregateUpdates(updateParams),
+			Combined:       analytics.AggregateCombined(provParams, updateParams),
 			Distributions:  analytics.BuildDistributions(provParams),
 			Plans:          plans,
 			RegionsByPlan:  regionsByPlan,
@@ -206,8 +207,8 @@ func main() {
 // buildFilteredStats filters provParams/updateParams by plan and region, then aggregates.
 // plans and regionsByPlan are always the full unfiltered index (for dropdown population).
 func buildFilteredStats(
-	provParams []internal.ProvisioningParameters,
-	updateParams []internal.UpdatingParametersDTO,
+	provParams []analytics.ProvisioningParamsWithID,
+	updateParams []analytics.UpdateParamsWithID,
 	planFilter, regionFilter string,
 	planIDToName map[string]string,
 	plans []string,
@@ -222,8 +223,10 @@ func buildFilteredStats(
 	}
 	return analytics.StatsResponse{
 		TotalInstances: len(filtered),
+		TotalUpdates:   len(updateParams),
 		Provisioning:   analytics.AggregateProvisioning(filtered),
 		Updates:        analytics.AggregateUpdates(updateParams),
+		Combined:       analytics.AggregateCombined(filtered, updateParams),
 		Distributions:  analytics.BuildDistributions(filtered),
 		Plans:          plans,
 		RegionsByPlan:  regionsByPlan,

--- a/cmd/keb-analytics/static/index.html
+++ b/cmd/keb-analytics/static/index.html
@@ -27,6 +27,7 @@
       border-bottom-color: #0070f3;
       font-weight: 700;
     }
+    .tab-info { color: #555; font-size: 0.88rem; margin: 0.4rem 0 0.8rem; max-width: 800px; }
   </style>
 </head>
 <body>
@@ -58,29 +59,37 @@
   <p id="error"></p>
 
   <div id="tab-bar" style="display:flex;gap:0;border-bottom:2px solid #ccc;margin-bottom:1rem">
-    <button class="tab-btn active" data-tab="provisioning">Provisioning</button>
+    <button class="tab-btn active" data-tab="combined">Combined</button>
+    <button class="tab-btn"        data-tab="provisioning">Provisioning</button>
     <button class="tab-btn"        data-tab="update">Update</button>
-    <button class="tab-btn"        data-tab="combined">Combined</button>
     <button class="tab-btn"        data-tab="distribution">Value Distribution</button>
   </div>
 
-  <div id="tab-provisioning" class="tab-pane">
+  <div id="tab-combined" class="tab-pane">
+    <p class="tab-info">An active instance is counted as using a parameter if it was set in its provisioning <em>or</em> in any of its update operations. Each instance is counted at most once per parameter. Total = number of active instances.</p>
+    <div class="chart-container"><canvas id="combinedChart"></canvas></div>
+  </div>
+
+  <div id="tab-provisioning" class="tab-pane" style="display:none">
+    <p class="tab-info">Each active instance is counted once per parameter if that parameter was set in its provisioning operation. Total = number of active instances.</p>
     <div class="chart-container"><canvas id="provChart"></canvas></div>
   </div>
 
   <div id="tab-update" class="tab-pane" style="display:none">
+    <p class="tab-info">Each succeeded update operation is counted once per parameter if that parameter was set in that update. Percentage is out of all update operations on active instances.</p>
     <p id="update-total"></p>
     <div class="chart-container"><canvas id="updateChart"></canvas></div>
   </div>
 
-  <div id="tab-combined" class="tab-pane" style="display:none">
-    <div class="chart-container"><canvas id="combinedChart"></canvas></div>
-  </div>
-
   <div id="tab-distribution" class="tab-pane" style="display:none">
+    <p class="tab-info">Value breakdown for selected parameters across active instances that provisioned with that parameter set.</p>
     <div id="dist-controls" style="display:flex;align-items:center;gap:1rem;margin-bottom:1rem">
       <label for="distParam" style="font-weight:bold">Parameter:</label>
       <select id="distParam"></select>
+      <label style="display:flex;align-items:center;gap:0.4rem;cursor:pointer">
+        <input type="checkbox" id="distIncludeNull">
+        <span>not provided/null included</span>
+      </label>
     </div>
     <div class="chart-container"><canvas id="distChart"></canvas></div>
   </div>
@@ -88,7 +97,7 @@
   <script>
     const charts = [];
     let currentData = null; // last fetched StatsResponse (full, unfiltered by plan/region)
-    let activeTab = 'provisioning';
+    let activeTab = 'combined';
 
     function destroyCharts() {
       charts.forEach(c => c.destroy());
@@ -141,11 +150,7 @@
 
     function renderBar(canvasId, stats) {
       if (!stats || !stats.parameters || stats.parameters.length === 0) return;
-      const labels = stats.parameters.map(p =>
-        p.total > 0
-          ? p.parameter + '  (' + p.set_count + ')'
-          : p.parameter
-      );
+      const labels = stats.parameters.map(p => p.parameter + '  (' + p.set_count + ')');
       const pct = stats.parameters.map(p =>
         p.total > 0 ? ((p.set_count / p.total) * 100).toFixed(1) : 0
       );
@@ -156,33 +161,30 @@
           datasets: [{ label: '% instances with parameter set', data: pct,
             backgroundColor: 'rgba(54,162,235,0.6)' }]
         },
-        options: { indexAxis: 'y', scales: { x: { max: 100 } } }
+        options: { indexAxis: 'y', scales: { x: { max: 100 }, y: { reverse: true } } }
       });
       charts.push(chart);
     }
 
-    // mergeStats merges two ParameterStats objects into one.
-    // Parameters present in both have set_count and total summed.
-    // Result is sorted by descending set_count, then alphabetically.
-    function mergeStats(prov, upd) {
-      const map = {};
-      function absorb(stats) {
-        (stats.parameters || []).forEach(p => {
-          if (!map[p.parameter]) map[p.parameter] = { set_count: 0, total: 0 };
-          map[p.parameter].set_count += p.set_count;
-          map[p.parameter].total    += p.total;
-        });
-      }
-      absorb(prov);
-      absorb(upd);
-      const parameters = Object.entries(map)
-        .map(([parameter, v]) => ({ parameter, set_count: v.set_count, total: v.total }))
-        .sort((a, b) =>
-          b.set_count !== a.set_count
-            ? b.set_count - a.set_count
-            : a.parameter.localeCompare(b.parameter)
-        );
-      return { parameters };
+    function renderUpdateBar(canvasId, stats, totalUpdates) {
+      if (!stats || !stats.parameters || stats.parameters.length === 0) return;
+      const labels = stats.parameters.map(p => {
+        const pct = p.total > 0 ? ((p.set_count / p.total) * 100).toFixed(1) : 0;
+        return p.parameter + '  (' + p.set_count + ' times / ' + pct + '%)';
+      });
+      const pct = stats.parameters.map(p =>
+        p.total > 0 ? ((p.set_count / p.total) * 100).toFixed(1) : 0
+      );
+      const chart = new Chart(document.getElementById(canvasId), {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{ label: '% of update operations with parameter set', data: pct,
+            backgroundColor: 'rgba(54,162,235,0.6)' }]
+        },
+        options: { indexAxis: 'y', scales: { x: { max: 100 }, y: { reverse: true } } }
+      });
+      charts.push(chart);
     }
 
     function populateDistParam(distributions) {
@@ -209,16 +211,33 @@
       const dist = (data.distributions || []).find(d => d.parameter === chosen);
       if (!dist) return;
 
-      const labels = Object.keys(dist.values);
-      const vals   = Object.values(dist.values);
-      const chart  = new Chart(document.getElementById('distChart'), {
+      const includeNull = document.getElementById('distIncludeNull').checked;
+      const total = data.total_instances;
+
+      const entries = Object.entries(dist.values)
+        .sort((a, b) => b[1] - a[1]);
+      const setCount = entries.reduce((s, e) => s + e[1], 0);
+
+      if (includeNull && total > setCount) {
+        entries.push(['not provided/null', total - setCount]);
+      }
+
+      const labels = entries.map(([v, n]) => {
+        const pct = total > 0 ? ((n / total) * 100).toFixed(1) : 0;
+        return v + '  (' + n + ' times / ' + pct + '% all)';
+      });
+      const vals = entries.map(([, n]) => n);
+      const colors = entries.map(([v]) =>
+        v === 'not provided/null' ? 'rgba(180,180,180,0.6)' : 'rgba(255,159,64,0.6)'
+      );
+
+      const chart = new Chart(document.getElementById('distChart'), {
         type: 'bar',
         data: {
           labels,
-          datasets: [{ label: 'count', data: vals,
-            backgroundColor: 'rgba(255,159,64,0.6)' }]
+          datasets: [{ label: 'count', data: vals, backgroundColor: colors }]
         },
-        options: { scales: { y: { ticks: { stepSize: 1, precision: 0 } } } }
+        options: { indexAxis: 'y', scales: { y: { reverse: true }, x: { ticks: { stepSize: 1, precision: 0 } } } }
       });
       charts.push(chart);
     }
@@ -226,19 +245,18 @@
     function renderActiveTab(data) {
       destroyCharts();
       document.getElementById('error').textContent = '';
+      document.getElementById('update-total').textContent = '';
       document.getElementById('total').textContent =
         'Total active instances: ' + data.total_instances;
 
-      if (activeTab === 'provisioning') {
+      if (activeTab === 'combined') {
+        renderBar('combinedChart', data.combined);
+      } else if (activeTab === 'provisioning') {
         renderBar('provChart', data.provisioning);
       } else if (activeTab === 'update') {
-        const updateTotal = (data.updates.parameters && data.updates.parameters.length > 0)
-          ? data.updates.parameters[0].total : 0;
         document.getElementById('update-total').textContent =
-          'Total update operations: ' + updateTotal;
-        renderBar('updateChart', data.updates);
-      } else if (activeTab === 'combined') {
-        renderBar('combinedChart', mergeStats(data.provisioning, data.updates));
+          'Total update operations: ' + data.total_updates;
+        renderUpdateBar('updateChart', data.updates, data.total_updates);
       } else if (activeTab === 'distribution') {
         renderDistTab(data);
       }
@@ -251,7 +269,6 @@
       document.querySelectorAll('.tab-btn').forEach(b => {
         b.classList.toggle('active', b.dataset.tab === name);
       });
-      if (name !== 'update') document.getElementById('update-total').textContent = '';
       if (currentData) renderActiveTab(currentData);
     }
 
@@ -261,6 +278,13 @@
     });
 
     document.getElementById('distParam').addEventListener('change', () => {
+      if (currentData) {
+        destroyCharts();
+        renderDistTab(currentData);
+      }
+    });
+
+    document.getElementById('distIncludeNull').addEventListener('change', () => {
       if (currentData) {
         destroyCharts();
         renderDistTab(currentData);

--- a/internal/analytics/aggregator.go
+++ b/internal/analytics/aggregator.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
-	"github.com/kyma-project/kyma-environment-broker/internal"
 )
 
 type fieldBehavior int
@@ -198,27 +197,79 @@ func record(counts map[string]map[string]int, key, value string) {
 }
 
 // buildCounts walks all params once and returns field-value occurrence counts.
-func buildCounts(params []internal.ProvisioningParameters) map[string]map[string]int {
+func buildCounts(params []ProvisioningParamsWithID) map[string]map[string]int {
 	counts := make(map[string]map[string]int)
 	for _, p := range params {
-		walkFields(p.Parameters, provisioningFieldConfig, counts)
+		walkFields(p.Params.Parameters, provisioningFieldConfig, counts)
 	}
 	return counts
 }
 
 // AggregateProvisioning computes parameter usage stats from a slice of ProvisioningParameters.
-func AggregateProvisioning(params []internal.ProvisioningParameters) ParameterStats {
-	return toParameterStats(buildCounts(params), len(params))
+func AggregateProvisioning(params []ProvisioningParamsWithID) ParameterStats {
+	plain := PlainProvisioningParams(params)
+	counts := make(map[string]map[string]int)
+	for _, p := range plain {
+		walkFields(p.Parameters, provisioningFieldConfig, counts)
+	}
+	return toParameterStats(counts, len(plain))
 }
 
-// AggregateUpdates computes parameter usage stats from a slice of UpdatingParametersDTO.
-func AggregateUpdates(params []internal.UpdatingParametersDTO) ParameterStats {
+// AggregateUpdates computes parameter usage stats from a slice of UpdateParamsWithID.
+func AggregateUpdates(params []UpdateParamsWithID) ParameterStats {
 	counts := make(map[string]map[string]int)
-	total := len(params)
 	for _, p := range params {
-		walkFields(p, updatingFieldConfig, counts)
+		walkFields(p.Params, updatingFieldConfig, counts)
 	}
-	return toParameterStats(counts, total)
+	return toParameterStats(counts, len(params))
+}
+
+// AggregateCombined computes per-instance parameter usage: an instance is counted as
+// "using" a parameter if it was set in its provisioning operation OR in any update operation.
+// total = number of unique active instances (from provParams).
+func AggregateCombined(provParams []ProvisioningParamsWithID, updateParams []UpdateParamsWithID) ParameterStats {
+	// instancesWithParam[param] = set of instance IDs that have the param set
+	instancesWithParam := make(map[string]map[string]struct{})
+
+	record := func(instanceID, param string) {
+		if _, ok := instancesWithParam[param]; !ok {
+			instancesWithParam[param] = make(map[string]struct{})
+		}
+		instancesWithParam[param][instanceID] = struct{}{}
+	}
+
+	for _, p := range provParams {
+		counts := make(map[string]map[string]int)
+		walkFields(p.Params.Parameters, provisioningFieldConfig, counts)
+		for param := range counts {
+			record(p.InstanceID, param)
+		}
+	}
+
+	for _, p := range updateParams {
+		counts := make(map[string]map[string]int)
+		walkFields(p.Params, updatingFieldConfig, counts)
+		for param := range counts {
+			record(p.InstanceID, param)
+		}
+	}
+
+	total := len(provParams)
+	var result []ParameterStat
+	for param, instances := range instancesWithParam {
+		result = append(result, ParameterStat{
+			Parameter: param,
+			SetCount:  len(instances),
+			Total:     total,
+		})
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].SetCount != result[j].SetCount {
+			return result[i].SetCount > result[j].SetCount
+		}
+		return result[i].Parameter < result[j].Parameter
+	})
+	return ParameterStats{Parameters: result}
 }
 
 // toParameterStats converts raw counts into a ranked ParameterStats list.
@@ -245,7 +296,7 @@ func toParameterStats(counts map[string]map[string]int, total int) ParameterStat
 }
 
 // BuildDistributions computes value breakdowns for selected distribution fields.
-func BuildDistributions(params []internal.ProvisioningParameters) []DistributionStat {
+func BuildDistributions(params []ProvisioningParamsWithID) []DistributionStat {
 	distributionFields := []string{"machineType", "region", "autoScalerMin", "autoScalerMax"}
 	counts := buildCounts(params)
 	var result []DistributionStat
@@ -263,21 +314,21 @@ func BuildDistributions(params []internal.ProvisioningParameters) []Distribution
 // BuildPlanRegionIndex builds a map of plan name → sorted distinct regions,
 // plus a sorted list of all plan names. planIDToName maps plan UUID → plan name.
 // The special key "" in the returned map contains all regions across all plans.
-func BuildPlanRegionIndex(params []internal.ProvisioningParameters, planIDToName map[string]string) ([]string, map[string][]string) {
+func BuildPlanRegionIndex(params []ProvisioningParamsWithID, planIDToName map[string]string) ([]string, map[string][]string) {
 	planSet := make(map[string]struct{})
 	// plan → region → present
 	byPlan := make(map[string]map[string]struct{})
 
 	for _, p := range params {
-		name := planIDToName[p.PlanID]
+		name := planIDToName[p.Params.PlanID]
 		if name == "" {
-			name = p.PlanID // fallback to raw ID
+			name = p.Params.PlanID // fallback to raw ID
 		}
 		planSet[name] = struct{}{}
 
 		region := ""
-		if p.Parameters.Region != nil {
-			region = *p.Parameters.Region
+		if p.Params.Parameters.Region != nil {
+			region = *p.Params.Parameters.Region
 		}
 
 		if _, ok := byPlan[name]; !ok {
@@ -321,12 +372,12 @@ func BuildPlanRegionIndex(params []internal.ProvisioningParameters, planIDToName
 
 // FilterByPlan returns only params matching the given plan name.
 // planIDToName maps plan UUID → plan name.
-func FilterByPlan(params []internal.ProvisioningParameters, plan string, planIDToName map[string]string) []internal.ProvisioningParameters {
+func FilterByPlan(params []ProvisioningParamsWithID, plan string, planIDToName map[string]string) []ProvisioningParamsWithID {
 	result := params[:0:0]
 	for _, p := range params {
-		name := planIDToName[p.PlanID]
+		name := planIDToName[p.Params.PlanID]
 		if name == "" {
-			name = p.PlanID
+			name = p.Params.PlanID
 		}
 		if name == plan {
 			result = append(result, p)
@@ -336,10 +387,10 @@ func FilterByPlan(params []internal.ProvisioningParameters, plan string, planIDT
 }
 
 // FilterByRegion returns only params where Parameters.Region matches the given region.
-func FilterByRegion(params []internal.ProvisioningParameters, region string) []internal.ProvisioningParameters {
+func FilterByRegion(params []ProvisioningParamsWithID, region string) []ProvisioningParamsWithID {
 	result := params[:0:0]
 	for _, p := range params {
-		if p.Parameters.Region != nil && *p.Parameters.Region == region {
+		if p.Params.Parameters.Region != nil && *p.Params.Parameters.Region == region {
 			result = append(result, p)
 		}
 	}

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -158,10 +158,10 @@ func TestWalkFields_NetworkingWithDualStack(t *testing.T) {
 }
 
 func TestAggregateProvisioning_RanksParameters(t *testing.T) {
-	params := []internal.ProvisioningParameters{
-		{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr("m6i.xlarge")}},
-		{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr("m6i.xlarge")}},
-		{Parameters: pkg.ProvisioningParametersDTO{}},
+	params := []ProvisioningParamsWithID{
+		{InstanceID: "i1", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr("m6i.xlarge")}}},
+		{InstanceID: "i2", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr("m6i.xlarge")}}},
+		{InstanceID: "i3", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{}}},
 	}
 	stats := AggregateProvisioning(params)
 	assert.Equal(t, 3, stats.Parameters[0].Total)
@@ -176,10 +176,10 @@ func TestAggregateProvisioning_RanksParameters(t *testing.T) {
 }
 
 func TestAggregateUpdates_CountsSetFields(t *testing.T) {
-	params := []internal.UpdatingParametersDTO{
-		{MachineType: strPtr("m6i.xlarge")},
-		{MachineType: strPtr("m5.xlarge")},
-		{},
+	params := []UpdateParamsWithID{
+		{InstanceID: "i1", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m6i.xlarge")}},
+		{InstanceID: "i2", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m5.xlarge")}},
+		{InstanceID: "i3", Params: internal.UpdatingParametersDTO{}},
 	}
 	stats := AggregateUpdates(params)
 	assert.Equal(t, 3, stats.Parameters[0].Total)
@@ -195,9 +195,9 @@ func TestAggregateUpdates_CountsSetFields(t *testing.T) {
 
 func TestBuildDistributions_IncludesRegion(t *testing.T) {
 	region := "eu-central-1"
-	params := []internal.ProvisioningParameters{
-		{Parameters: pkg.ProvisioningParametersDTO{Region: &region}},
-		{Parameters: pkg.ProvisioningParametersDTO{Region: &region}},
+	params := []ProvisioningParamsWithID{
+		{InstanceID: "i1", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{Region: &region}}},
+		{InstanceID: "i2", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{Region: &region}}},
 	}
 	dists := BuildDistributions(params)
 	found := false

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -27,9 +27,21 @@ type TimeRange struct {
 	To   time.Time
 }
 
-func (r *DBReader) fetchProvisioningParams(tr TimeRange) ([]internal.ProvisioningParameters, error) {
+// ProvisioningParamsWithID pairs an instance ID with its provisioning parameters.
+type ProvisioningParamsWithID struct {
+	InstanceID string
+	Params     internal.ProvisioningParameters
+}
+
+// UpdateParamsWithID pairs an instance ID with its update parameters.
+type UpdateParamsWithID struct {
+	InstanceID string
+	Params     internal.UpdatingParametersDTO
+}
+
+func (r *DBReader) fetchProvisioningParams(tr TimeRange) ([]ProvisioningParamsWithID, error) {
 	q := `
-SELECT o.provisioning_parameters
+SELECT o.instance_id, o.provisioning_parameters
 FROM operations o
 JOIN instances i ON i.instance_id = o.instance_id
 WHERE o.type = 'provision'
@@ -46,6 +58,7 @@ WHERE o.type = 'provision'
 	}
 
 	var rows []struct {
+		InstanceID             string `db:"instance_id"`
 		ProvisioningParameters string `db:"provisioning_parameters"`
 	}
 	_, err := r.session.SelectBySql(q, args...).Load(&rows)
@@ -53,14 +66,14 @@ WHERE o.type = 'provision'
 		return nil, fmt.Errorf("fetching active provisioning params: %w", err)
 	}
 
-	result := make([]internal.ProvisioningParameters, 0, len(rows))
+	result := make([]ProvisioningParamsWithID, 0, len(rows))
 	for _, row := range rows {
 		p, err := parseProvisioningParameters(row.ProvisioningParameters)
 		if err != nil {
 			slog.Warn("analytics: skipping malformed provisioning_parameters row", "error", err)
 			continue
 		}
-		result = append(result, p)
+		result = append(result, ProvisioningParamsWithID{InstanceID: row.InstanceID, Params: p})
 	}
 	return result, nil
 }
@@ -68,18 +81,18 @@ WHERE o.type = 'provision'
 // FetchActiveProvisioningParams returns ProvisioningParameters for all active instances.
 // Active = row exists in instances table with deleted_at = zero (not permanently deprovisioned,
 // not failed-deprovision). Temporary deprovisioned instances are considered active.
-func (r *DBReader) FetchActiveProvisioningParams() ([]internal.ProvisioningParameters, error) {
+func (r *DBReader) FetchActiveProvisioningParams() ([]ProvisioningParamsWithID, error) {
 	return r.fetchProvisioningParams(TimeRange{})
 }
 
 // FetchActiveProvisioningParamsInRange is like FetchActiveProvisioningParams but scoped to tr.
-func (r *DBReader) FetchActiveProvisioningParamsInRange(tr TimeRange) ([]internal.ProvisioningParameters, error) {
+func (r *DBReader) FetchActiveProvisioningParamsInRange(tr TimeRange) ([]ProvisioningParamsWithID, error) {
 	return r.fetchProvisioningParams(tr)
 }
 
-func (r *DBReader) fetchUpdateParams(tr TimeRange) ([]internal.UpdatingParametersDTO, error) {
+func (r *DBReader) fetchUpdateParams(tr TimeRange) ([]UpdateParamsWithID, error) {
 	q := `
-SELECT o.data
+SELECT o.instance_id, o.data
 FROM operations o
 JOIN instances i ON i.instance_id = o.instance_id
 WHERE o.type = 'update'
@@ -96,32 +109,33 @@ WHERE o.type = 'update'
 	}
 
 	var rows []struct {
-		Data string `db:"data"`
+		InstanceID string `db:"instance_id"`
+		Data       string `db:"data"`
 	}
 	_, err := r.session.SelectBySql(q, args...).Load(&rows)
 	if err != nil {
 		return nil, fmt.Errorf("fetching update params: %w", err)
 	}
 
-	result := make([]internal.UpdatingParametersDTO, 0, len(rows))
+	result := make([]UpdateParamsWithID, 0, len(rows))
 	for _, row := range rows {
 		var op internal.Operation
 		if err := json.Unmarshal([]byte(row.Data), &op); err != nil {
 			slog.Warn("analytics: skipping malformed operation data row", "error", err)
 			continue
 		}
-		result = append(result, op.UpdatingParameters)
+		result = append(result, UpdateParamsWithID{InstanceID: row.InstanceID, Params: op.UpdatingParameters})
 	}
 	return result, nil
 }
 
 // FetchUpdateParams returns UpdatingParametersDTO for all update operations on active instances.
-func (r *DBReader) FetchUpdateParams() ([]internal.UpdatingParametersDTO, error) {
+func (r *DBReader) FetchUpdateParams() ([]UpdateParamsWithID, error) {
 	return r.fetchUpdateParams(TimeRange{})
 }
 
 // FetchUpdateParamsInRange is like FetchUpdateParams but scoped to tr.
-func (r *DBReader) FetchUpdateParamsInRange(tr TimeRange) ([]internal.UpdatingParametersDTO, error) {
+func (r *DBReader) FetchUpdateParamsInRange(tr TimeRange) ([]UpdateParamsWithID, error) {
 	return r.fetchUpdateParams(tr)
 }
 
@@ -134,4 +148,22 @@ func parseProvisioningParameters(raw string) (internal.ProvisioningParameters, e
 		return internal.ProvisioningParameters{}, fmt.Errorf("parsing provisioning_parameters: %w", err)
 	}
 	return p, nil
+}
+
+// PlainProvisioningParams extracts just the ProvisioningParameters slice from ProvisioningParamsWithID.
+func PlainProvisioningParams(params []ProvisioningParamsWithID) []internal.ProvisioningParameters {
+	result := make([]internal.ProvisioningParameters, len(params))
+	for i, p := range params {
+		result[i] = p.Params
+	}
+	return result
+}
+
+// PlainUpdateParams extracts just the UpdatingParametersDTO slice from UpdateParamsWithID.
+func PlainUpdateParams(params []UpdateParamsWithID) []internal.UpdatingParametersDTO {
+	result := make([]internal.UpdatingParametersDTO, len(params))
+	for i, p := range params {
+		result[i] = p.Params
+	}
+	return result
 }

--- a/internal/analytics/model.go
+++ b/internal/analytics/model.go
@@ -31,8 +31,10 @@ type DistributionStat struct {
 // StatsResponse is the top-level JSON returned by GET /api/stats.
 type StatsResponse struct {
 	TotalInstances int                 `json:"total_instances"`
+	TotalUpdates   int                 `json:"total_updates"`
 	Provisioning   ParameterStats      `json:"provisioning"`
 	Updates        ParameterStats      `json:"updates"`
+	Combined       ParameterStats      `json:"combined"`
 	Distributions  []DistributionStat  `json:"distributions"`
 	Plans          []string            `json:"plans"`
 	RegionsByPlan  map[string][]string `json:"regions_by_plan"`


### PR DESCRIPTION
## Summary

- Fixes Combined tab semantics: each active instance is counted once per parameter if it was set in provisioning **or** any update operation (previously used operation-weighted client-side merge)
- Introduces `ProvisioningParamsWithID` / `UpdateParamsWithID` types and replaces NOT IN subquery with JOIN on instances table
- Adds `TotalUpdates` to `StatsResponse`; Update tab shows total operation count and per-row `(N times / X%)` labels
- Adds per-row instance count `(N)` to Provisioning and Combined bar labels
- Adds per-tab info text explaining how numbers are calculated
- Fixes chart ordering: most-used parameter on top
- Combined is now the default first tab; dead client-side `mergeStats` JS removed

Relates to https://github.com/kyma-project/kyma-environment-broker/issues/3043