### PR TITLE
Add AddNetworking Provisioning Step

### DIFF
--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -184,7 +184,7 @@ func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, de
 	region, found := middleware.RegionFromContext(ctx)
 	if !found {
 		err := fmt.Errorf("%s", "No region specified in request.")
-		return domain.ProvisionedServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusInternalServerError, "provisioning")
+		return domain.ProvisionedServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusPermanentRedirect, "provisioning")
 	}
 	platformProvider, found := middleware.ProviderFromContext(ctx)
 	if !found {

--- a/internal/process/provisioning/add_networking_step.go
+++ b/internal/process/provisioning/add_networking_step.go
@@ -1,0 +1,30 @@
+package provisioning
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/kyma-project/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+)
+
+type AddNetworkingStep struct {
+	operationManager *process.OperationManager
+}
+
+func NewAddNetworkingStep(os storage.Operations) *AddNetworkingStep {
+	step := &AddNetworkingStep{}
+	step.operationManager = process.NewOperationManager(os, step.Name(), kebError.KEBDependency)
+	return step
+}
+
+func (s *AddNetworkingStep) Name() string {
+	return "Add_Networking"
+}
+
+func (s *AddNetworkingStep) Run(operation internal.Operation, log *slog.Logger) (internal.Operation, time.Duration, error) {
+	// TODO: implement
+	return operation, 0, nil
+}

--- a/internal/process/provisioning/add_networking_step_test.go
+++ b/internal/process/provisioning/add_networking_step_test.go
@@ -1,0 +1,27 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddNetworkingStep_HappyPath(t *testing.T) {
+	// given
+	st := storage.NewMemoryStorage()
+	step := NewAddNetworkingStep(st.Operations())
+
+	op := fixture.FixProvisioningOperation("op-id", "instance-id")
+	require.NoError(t, st.Operations().InsertOperation(op))
+
+	// when
+	result, retry, err := step.Run(op, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, retry)
+	_ = result
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `AddNetworkingStep` provisioning step scaffold with `Add_Networking` name and operation manager wiring
- Add happy-path unit test for `AddNetworkingStep`

**Related issue(s)**