### PR TITLE
Add Claude Code skills and document them in `CLAUDE.md`

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -32,6 +32,8 @@ Create a git commit for staged or unstaged changes in the KEB repository.
 
 5. **Commit** once confirmed.
 
+6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes?"  If yes, run `git push`.
+
 ---
 
 ## Commit message conventions

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: commit
+description: Drafts and creates a git commit following KEB commit message conventions.
+---
+
+# commit
+
+Create a git commit for staged or unstaged changes in the KEB repository.
+
+## Usage
+
+```
+/commit [optional hint about what changed]
+```
+
+**Examples:**
+- `/commit`
+- `/commit Add quota validation step`
+- `/commit Fix deprovisioning race condition`
+
+---
+
+## What to do
+
+1. **Check current state** — run `git status` and `git diff` (staged + unstaged) to understand what changed. If nothing has changed, say so and stop.
+
+2. **Stage changes** — if files are unstaged and the user didn't already stage them, ask which files to include before staging. Never run `git add -A` or `git add .` without asking — that can accidentally commit test data, `.env` files, or generated files.
+
+3. **Draft the commit message** using the conventions below.
+
+4. **Show the message** to the user for approval before committing. Ask: "Shall I commit with this message?"
+
+5. **Commit** once confirmed.
+
+---
+
+## Commit message conventions
+
+```
+<Short summary>
+
+[optional body — only if the why isn't obvious from the diff]
+```
+
+**Short summary:** imperative mood, title case, no trailing period, ≤72 chars.
+
+**Examples:**
+```
+Add quota validation step
+Fix deprovisioning race condition
+Handle missing runtime ID gracefully
+Add unit tests for CreateRuntimeResource retry logic
+Update CLAUDE.md with new step registration pattern
+Bump golang to 1.26.3-alpine3.22
+```
+
+---
+
+## Rules
+
+- Never commit files that look like secrets (`.env`, `credentials*.json`, `*_key.pem`, etc.) — warn the user if such files are staged.
+- Never use `--no-verify`.
+- Never amend published commits. Create a new commit instead.
+- If a pre-commit hook fails, fix the issue and create a **new** commit — do not `--amend`.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -32,7 +32,7 @@ Create a git commit for staged or unstaged changes in the KEB repository.
 
 5. **Commit** once confirmed.
 
-6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes?"  If yes, run `git push -u origin HEAD`.
+6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes to `<current-branch>`?" If yes, run `git push -u origin HEAD`. If no, ask which branch to push to and run `git push -u origin HEAD:<target-branch>`.
 
 ---
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -32,7 +32,7 @@ Create a git commit for staged or unstaged changes in the KEB repository.
 
 5. **Commit** once confirmed.
 
-6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes?"  If yes, run `git push`.
+6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes?"  If yes, run `git push -u origin HEAD`.
 
 ---
 

--- a/.claude/skills/new-step/SKILL.md
+++ b/.claude/skills/new-step/SKILL.md
@@ -81,10 +81,16 @@ func (s *{{StepName}}Step) Run(operation internal.Operation, log *slog.Logger) (
 
 Use this template:
 
+Use the fixture function that matches the operation type:
+- provisioning → `fixture.FixProvisioningOperation("op-id", "instance-id")`
+- deprovisioning → `fixture.FixDeprovisioningOperation("op-id", "instance-id")`
+- update → `fixture.FixUpdatingOperation("op-id", "instance-id")`
+
 ```go
 package {{package}}
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
@@ -98,11 +104,11 @@ func Test{{StepName}}Step_HappyPath(t *testing.T) {
 	st := storage.NewMemoryStorage()
 	step := New{{StepName}}Step(st.Operations())
 
-	op := fixture.FixProvisioningOperation("op-id", "instance-id")
+	op := fixture.Fix{{OperationType}}Operation("op-id", "instance-id")
 	require.NoError(t, st.Operations().InsertOperation(op))
 
 	// when
-	result, retry, err := step.Run(op, fixLogger())
+	result, retry, err := step.Run(op, slog.Default())
 
 	// then
 	assert.NoError(t, err)
@@ -114,7 +120,7 @@ func Test{{StepName}}Step_HappyPath(t *testing.T) {
 **Key rules:**
 - Use `fixture.FixProvisioningOperation` / `fixture.FixDeprovisioningOperation` / `fixture.FixInstance` from `internal/fixture/`.
 - Use `storage.NewMemoryStorage()` — never PostgreSQL in unit tests.
-- Use `fixLogger()` — it is already defined in other `_test.go` files in the same package; don't redefine it.
+- Use `slog.Default()` for the logger. If the package already defines a `fixLogger()` helper (check other `_test.go` files in the same package), use that instead — but do not redefine it.
 - Use `require` for setup (fatal on failure), `assert` for outcome checks.
 
 ### 3. Registration reminder

--- a/.claude/skills/new-step/SKILL.md
+++ b/.claude/skills/new-step/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: new-step
+description: Scaffolds a new KEB provisioning/deprovisioning/update step with implementation and test file.
+---
+
+# new-step
+
+Scaffold a new KEB process step (provisioning, deprovisioning, or update) with its implementation file and test file.
+
+## Usage
+
+```
+/new-step <StepName> [provisioning|deprovisioning|update]
+```
+
+**Examples:**
+- `/new-step ValidateQuota provisioning`
+- `/new-step ArchiveAuditLog deprovisioning`
+- `/new-step SyncLabels update`
+
+If the operation type is omitted, ask the user which one they want.
+
+---
+
+## What to do
+
+Given `<StepName>` and the operation type, produce two files:
+
+### 1. Implementation file
+
+**Path:** `internal/process/<operation_type>/<snake_case_name>_step.go`
+
+Use this template (replace `{{StepName}}`, `{{snake_case_name}}`, `{{Pascal_Snake_name}}`, `{{package}}`):
+
+- `{{StepName}}` — PascalCase struct name, e.g. `ValidateQuota`
+- `{{snake_case_name}}` — file name part, e.g. `validate_quota`
+- `{{Pascal_Snake_name}}` — `Name()` return value: PascalCase words joined by underscores, e.g. `Validate_Quota`
+- `{{package}}` — Go package name (`provisioning`, `deprovisioning`, or `update`)
+
+```go
+package {{package}}
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+)
+
+type {{StepName}}Step struct {
+	operationManager *process.OperationManager
+}
+
+func New{{StepName}}Step(os storage.Operations) *{{StepName}}Step {
+	step := &{{StepName}}Step{}
+	step.operationManager = process.NewOperationManager(os, step.Name(), kebError.KEBDependency)
+	return step
+}
+
+func (s *{{StepName}}Step) Name() string {
+	return "{{Pascal_Snake_name}}"
+}
+
+func (s *{{StepName}}Step) Run(operation internal.Operation, log *slog.Logger) (internal.Operation, time.Duration, error) {
+	// TODO: implement
+	return operation, 0, nil
+}
+```
+
+**Key rules:**
+- `kebError` dependency: use `KEBDependency` as default; change to `InfrastructureManagerDependency`, `LifeCycleManagerDependency`, etc. if the step calls an external system — ask the user if unsure.
+- Add only the dependencies actually needed (storage, k8sClient, etc.). Don't add fields speculatively.
+- The package name matches the directory: `provisioning`, `deprovisioning`, or `update`.
+
+### 2. Test file
+
+**Path:** `internal/process/<operation_type>/<snake_case_name>_step_test.go`
+
+Use this template:
+
+```go
+package {{package}}
+
+import (
+	"testing"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test{{StepName}}Step_HappyPath(t *testing.T) {
+	// given
+	st := storage.NewMemoryStorage()
+	step := New{{StepName}}Step(st.Operations())
+
+	op := fixture.FixProvisioningOperation("op-id", "instance-id")
+	require.NoError(t, st.Operations().InsertOperation(op))
+
+	// when
+	result, retry, err := step.Run(op, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, retry)
+	_ = result
+}
+```
+
+**Key rules:**
+- Use `fixture.FixProvisioningOperation` / `fixture.FixDeprovisioningOperation` / `fixture.FixInstance` from `internal/fixture/`.
+- Use `storage.NewMemoryStorage()` — never PostgreSQL in unit tests.
+- Use `fixLogger()` — it is already defined in other `_test.go` files in the same package; don't redefine it.
+- Use `require` for setup (fatal on failure), `assert` for outcome checks.
+
+### 3. Registration reminder
+
+After creating the files, remind the user:
+
+> **Next step:** Register the new step in `cmd/broker/<operation_type>.go` by adding an entry to the `<operation_type>Steps` slice:
+>
+> ```go
+> {
+>     step: <package>.New{{StepName}}Step(db.Operations()),
+> },
+> ```
+>
+> Add it at the position in the pipeline where it logically belongs. If you want a conditional step, add a `condition` field (provisioning only).
+
+---
+
+## Conventions to follow
+
+- Step names use PascalCase for the struct; `Name()` returns the step name with words separated by underscores (e.g. struct `ValidateQuotaStep` → `Name()` returns `"Validate_Quota"`, struct `ApplyKymaStep` → `Name()` returns `"Apply_Kyma"`).
+- Do not add error handling for impossible paths.
+- Do not add comments unless the logic is non-obvious.
+- Match the style of existing steps in the same package — read one before generating.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pr-review
+description: Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
+---
+
+# pr-review
+
+Review a pull request with KEB-specific context in mind.
+
+## Usage
+
+```
+/pr-review <PR number or URL>
+```
+
+**Examples:**
+- `/pr-review 3178`
+- `/pr-review https://github.com/kyma-project/kyma-environment-broker/pull/3178`
+
+---
+
+## What to do
+
+Fetch the PR diff and review it through the lens of KEB conventions. Structure your review as:
+
+### Summary
+One paragraph: what the PR does and whether the approach makes sense.
+
+### Issues (if any)
+
+List only real problems — not style nits unless they violate a hard rule. For each issue:
+- **File:line** — description of the problem
+- Severity: `blocking` | `suggestion`
+
+### KEB checklist
+
+Evaluate every item below. **Only print items that have a note or failure** — skip items that pass cleanly. If everything passes, write a single line: `KEB checklist: all clear`.
+
+Use this format for printed items only:
+- ⚠️ **[category]** — description of the note
+- ❌ **[category]** — description of the failure
+
+**Process steps (if any new/modified steps):**
+- Step implements `Name()` and `Run(operation, log)` correctly
+- `Name()` return value matches file name: `create_runtime_resource_step.go` → `"Create_Runtime_Resource"`
+- `operationManager.RetryOperation` used for transient failures; `RetryOperationWithoutFail` used in deprovisioning when exhausting retries without failing the operation
+- `kebError` dependency type matches the external system called: `KEBDependency` for internal logic, `InfrastructureManagerDependency` / `LifeCycleManagerDependency` for external components
+- Conditional steps use a `StepCondition` function, not inline `if` in `Run`
+- New step has a unit test using `storage.NewMemoryStorage()` and `fixture.*` helpers
+
+**Storage:**
+- Storage is accessed only through interfaces from `internal/storage/storage.go`
+- No direct DB driver imports outside `internal/storage/driver/`
+
+**Documentation:**
+- Any new/modified `.md` file in `docs/` (excluding `docs/assets/`) has `<!--{"metadata":{"publish":true/false}}-->` on line 1
+- `CLAUDE.md` updated if project structure, conventions, or build/test workflow changed
+
+**Tests:**
+- Tests use `testify/assert` and `testify/require` (not Ginkgo)
+- Operations constructed via `fixture.FixProvisioningOperation` / `fixture.FixDeprovisioningOperation` / `fixture.FixInstance` — never constructed manually
+- No mocked storage in unit tests — use `storage.NewMemoryStorage()`
+- `make test` would pass (FIPS140-compliant crypto only: `GODEBUG=fips140=only`; no `crypto/md5`, `crypto/sha1`)
+
+**General:**
+- No speculative abstractions or features beyond the PR scope
+- Imports cleaned up (no unused imports left from changes)
+- No backwards-compatibility shims for removed code
+- If a DB schema change is included, migration files exist in `cmd/schemamigrator/` with `.up.sql` and `.down.sql` counterparts
+
+### Verdict
+`Approve` / `Request changes` / `Comment` — with one sentence explaining why.
+
+---
+
+## Tone
+
+- Be direct and specific. Point to file and line numbers.
+- Don't praise code that is merely correct — save positive comments for non-obvious good decisions.
+- Don't suggest improvements outside the PR scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,3 +173,14 @@ Providers are selected by plan ID (not cloud provider name) in `internal/provide
 - Fast, short unit tests use the in-memory storage from `internal/storage/driver/memory/`.
 - Test suites use `TestMain` or `suite_test.go` files for shared setup.
 - `make test` runs tests with FIPS140 enforcement (`GODEBUG=fips140=only`). All cryptographic operations must be FIPS-compliant.
+
+### Claude Skills
+
+Skills for Claude Code are stored in `.claude/skills/`. Each skill is a directory containing a `SKILL.md` file.
+
+Available skills:
+- **`new-step`** — Scaffolds a new provisioning/deprovisioning/update step with implementation and test file.
+- **`pr-review`** — Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
+- **`commit`** — Drafts and creates a git commit following KEB commit message conventions.
+
+**Maintenance:** Any PR that changes project structure, adds a new pattern, or modifies the build/test workflow must update `CLAUDE.md` and the relevant skills in the same PR. This keeps Claude Code's assistance accurate as the project evolves.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add Claude Code skills (`new-step`, `pr-review`, `commit`) and document them in `CLAUDE.md`.

**Related issue(s)**
See also #3111
