### PR TITLE
Add Claude Code Skills for PR Review and Creation

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -79,6 +79,15 @@ Show the user the full title + body and ask: "Shall I open the PR with this titl
 
 ### 7. Create the PR
 
+To determine `<fork-owner>` and the PR creator's GitHub username, run:
+
+```bash
+git remote get-url origin
+gh api user --jq .login
+```
+
+Extract `<fork-owner>` from the origin URL. The PR creator's GitHub username comes from `gh api user`.
+
 ```bash
 gh pr create \
   --repo kyma-project/kyma-environment-broker \
@@ -86,19 +95,12 @@ gh pr create \
   --head <fork-owner>:<current-branch> \
   --title "<title>" \
   --label "<chosen-label>" \
+  --assignee "<github-username>" \
   --body "$(cat <<'EOF'
 <body>
 EOF
 )"
 ```
-
-To determine `<fork-owner>`, run:
-
-```bash
-git remote get-url origin
-```
-
-and extract the GitHub username from the URL.
 
 Return the PR URL to the user once created.
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -34,11 +34,10 @@ Stop if they say no.
 Run the following to understand what this branch adds on top of main:
 
 ```bash
-git log main..HEAD --oneline
 git diff main..HEAD
 ```
 
-Use the commit log and diff to generate a concise bullet-list summary of changes for the PR description.
+Read the diff carefully and summarize the most important changes as bullet points. Base the summary entirely on what the code actually changed.
 
 ### 3. Draft the PR body
 
@@ -69,7 +68,7 @@ Apply exactly one of these labels. No other labels unless the user explicitly re
 
 ### 6. Draft the PR title
 
-Derive the title from the commits / diff:
+Derive the title from the diff:
 
 - Imperative mood, title case, no trailing period, ≤72 chars.
 - No `feat:`, `fix:`, `chore:` prefixes.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: create-pr
+description: Creates a pull request from a fork branch to kyma-project/kyma-environment-broker main.
+---
+
+# create-pr
+
+Create a pull request from the current fork branch to the upstream `kyma-project/kyma-environment-broker` repository.
+
+## Usage
+
+```
+/create-pr [optional hint about what changed]
+```
+
+**Examples:**
+- `/create-pr`
+- `/create-pr Add integration test for autoScalerMin`
+
+---
+
+## What to do
+
+### 1. Confirm intent
+
+Ask the user:
+
+> You are about to open a PR from branch `<current-branch>` to `kyma-project/kyma-environment-broker:main`. Continue?
+
+Stop if they say no.
+
+### 2. Gather changes
+
+Run the following to understand what this branch adds on top of main:
+
+```bash
+git log main..HEAD --oneline
+git diff main..HEAD
+```
+
+Use the commit log and diff to generate a concise bullet-list summary of changes for the PR description.
+
+### 3. Draft the PR body
+
+Read `.github/pull-request-template.md` and use it as the body structure. Fill in the **Description** bullets from the diff.
+
+Rules:
+- Never include `Closes #<issue>`, `Fixes #<issue>`, or any issue-closing keywords unless the user explicitly asks.
+- Keep bullets factual and concise — derived from the actual diff, not paraphrased vaguely.
+
+### 4. Ask about related issues
+
+Ask the user:
+
+> Would you like to reference any related issues? (e.g. `See also #123`) If yes, provide the issue number(s).
+
+If yes, append the references to the **Related issue(s)** section. Use `See also #<n>` unless the user explicitly asks for a closing keyword.
+
+### 5. Ask about the changelog label
+
+Ask the user which changelog label to apply:
+
+> Which changelog label should this PR have?
+> - `kind/feature` — New feature
+> - `kind/enhancement` — Enhancement to an existing feature
+> - `kind/bug` — Bug fix
+
+Apply exactly one of these labels. No other labels unless the user explicitly requests them.
+
+### 6. Draft the PR title
+
+Derive the title from the commits / diff:
+
+- Imperative mood, title case, no trailing period, ≤72 chars.
+- No `feat:`, `fix:`, `chore:` prefixes.
+- Examples: `Add integration test for autoScalerMin changes`, `Fix deprovisioning race condition`
+
+Show the user the full title + body and ask: "Shall I open the PR with this title and description?"
+
+### 7. Create the PR
+
+```bash
+gh pr create \
+  --repo kyma-project/kyma-environment-broker \
+  --base main \
+  --head <fork-owner>:<current-branch> \
+  --title "<title>" \
+  --label "<chosen-label>" \
+  --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+To determine `<fork-owner>`, run:
+
+```bash
+git remote get-url origin
+```
+
+and extract the GitHub username from the URL.
+
+Return the PR URL to the user once created.
+
+---
+
+## Rules
+
+- Always target `--base main` on `kyma-project/kyma-environment-broker` — never an upstream feature branch.
+- Never add issue-closing keywords (`Closes`, `Fixes`, `Resolves`) unless the user explicitly asks.
+- Never use `--no-verify` or bypass any git hooks.
+- Apply exactly one `kind/*` label per PR.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -62,6 +62,10 @@ Use this format for printed items only:
 - No mocked storage in unit tests — use `storage.NewMemoryStorage()`
 - `make test` would pass (FIPS140-compliant crypto only: `GODEBUG=fips140=only`; no `crypto/md5`, `crypto/sha1`)
 
+**OSB API compatibility (if broker endpoints, catalog, or OSB request/response types are touched):**
+- Fetch the v2.16 spec: `https://raw.githubusercontent.com/openservicebrokerapi/servicebroker/v2.16/spec.md` and verify the changed code against it
+- Flag any violation of required status codes, mandatory request/response fields, async semantics, or backward compatibility rules
+
 **General:**
 - No speculative abstractions or features beyond the PR scope
 - Imports cleaned up (no unused imports left from changes)

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-review
+name: review-pr
 description: Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,6 @@ Available skills:
 - **`new-step`** — Scaffolds a new provisioning/deprovisioning/update step with implementation and test file.
 - **`pr-review`** — Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
 - **`commit`** — Drafts and creates a git commit following KEB commit message conventions.
+- **`create-pr`** — Creates a pull request from a fork branch to `kyma-project/kyma-environment-broker:main`.
 
 **Maintenance:** Any PR that changes project structure, adds a new pattern, or modifies the build/test workflow must update `CLAUDE.md` and the relevant skills in the same PR. This keeps Claude Code's assistance accurate as the project evolves.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Skills for Claude Code are stored in `.claude/skills/`. Each skill is a director
 
 Available skills:
 - **`new-step`** — Scaffolds a new provisioning/deprovisioning/update step with implementation and test file.
-- **`pr-review`** — Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
+- **`review-pr`** — Reviews a PR against KEB conventions (step interface, storage access, docs metadata, FIPS compliance, etc.).
 - **`commit`** — Drafts and creates a git commit following KEB commit message conventions.
 - **`create-pr`** — Creates a pull request from a fork branch to `kyma-project/kyma-environment-broker:main`.
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add OSB API v2.16 compatibility check to the `review-pr` skill — fetches the live spec at review time and flags violations
- Add `create-pr` skill for opening PRs from a fork branch to `kyma-project/kyma-environment-broker:main`
- Rename `pr-review` skill to `review-pr` for naming consistency with `create-pr`

**Related issue(s)**
See also #3111