### PR TITLE
Fix Flaky TestMetrics by Using Absolute Step Timeout

### DIFF
--- a/cmd/broker/metrics_test.go
+++ b/cmd/broker/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -14,7 +15,7 @@ import (
 
 func TestMetrics(t *testing.T) {
 	cfg := fixConfig()
-	cfg.StepTimeouts.CheckRuntimeResourceCreate = cfg.StepTimeouts.CheckRuntimeResourceCreate / 1000 // reduce timeout to speed up the test
+	cfg.StepTimeouts.CheckRuntimeResourceCreate = 500 * time.Millisecond
 	suite := NewBrokerSuiteTest(t, WithConfig(cfg), WithMetrics())
 	defer suite.TearDown()
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix `TestMetrics` instability by replacing `CheckRuntimeResourceCreate / 1000` (60ms) with an explicit `500ms` timeout
- The previous value was too tight on loaded CI runners: the step could expire before `processKIMProvisioningByOperationID` set the Runtime state to Ready, causing an expected-success provisioning to fail and the metric counter to fall short by one

**Related issue(s)**
See also #3110