### PR TITLE
Change metadata for Plan Configuration

### DIFF
--- a/docs/contributor/02-60-plan-configuration.md
+++ b/docs/contributor/02-60-plan-configuration.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"publish":false}}-->
+<!--{"metadata":{"publish":true}}-->
 
 # Plan Configuration
 

--- a/docs/contributor/02-60-plan-configuration.md
+++ b/docs/contributor/02-60-plan-configuration.md
@@ -125,7 +125,7 @@ For more information, see the following documents:
  * [Regions Supporting Machine Types](03-50-regions-supporting-machine.md)
  * [Zones Discovery](03-55-zones-discovery.md)
  * [Plan Updates](03-83-plan-updates.md)
- * [Dual-Stack Configuration](03-85-dual-stack-configuration.md)
+ * [Dual-Stack Configuration](https://github.com/kyma-project/kyma-environment-broker/blob/main/docs/contributor/03-85-dual-stack-configuration.md)
 
 ## Bindings
 

--- a/docs/contributor/02-60-plan-configuration.md
+++ b/docs/contributor/02-60-plan-configuration.md
@@ -121,7 +121,7 @@ For more information, see the following documents:
 
  * [Regions Configuration](03-60-regions-configuration.md)
  * [Machine Types Configuration](03-70-machines-configuration.md)
- * [Machines Versions](03-72-machines-versions.md)
+ * [Machines Versions]([03-72-machines-versions.md](https://github.com/kyma-project/kyma-environment-broker/blob/main/docs/contributor/03-72-machines-versions.md))
  * [Regions Supporting Machine Types](03-50-regions-supporting-machine.md)
  * [Zones Discovery](03-55-zones-discovery.md)
  * [Plan Updates](03-83-plan-updates.md)

--- a/docs/user/05-50-configure-list-of-modules.md
+++ b/docs/user/05-50-configure-list-of-modules.md
@@ -1,4 +1,4 @@
-<!--{"metadata":{"publish":true}}-->
+<!--{"metadata":{"publish":false}}-->
 
 # Configure List of Modules
 


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Change metadata so that the Plan Configuration document is published in the operator's guide.
