### PR TITLE
Switch keb-analytics to Dedicated Read-Only DB User

### DIFF
--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -73,9 +73,10 @@
 | analytics.database.<br>hostSecretKey | - | `postgresql-serviceName` |
 | analytics.database.<br>portSecretKey | - | `postgresql-servicePort` |
 | analytics.database.<br>nameSecretKey | - | `postgresql-broker-db-name` |
-| analytics.database.<br>userSecretKey | - | `postgresql-broker-username` |
-| analytics.database.<br>passwordSecretKey | - | `postgresql-broker-password` |
 | analytics.database.<br>sslModeSecretKey | - | `postgresql-sslMode` |
+| analytics.database.<br>credentialsSecretName | - | `keb-analytics-db` |
+| analytics.database.<br>userSecretKey | - | `username` |
+| analytics.database.<br>passwordSecretKey | - | `password` |
 | analytics.<br>serviceAccountName | - | `kcp-kyma-environment-broker` |
 | analytics.host | - | `keb-analytics` |
 | analytics.oidc.<br>issuerURL | - | `https://kymatest.accounts400.ondemand.com` |
@@ -316,3 +317,9 @@
 | vsoSecrets.secrets.keb-analytics-oauth2-proxy.<br>templating.keys.<br>client-id | - | `keb_analytics_client_id` |
 | vsoSecrets.secrets.keb-analytics-oauth2-proxy.<br>templating.keys.<br>client-secret | - | `keb_analytics_client_secret` |
 | vsoSecrets.secrets.keb-analytics-oauth2-proxy.<br>templating.keys.<br>cookie-secret | - | `keb_analytics_biscuit_secret` |
+| vsoSecrets.secrets.keb-analytics-db.<br>path | - | `gcp` |
+| vsoSecrets.secrets.keb-analytics-db.<br>secretName | - | `keb-analytics-db` |
+| vsoSecrets.secrets.keb-analytics-db.<br>restartTargets | - | `- {'kind': 'Deployment', 'name': 'keb-analytics'}` |
+| vsoSecrets.secrets.keb-analytics-db.<br>templating.enabled | - | `True` |
+| vsoSecrets.secrets.keb-analytics-db.<br>templating.keys.<br>username | - | `managed_gcp_postgresql_brokerread_user` |
+| vsoSecrets.secrets.keb-analytics-db.<br>templating.keys.<br>password | - | `managed_gcp_postgresql_brokerread_password` |

--- a/resources/keb/templates/analytics-deployment.yaml
+++ b/resources/keb/templates/analytics-deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: APP_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.analytics.database.secretName }}
+                  name: {{ .Values.analytics.database.credentialsSecretName }}
                   key: {{ .Values.analytics.database.passwordSecretKey }}
             - name: APP_DATABASE_PORT
               valueFrom:
@@ -83,7 +83,7 @@ spec:
             - name: APP_DATABASE_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.analytics.database.secretName }}
+                  name: {{ .Values.analytics.database.credentialsSecretName }}
                   key: {{ .Values.analytics.database.userSecretKey }}
             - name: APP_PORT
               value: "{{ .Values.analytics.port }}"

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -139,17 +139,15 @@ analytics:
   name: keb-analytics
   port: 8080
   refreshInterval: "1h"
-  # DB credentials for keb-analytics — separate from KEB broker credentials.
-  # In Phase 1 these reference the same Secret as KEB; in Phase 2 swap to a
-  # dedicated read-only user.
   database:
     secretName: "kcp-postgresql"
     hostSecretKey: "postgresql-serviceName"
     portSecretKey: "postgresql-servicePort"
     nameSecretKey: "postgresql-broker-db-name"
-    userSecretKey: "postgresql-broker-username"
-    passwordSecretKey: "postgresql-broker-password"
     sslModeSecretKey: "postgresql-sslMode"
+    credentialsSecretName: "keb-analytics-db"
+    userSecretKey: "username"
+    passwordSecretKey: "password" # gitleaks:allow
   serviceAccountName: "kcp-kyma-environment-broker"
   host: keb-analytics
   oidc:
@@ -841,4 +839,18 @@ vsoSecrets:
           client-id: {}
           client-secret: {}
           cookie-secret: {}
+    keb-analytics-db:
+      path: gcp
+      secretName: keb-analytics-db
+      restartTargets:
+        - kind: Deployment
+          name: keb-analytics
+      templating:
+        enabled: true
+        keys:
+          username: managed_gcp_postgresql_brokerread_user
+          password: managed_gcp_postgresql_brokerread_password
+        data:
+          username: {}
+          password: {}
 # =================================================

--- a/scripts/testing/yaml/postgres/keb-analytics-db-secret.yaml
+++ b/scripts/testing/yaml/postgres/keb-analytics-db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keb-analytics-db
+type: Opaque
+stringData:
+  username: brokerread1
+  password: brokerread1read#

--- a/scripts/testing/yaml/postgres/postgres-configmap.yaml
+++ b/scripts/testing/yaml/postgres/postgres-configmap.yaml
@@ -8,3 +8,6 @@ data:
   POSTGRES_DB: postgresdb
   POSTGRES_USER: postgresadmin
   POSTGRES_PASSWORD: admin12345678901#
+  init-readonly-user.sql: |
+    CREATE USER brokerread1 WITH PASSWORD 'brokerread1read#';
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO brokerread1;

--- a/scripts/testing/yaml/postgres/postgres-deployment.yaml
+++ b/scripts/testing/yaml/postgres/postgres-deployment.yaml
@@ -21,4 +21,14 @@ spec:
               name: postgres-port
           envFrom:
             - configMapRef:
-                name: postgres-config 
+                name: postgres-config
+          volumeMounts:
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: initdb
+          configMap:
+            name: postgres-config
+            items:
+              - key: init-readonly-user.sql
+                path: init-readonly-user.sql


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `keb-analytics-db` VSO `VaultStaticSecret` entry in `values.yaml` that pulls `brokerread1` credentials from Vault (`managed_gcp_postgresql_brokerread_user` / `managed_gcp_postgresql_brokerread_password` under path `gcp`)
- Split `analytics.database` Helm values into `secretName` (host/port/name/sslmode from `kcp-postgresql`) and `credentialsSecretName` (`keb-analytics-db` for user/password)
- Update `analytics-deployment.yaml` so `APP_DATABASE_USER` and `APP_DATABASE_PASSWORD` reference the new `keb-analytics-db` secret
- Add `init-readonly-user.sql` initdb script to the local postgres ConfigMap that creates `brokerread1` and grants default SELECT privileges on all tables
- Mount the initdb script into the local postgres Deployment via a volume
- Add `keb-analytics-db` Secret manifest for local/CI postgres with `brokerread1` credentials

**Related issue(s)**
See also #9320