### PR TITLE
Add CODEOWNERS Entry for Claude Code Skills Directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,6 @@
 # Owners of all .md files in the repository
 *.md @kyma-project/technical-writers
 
-# CLAUDE.md is also reviewed by gophers
+# CLAUDE.md and Claude Code skills are also reviewed by gophers
 CLAUDE.md @kyma-project/technical-writers @kyma-project/gopher
+/.claude/skills/ @kyma-project/technical-writers @kyma-project/gopher


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update CODEOWNERS comment to mention Claude Code skills alongside CLAUDE.md
- Add ownership rule for `/.claude/skills/` requiring review by `@kyma-project/technical-writers` and `@kyma-project/gopher`

**Related issue(s)**
See also #3111