### PR TITLE
Default CIS Event Service to v2 for Subaccount Cleanup

### DIFF
--- a/cmd/accountcleanup/main.go
+++ b/cmd/accountcleanup/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Config struct {
-	EventsServiceVersion string `envconfig:"default=v1"`
+	EventsServiceVersion string `envconfig:"default=v2"`
 	CIS                  cis.Config
 	Database             storage.Config
 	Broker               broker.ClientConfig

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -257,7 +257,7 @@
 | serviceBindingCleanup.<br>schedule | - | `0 2,14 * * *` |
 | subaccountCleanup.<br>enabled | - | `true` |
 | subaccountCleanup.<br>schedule | - | `0 1 * * *` |
-| subaccountCleanup.<br>eventsServiceVersion | Specifies the Events Service version. | `v1` |
+| subaccountCleanup.<br>eventsServiceVersion | Specifies the Events Service version. | `v2` |
 | subaccountSync.<br>accountSyncInterval | Interval between full account synchronization runs. | `24h` |
 | subaccountSync.<br>alwaysSubaccountFromDatabase | If true, fetches subaccountID from the database only when the subaccount is empty. | `False` |
 | subaccountSync.cisRateLimits.<br>accounts.<br>maxRequestsPerInterval | Maximum number of requests per interval to the CIS Accounts API. | `5` |

--- a/docs/contributor/06-30-subaccount-cleanup-cronjob.md
+++ b/docs/contributor/06-30-subaccount-cleanup-cronjob.md
@@ -12,7 +12,7 @@ The Subaccount Cleanup workflow is divided into several steps:
 
 1. Fetch **SUBACCOUNT_DELETE** events from the CIS service.
 
-   The behavior depends on the configured Events Service version (`APP_EVENTS_SERVICE_VERSION`):
+   The behavior depends on the configured Events Service version (**APP_EVENTS_SERVICE_VERSION**):
 
    - **CIS v1** (legacy):
      1. The CIS client calls the CIS service and receives a paginated list of events.

--- a/docs/contributor/06-30-subaccount-cleanup-cronjob.md
+++ b/docs/contributor/06-30-subaccount-cleanup-cronjob.md
@@ -22,7 +22,7 @@ The Subaccount Cleanup workflow is divided into several steps:
 
    - **CIS v2** (default):
      1. The CIS client calls `/events/v2/events/central` requesting `Subaccount_Deletion` events for the `Subaccount` entity type, covering the last 30 days.
-     2. It fetches subsequent pages by following the `nextCursor` value in each response, until no cursor is returned.
+     2. It fetches subsequent pages by following the **nextCursor** value in each response, until no cursor is returned.
      3. A subaccount ID is extracted from each event and collected into an array.
      4. Once complete, the client logs the number of subaccounts fetched and the time range of events.
 

--- a/docs/contributor/06-30-subaccount-cleanup-cronjob.md
+++ b/docs/contributor/06-30-subaccount-cleanup-cronjob.md
@@ -3,14 +3,14 @@
 # Subaccount Cleanup CronJob
 
 Each SAP BTP, Kyma runtime instance in the Kyma Environment Broker (KEB) database belongs to a global account and to a subaccount.
-Subaccount Cleanup is an application that periodically calls the CIS service and reports **SUBACCOUNT_DELETE** events.
+Subaccount Cleanup is an application that periodically calls the CIS service and reports **Subaccount_Deletion** events.
 Based on these events, Subaccount Cleanup triggers the deprovisioning action on Kyma runtime instances belonging to the given subaccount.
 
 ## Details
 
 The Subaccount Cleanup workflow is divided into several steps:
 
-1. Fetch **SUBACCOUNT_DELETE** events from the CIS service.
+1. Fetch **Subaccount_Deletion** events from the CIS service.
 
    The behavior depends on the configured Events Service version (**APP_EVENTS_SERVICE_VERSION**):
 
@@ -21,7 +21,7 @@ The Subaccount Cleanup workflow is divided into several steps:
      4. Once complete, the client logs the number of subaccounts fetched and the time range of events.
 
    - **CIS v2** (default):
-     1. The CIS client calls `/events/v2/events/central` requesting `Subaccount_Deletion` events for the `Subaccount` entity type, covering the last 30 days.
+     1. The CIS client calls `/events/v2/events/central` requesting **Subaccount_Deletion** events for the `Subaccount` entity type, covering the last 30 days.
      2. It fetches subsequent pages by following the **nextCursor** value in each response, until no cursor is returned.
      3. A subaccount ID is extracted from each event and collected into an array.
      4. Once complete, the client logs the number of subaccounts fetched and the time range of events.
@@ -41,8 +41,8 @@ The Subaccount Cleanup workflow is divided into several steps:
 
 ## Prerequisites
 
-* CIS service to receive all **SUBACCOUNT_DELETE** events
-* The KEB database to get the instance ID for each subaccount ID from the **SUBACCOUNT_DELETE** event
+* CIS service to receive all **Subaccount_Deletion** events
+* The KEB database to get the instance ID for each subaccount ID from the **Subaccount_Deletion** event
 * KEB to trigger Kyma runtime instance deprovisioning
 
 ## Configuration

--- a/docs/contributor/06-30-subaccount-cleanup-cronjob.md
+++ b/docs/contributor/06-30-subaccount-cleanup-cronjob.md
@@ -12,13 +12,19 @@ The Subaccount Cleanup workflow is divided into several steps:
 
 1. Fetch **SUBACCOUNT_DELETE** events from the CIS service.
 
-    a. CIS client makes a call to the CIS service and in response, it gets a list of events divided into pages.
+   The behavior depends on the configured Events Service version (`APP_EVENTS_SERVICE_VERSION`):
 
-    b. CIS client fetches the rest of the events by making a call to each page one by one.
+   - **CIS v1** (legacy):
+     1. The CIS client calls the CIS service and receives a paginated list of events.
+     2. It fetches remaining pages one by one, identified by page number.
+     3. A subaccount ID is extracted from each event and collected into an array.
+     4. Once complete, the client logs the number of subaccounts fetched and the time range of events.
 
-    c. A subaccount ID is taken from each event and kept in an array.
-
-    d. When the CIS client completes its workflow, it displays logs with information on how many subaccounts were fetched.
+   - **CIS v2** (default):
+     1. The CIS client calls `/events/v2/events/central` requesting `Subaccount_Deletion` events for the `Subaccount` entity type, covering the last 30 days.
+     2. It fetches subsequent pages by following the `nextCursor` value in each response, until no cursor is returned.
+     3. A subaccount ID is extracted from each event and collected into an array.
+     4. Once complete, the client logs the number of subaccounts fetched and the time range of events.
 
 2. Find all instances in the KEB database based on the fetched subaccount IDs.
    The subaccounts pool is divided into batches. For each batch, a query is made to the database to fetch instances.

--- a/docs/contributor/06-30-subaccount-cleanup-cronjob.md
+++ b/docs/contributor/06-30-subaccount-cleanup-cronjob.md
@@ -53,7 +53,7 @@ Use the following environment variables to configure the application:
 | **APP_CIS_MAX_REQUEST_&#x200b;RETRIES** | <code>3</code> | The maximum number of request retries to the CIS v2 API in case of errors. |
 | **APP_CIS_RATE_&#x200b;LIMITING_INTERVAL** | <code>2s</code> | The minimum interval between requests to the CIS v2 API in case of errors. |
 | **APP_CIS_REQUEST_&#x200b;INTERVAL** | <code>200ms</code> | The interval between requests to the CIS v2 API. |
-| **APP_EVENTS_SERVICE_&#x200b;VERSION** | <code>v1</code> | Specifies the Events Service version. |
+| **APP_EVENTS_SERVICE_&#x200b;VERSION** | <code>v2</code> | Specifies the Events Service version. |
 | **APP_DATABASE_HOST** | None | Specifies the host of the database. |
 | **APP_DATABASE_NAME** | None | Specifies the name of the database. |
 | **APP_DATABASE_&#x200b;PASSWORD** | None | Specifies the user password for the database. |

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -679,7 +679,7 @@ subaccountCleanup:
   enabled: "true"
   schedule: "0 1 * * *"
   # Specifies the Events Service version.
-  eventsServiceVersion: "v1"
+  eventsServiceVersion: "v2"
 # =================================================
 
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Default `APP_EVENTS_SERVICE_VERSION` to `v2` in the Subaccount Cleanup job (`cmd/accountcleanup/main.go`)
- Update default `eventsServiceVersion` from `v1` to `v2` in `resources/keb/values.yaml`
- Update documentation to reflect the new default and document both CIS v1 and v2 event-fetching flows

**Related issue(s)**
See also https://github.tools.sap/kyma/backlog/issues/9368