### PR TITLE
Make MaxPods Configurable

### DIFF
--- a/cmd/broker/suite_test.go
+++ b/cmd/broker/suite_test.go
@@ -224,6 +224,7 @@ func fixConfig() *Config {
 			DefaultTrialProvider:         "AWS",
 			ControlPlaneFailureTolerance: "zone",
 			IngressFilteringPlans:        []string{"aws", "azure", "gcp"},
+			MaxPods:                      200,
 		},
 		StepTimeouts: StepTimeoutsConfig{
 			CheckRuntimeResourceUpdate:   180 * time.Second,

--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -75,6 +75,7 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_KUBERNETES_&#x200b;VERSION** | <code>1.16.9</code> | Sets the default Kubernetes version for new clusters provisioned by the broker. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MACHINE_&#x200b;IMAGE** | None | Sets the default machine image name for nodes in provisioned clusters. If empty, the Gardener default value is used. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MACHINE_&#x200b;IMAGE_VERSION** | None | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. |
+| **APP_INFRASTRUCTURE_&#x200b;MANAGER_MAX_PODS** | <code>200</code> | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MULTI_ZONE_&#x200b;CLUSTER** | <code>false</code> | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_USE_SMALLER_&#x200b;MACHINE_TYPES** | <code>false</code> | If true, provisions trial and freemium clusters using smaller machine types. |
 | **APP_KUBECONFIG_&#x200b;ALLOW_ORIGINS** | <code>*</code> | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. |

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -140,7 +140,7 @@
 | disableProcessOperationsInProgress | If true, the broker does NOT resume processing operations (provisioning, deprovisioning, updating, etc.) that were in progress when the broker process last stopped or restarted. | `false` |
 | events.enabled | Enables or disables the events API and event storage for operation events (true/false). | `True` |
 | freemiumWhitelistedGlobalAccountIds | List of global account IDs that are allowed unlimited access to freemium (free) Kyma runtimes. Only accounts listed here can provision more than the default limit of free environments. | `whitelist:` |
-| maxPodsWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use an increased maximum number of Pods. For accounts listed here, the maximum number of Pods in all worker node pools is set to the value of `infrastructureManager.maxPods`. | `whitelist:` |
+| maxPodsWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use an increased maximum number of Pods. For accounts listed here, the maximum number of Pods per node in all worker node pools is set to the value of `infrastructureManager.maxPods`. | `whitelist:` |
 | openShellWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use Open Shell. | `whitelist:` |
 | operationBlocklist | Rules for blocking specific operations (provision, update, planUpgrade, deprovision) per plan. Leave empty to disable all blocking. See internal/blocklist/blocklist.go for format. | `` |
 | gvisorWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use the gVisor container runtime. | `whitelist:` |

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -140,7 +140,7 @@
 | disableProcessOperationsInProgress | If true, the broker does NOT resume processing operations (provisioning, deprovisioning, updating, etc.) that were in progress when the broker process last stopped or restarted. | `false` |
 | events.enabled | Enables or disables the events API and event storage for operation events (true/false). | `True` |
 | freemiumWhitelistedGlobalAccountIds | List of global account IDs that are allowed unlimited access to freemium (free) Kyma runtimes. Only accounts listed here can provision more than the default limit of free environments. | `whitelist:` |
-| maxPodsWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use an increased maximum number of Pods. For accounts listed here, the maximum number of Pods in all worker node pools is set to 250. | `whitelist:` |
+| maxPodsWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use an increased maximum number of Pods. For accounts listed here, the maximum number of Pods in all worker node pools is set to the value of `infrastructureManager.maxPods`. | `whitelist:` |
 | openShellWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use Open Shell. | `whitelist:` |
 | operationBlocklist | Rules for blocking specific operations (provision, update, planUpgrade, deprovision) per plan. Leave empty to disable all blocking. See internal/blocklist/blocklist.go for format. | `` |
 | gvisorWhitelistedGlobalAccountIds | List of global account IDs that are allowed to use the gVisor container runtime. | `whitelist:` |
@@ -164,6 +164,7 @@
 | infrastructureManager.<br>kubernetesVersion | Sets the default Kubernetes version for new clusters provisioned by the broker. | `1.16.9` |
 | infrastructureManager.<br>machineImage | Sets the default machine image name for nodes in provisioned clusters. If empty, the Gardener default value is used. | `` |
 | infrastructureManager.<br>machineImageVersion | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. | `` |
+| infrastructureManager.<br>maxPods | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. | `200` |
 | infrastructureManager.<br>multiZoneCluster | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. | `false` |
 | infrastructureManager.<br>useSmallerMachineTypes | If true, provisions trial and freemium clusters using smaller machine types. | `false` |
 | kubeconfig.<br>allowOrigins | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. | `*` |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -172,6 +172,8 @@ type InfrastructureManager struct {
 	GcpVolumeSizeGb   int `envconfig:"default=80"`
 	AwsVolumeSizeGb   int `envconfig:"default=80"`
 	AzureVolumeSizeGb int `envconfig:"default=80"`
+
+	MaxPods int32 `envconfig:"default=200"`
 }
 
 type PlansConfig map[string]PlanData

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -39,8 +39,6 @@ const (
 	dbRetryTimeout   = 1 * time.Minute
 )
 
-var MaxPods int32 = 200
-
 type CreateRuntimeResourceStep struct {
 	operationManager  *process.OperationManager
 	instanceStorage   storage.Instances
@@ -282,7 +280,7 @@ func (s *CreateRuntimeResourceStep) createShootProvider(log *slog.Logger, operat
 	if s.globalAccounts.MaxPodsWhitelistedGlobalAccountIds.Contains(operation.GlobalAccountID) {
 		provider.Workers[0].Kubernetes = &gardener.WorkerKubernetes{
 			Kubelet: &gardener.KubeletConfig{
-				MaxPods: &MaxPods,
+				MaxPods: &s.config.MaxPods,
 			},
 		}
 
@@ -290,7 +288,7 @@ func (s *CreateRuntimeResourceStep) createShootProvider(log *slog.Logger, operat
 			for i := range *provider.AdditionalWorkers {
 				(*provider.AdditionalWorkers)[i].Kubernetes = &gardener.WorkerKubernetes{
 					Kubelet: &gardener.KubeletConfig{
-						MaxPods: &MaxPods,
+						MaxPods: &s.config.MaxPods,
 					},
 				}
 			}

--- a/internal/process/update/update_runtime_step.go
+++ b/internal/process/update/update_runtime_step.go
@@ -278,14 +278,14 @@ func (s *UpdateRuntimeStep) applyMaxPodsConfig(operation internal.Operation, run
 	}
 	runtime.Spec.Shoot.Provider.Workers[0].Kubernetes = &gardener.WorkerKubernetes{
 		Kubelet: &gardener.KubeletConfig{
-			MaxPods: &provisioning.MaxPods,
+			MaxPods: &s.config.MaxPods,
 		},
 	}
 	if runtime.Spec.Shoot.Provider.AdditionalWorkers != nil {
 		for i := range *runtime.Spec.Shoot.Provider.AdditionalWorkers {
 			(*runtime.Spec.Shoot.Provider.AdditionalWorkers)[i].Kubernetes = &gardener.WorkerKubernetes{
 				Kubelet: &gardener.KubeletConfig{
-					MaxPods: &provisioning.MaxPods,
+					MaxPods: &s.config.MaxPods,
 				},
 			}
 		}

--- a/resources/keb/templates/deployment.yaml
+++ b/resources/keb/templates/deployment.yaml
@@ -262,6 +262,8 @@ spec:
               value: {{ .Values.infrastructureManager.machineImage }}
             - name: APP_INFRASTRUCTURE_MANAGER_MACHINE_IMAGE_VERSION
               value: "{{ .Values.infrastructureManager.machineImageVersion }}"
+            - name: APP_INFRASTRUCTURE_MANAGER_MAX_PODS
+              value: "{{ .Values.infrastructureManager.maxPods }}"
             - name: APP_INFRASTRUCTURE_MANAGER_MULTI_ZONE_CLUSTER
               value: "{{ .Values.infrastructureManager.multiZoneCluster }}"
             - name: APP_INFRASTRUCTURE_MANAGER_USE_SMALLER_MACHINE_TYPES

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -302,7 +302,7 @@ freemiumWhitelistedGlobalAccountIds: |-
   whitelist:
 
 # List of global account IDs that are allowed to use an increased maximum number of Pods.
-# For accounts listed here, the maximum number of Pods in all worker node pools is set to 250.
+# For accounts listed here, the maximum number of Pods in all worker node pools is set to the value of `infrastructureManager.maxPods`.
 maxPodsWhitelistedGlobalAccountIds: |-
   whitelist:
 
@@ -382,6 +382,8 @@ infrastructureManager:
   machineImage: ""
   # Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used.
   machineImageVersion: ""
+  # Sets the maximum number of Pods per node for global accounts in the max Pods allowlist.
+  maxPods: 200
   # If true, enables provisioning of clusters with nodes distributed across multiple availability zones.
   multiZoneCluster: "false"
   # If true, provisions trial and freemium clusters using smaller machine types.

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -302,7 +302,7 @@ freemiumWhitelistedGlobalAccountIds: |-
   whitelist:
 
 # List of global account IDs that are allowed to use an increased maximum number of Pods.
-# For accounts listed here, the maximum number of Pods in all worker node pools is set to the value of `infrastructureManager.maxPods`.
+# For accounts listed here, the maximum number of Pods per node in all worker node pools is set to the value of `infrastructureManager.maxPods`.
 maxPodsWhitelistedGlobalAccountIds: |-
   whitelist:
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `MaxPods` field to `InfrastructureManager` config with default value of `200`, configurable via `APP_INFRASTRUCTURE_MANAGER_MAX_PODS` env var
- Replace hardcoded `var MaxPods int32 = 200` in provisioning step with `s.config.MaxPods`
- Replace reference to `provisioning.MaxPods` in update step with `s.config.MaxPods`
- Add `infrastructureManager.maxPods` to Helm chart values and deployment template
- Update docs to document the new field and fix stale hardcoded value of 250 in chart config docs

**Related issue(s)**
Closes #3132