### PR TITLE
Add Landscaper Compatibility documentation

### DIFF
--- a/cmd/broker/provisioning_test.go
+++ b/cmd/broker/provisioning_test.go
@@ -2755,6 +2755,13 @@ func TestZoneMappingInAdditionalWorkerNodePools(t *testing.T) {
 								"haZones": false,
 								"autoScalerMin": 1,
 								"autoScalerMax": 1
+							},
+							{
+								"name": "name-4",
+								"machineType": "ri.xlarge",
+								"haZones": true,
+								"autoScalerMin": 3,
+								"autoScalerMax": 20
 							}
 						]
 					}
@@ -2767,10 +2774,11 @@ func TestZoneMappingInAdditionalWorkerNodePools(t *testing.T) {
 	// then
 	suite.WaitForOperationState(opID, domain.Succeeded)
 	runtime := suite.GetRuntimeResourceByInstanceID(iid)
-	assert.Len(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers, 3)
+	assert.Len(t, *runtime.Spec.Shoot.Provider.AdditionalWorkers, 4)
 	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-1", 3, "us-east-1w", "us-east-1x", "us-east-1y", "us-east-1z")
 	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-2", 1, "us-east-1x", "us-east-1y")
 	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-3", 1, "us-east-1x")
+	suite.assertAdditionalWorkerZones(t, runtime.Spec.Shoot.Provider, "name-4", 3, "us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f")
 }
 
 func TestProvisioning_BuildRuntimePlans(t *testing.T) {

--- a/cmd/broker/testdata/providers-zones-discovery.yaml
+++ b/cmd/broker/testdata/providers-zones-discovery.yaml
@@ -2,7 +2,7 @@ aws:
   zonesDiscovery: true
   regionsSupportingMachine:
     "c7i":
-      "us-east-1": ["w", "x", "y", "z"]
+      "us-east-1": []
     "g6":
       "us-east-1": ["x", "y"]
     "g4dn":

--- a/cmd/broker/testdata/providers.yaml
+++ b/cmd/broker/testdata/providers.yaml
@@ -7,6 +7,9 @@ aws:
       "us-east-1": ["x", "y"]
     "g4dn":
       "us-east-1": ["x"]
+    "ri":
+      "eu-central-1": []
+      "us-east-1": []
   machines:
     "mi.large": "mi.large (2vCPU, 8GB RAM)"
     "mi.xlarge": "mi.xlarge (4vCPU, 16GB RAM)"

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -72,7 +72,7 @@ regionsSupportingMachine:
 
 ### Machine type not available in any region
 
-Use an **empty map `{}`** as the value for the machine family:
+Use an empty map `{}` as the value for the machine family:
 
 ```yaml
 regionsSupportingMachine:

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -79,7 +79,7 @@ regionsSupportingMachine:
     g6: {}
 ```
 
-This makes the machine type unavailable in every region. Users attempting to provision in any region will receive an error similar to:
+This makes the machine type unavailable in every region. Users attempting to provision in any region receive an error similar to:
 
 ```
  In the region eu-central-1, the following machine types are not available: g6.xlarge (used in: worker-1), not supported in any region

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -51,6 +51,9 @@ regionsSupportingMachine:
         eu-central-1:
         eu-west-2:
     g6:
+```
+
+results in:
 
 ```yaml
 regionsSupportingMachine:

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -85,5 +85,5 @@ regionsSupportingMachine:
 This makes the machine type unavailable in every region. Users attempting to provision in any region will receive an error similar to:
 
 ```
-In the region eu-central-1, the following machine types are not available: g6.xlarge (used in: worker-1), it is not supported in any region
+ In the region eu-central-1, the following machine types are not available: g6.xlarge (used in: worker-1), not supported in any region
 ```

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -29,14 +29,57 @@ providersConfiguration:
     aws:
         regionsSupportingMachine:
             g6:
-                us-west-2:
+                us-west-2: []
                 eu-central-1: [a, b]
                 ap-south-1: [b]
                 us-east-1: [a, b, c, d]
             g4dn:
-                eu-central-1:
-                eu-west-2:
-                us-east-1:
-                ap-south-1:
+                eu-central-1: []
+                eu-west-2: []
+                us-east-1: []
+                ap-south-1: []
                 us-west-2: [a, b, c]
 ```
+
+## Landscaper Compatibility
+
+Landscaper uses **strategic merge patch** semantics when applying ConfigMaps. Under these semantics, a key with a null value is interpreted as "delete this key" rather than "set this key to null". This means that region entries written without a value:
+
+```yaml
+regionsSupportingMachine:
+    g4dn:
+        eu-central-1:
+        eu-west-2:
+    g6:
+```
+
+are silently dropped by Landscaper, resulting in:
+
+```yaml
+regionsSupportingMachine:
+    g4dn: {}
+```
+
+### Region supported in all its zones (no zone restriction)
+
+Use an **empty list `[]`** instead of a bare key (null value):
+
+```yaml
+regionsSupportingMachine:
+    g4dn:
+        eu-central-1: []
+        eu-west-2: []
+```
+
+`eu-central-1: []` means the region is supported but zone selection falls back to the Kyma worker node pool zones. This is functionally equivalent to a bare key when processed by KEB, but survives the Landscaper patch without being dropped.
+
+### Machine type not available in any region
+
+Use an **empty map `{}`** as the value for the machine family:
+
+```yaml
+regionsSupportingMachine:
+    g6: {}
+```
+
+This makes the machine type unavailable in every region.

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -43,7 +43,7 @@ providersConfiguration:
 
 ## Landscaper Compatibility
 
-Landscaper uses **strategic merge patch** semantics when applying ConfigMaps. Under these semantics, a key with a null value is interpreted as "delete this key" rather than "set this key to null". This means that region entries written without a value:
+Landscaper uses strategic merge patch semantics when applying ConfigMaps. Under these semantics, a key with a null value is interpreted as "delete this key" rather than "set this key to null". This means that region entries written without a value are silently dropped by Landscaper. Therefore, the following setting:
 
 ```yaml
 regionsSupportingMachine:
@@ -51,9 +51,6 @@ regionsSupportingMachine:
         eu-central-1:
         eu-west-2:
     g6:
-```
-
-are silently dropped by Landscaper, resulting in:
 
 ```yaml
 regionsSupportingMachine:

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -59,7 +59,7 @@ regionsSupportingMachine:
 
 ### Region supported in all its zones (no zone restriction)
 
-Use an **empty list `[]`** instead of a bare key (null value):
+Use an empty list `[]` instead of a bare key (null value):
 
 ```yaml
 regionsSupportingMachine:

--- a/docs/contributor/03-50-regions-supporting-machine.md
+++ b/docs/contributor/03-50-regions-supporting-machine.md
@@ -82,4 +82,8 @@ regionsSupportingMachine:
     g6: {}
 ```
 
-This makes the machine type unavailable in every region.
+This makes the machine type unavailable in every region. Users attempting to provision in any region will receive an error similar to:
+
+```
+In the region eu-central-1, the following machine types are not available: g6.xlarge (used in: worker-1), it is not supported in any region
+```

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -738,9 +738,9 @@ func checkUnsupportedMachines(providerSpec ConfigurationProvider, provider pkg.C
 		}
 		availableRegions := providerSpec.SupportedRegions(provider, machineType)
 		if len(availableRegions) == 0 {
-			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), it is not supported in any region", machineType, strings.Join(unsupportedMachines[machineType], ", ")))
+			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), not supported in any region", machineType, strings.Join(unsupportedMachines[machineType], ", ")))
 		} else {
-			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), it is supported in the %s", machineType, strings.Join(unsupportedMachines[machineType], ", "), strings.Join(availableRegions, ", ")))
+			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), supported in the %s", machineType, strings.Join(unsupportedMachines[machineType], ", "), strings.Join(availableRegions, ", ")))
 		}
 	}
 

--- a/internal/broker/instance_create.go
+++ b/internal/broker/instance_create.go
@@ -736,8 +736,12 @@ func checkUnsupportedMachines(providerSpec ConfigurationProvider, provider pkg.C
 		if i > 0 {
 			errorMsg.WriteString("; ")
 		}
-		availableRegions := strings.Join(providerSpec.SupportedRegions(provider, machineType), ", ")
-		errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), it is supported in the %s", machineType, strings.Join(unsupportedMachines[machineType], ", "), availableRegions))
+		availableRegions := providerSpec.SupportedRegions(provider, machineType)
+		if len(availableRegions) == 0 {
+			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), it is not supported in any region", machineType, strings.Join(unsupportedMachines[machineType], ", ")))
+		} else {
+			errorMsg.WriteString(fmt.Sprintf("%s (used in: %s), it is supported in the %s", machineType, strings.Join(unsupportedMachines[machineType], ", "), strings.Join(availableRegions, ", ")))
+		}
 	}
 
 	return fmt.Errorf("%s", errorMsg.String())

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -2000,17 +2000,17 @@ func TestUnsupportedMachineTypeInAdditionalWorkerNodePools(t *testing.T) {
 		{
 			name:                      "Single unsupported machine type",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m8g.large", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1), it is supported in the ap-northeast-1, ap-southeast-1, ca-central-1",
+			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1), supported in the ap-northeast-1, ap-southeast-1, ca-central-1",
 		},
 		{
 			name:                      "Multiple unsupported machine types",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m8g.large", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m7g.xlarge", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1), it is supported in the ap-northeast-1, ap-southeast-1, ca-central-1; m7g.xlarge (used in: name-2), it is supported in the us-west-2",
+			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1), supported in the ap-northeast-1, ap-southeast-1, ca-central-1; m7g.xlarge (used in: name-2), supported in the us-west-2",
 		},
 		{
 			name:                      "Duplicate unsupported machine type",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "m8g.large", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "m8g.large", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1, name-2), it is supported in the ap-northeast-1, ap-southeast-1, ca-central-1",
+			expectedError:             "In the region eu-central-1, the following machine types are not available: m8g.large (used in: name-1, name-2), supported in the ap-northeast-1, ap-southeast-1, ca-central-1",
 		},
 	}
 
@@ -3518,7 +3518,7 @@ func TestProvision_UnsupportedMachineType(t *testing.T) {
 				true,
 			)
 
-			require.EqualError(t, err, "In the region eu-west-2, the following machine types are not available: ri.xlarge (used in: name-1), it is not supported in any region")
+			require.EqualError(t, err, "In the region eu-west-2, the following machine types are not available: ri.xlarge (used in: name-1), not supported in any region")
 		})
 	}
 }

--- a/internal/broker/instance_create_test.go
+++ b/internal/broker/instance_create_test.go
@@ -3435,6 +3435,94 @@ func TestProvisionBlocklist(t *testing.T) {
 	})
 }
 
+func TestProvision_UnsupportedMachineType(t *testing.T) {
+	testCases := []struct {
+		name           string
+		zonesDiscovery bool
+	}{
+		{
+			name:           "zones discovery enabled",
+			zonesDiscovery: true,
+		},
+		{
+			name:           "zones discovery disabled",
+			zonesDiscovery: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
+
+			additionalWorkerNodePools := `[{"name": "name-1", "machineType": "ri.xlarge", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`
+
+			memoryStorage := storage.NewMemoryStorage()
+
+			queue := &automock.Queue{}
+			queue.On("Add", mock.AnythingOfType("string"))
+
+			factoryBuilder := &automock.PlanValidator{}
+			factoryBuilder.On("IsPlanSupport", broker.AWSPlanID).Return(true)
+
+			rulesService, err := rules.NewRulesServiceFromSlice([]string{"aws"}, sets.New("aws"), sets.New("aws"))
+			require.NoError(t, err)
+
+			kcBuilder := &kcMock.KcBuilder{}
+			kcBuilder.On("GetServerURL", "").Return("", fmt.Errorf("error"))
+
+			provisionEndpoint := broker.NewFakeProvisionEndpointBuilder().
+				WithConfig(broker.Config{
+					EnablePlans:          []string{"aws"},
+					URL:                  brokerURL,
+					OnlySingleTrialPerGA: true,
+				}).
+				WithGardenerConfig(fixGardenerConfig()).
+				WithInfrastructureManager(imConfigFixture).
+				WithStorage(memoryStorage).
+				WithQueue(queue).
+				WithLogger(log).
+				WithDashboardConfig(dashboardConfig).
+				WithKubeconfigBuilder(kcBuilder).
+				WithSchemaService(newSchemaService(t)).
+				WithConfigurationProvider(fixture.NewProviderSpecWithZonesDiscovery(t, tc.zonesDiscovery)).
+				WithValuesProvider(fixValueProvider(t)).
+				WithRulesService(rulesService).
+				WithGardenerClient(fixture.CreateGardenerClient()).
+				WithAwsClientFactory(fixture.NewFakeAWSClientFactory(map[string][]string{
+					"m6i.large": {"eu-west-2a", "eu-west-2b", "eu-west-2c"},
+					"ri.xlarge": {"eu-west-2a", "eu-west-2b", "eu-west-2c"},
+				}, nil)).
+				Build()
+
+			_, err = provisionEndpoint.Provision(
+				fixRequestContext(t, "req-region"),
+				instanceID,
+				domain.ProvisionDetails{
+					ServiceID: serviceID,
+					PlanID:    broker.AWSPlanID,
+					RawParameters: json.RawMessage(fmt.Sprintf(
+						`{"name": "%s", "region": "%s", "additionalWorkerNodePools": %s}`,
+						clusterName,
+						"eu-west-2",
+						additionalWorkerNodePools,
+					)),
+					RawContext: json.RawMessage(fmt.Sprintf(
+						`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`,
+						globalAccountID,
+						subAccountID,
+						"Test@Test.pl",
+					)),
+				},
+				true,
+			)
+
+			require.EqualError(t, err, "In the region eu-west-2, the following machine types are not available: ri.xlarge (used in: name-1), it is not supported in any region")
+		})
+	}
+}
+
 func fixExistOperation() internal.Operation {
 	provisioningOperation := fixture.FixProvisioningOperation(existOperationID, instanceID)
 	ptrClusterRegion := clusterRegion

--- a/internal/broker/instance_update_test.go
+++ b/internal/broker/instance_update_test.go
@@ -1474,17 +1474,17 @@ func TestUpdateUnsupportedMachineInAdditionalWorkerNodePools(t *testing.T) {
 		{
 			name:                      "Single unsupported machine type",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "Standard_D8s_v5", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1), it is supported in the brazilsouth, uksouth",
+			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1), supported in the brazilsouth, uksouth",
 		},
 		{
 			name:                      "Multiple unsupported machine types",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "Standard_D8s_v5", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "Standard_D16s_v5", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1), it is supported in the brazilsouth, uksouth; Standard_D16s_v5 (used in: name-2), it is supported in the brazilsouth, uksouth",
+			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1), supported in the brazilsouth, uksouth; Standard_D16s_v5 (used in: name-2), supported in the brazilsouth, uksouth",
 		},
 		{
 			name:                      "Duplicate unsupported machine type",
 			additionalWorkerNodePools: `[{"name": "name-1", "machineType": "Standard_D8s_v5", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}, {"name": "name-2", "machineType": "Standard_D8s_v5", "haZones": true, "autoScalerMin": 3, "autoScalerMax": 20}]`,
-			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1, name-2), it is supported in the brazilsouth, uksouth",
+			expectedError:             "In the region westeurope, the following machine types are not available: Standard_D8s_v5 (used in: name-1, name-2), supported in the brazilsouth, uksouth",
 		},
 	}
 

--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -439,6 +439,8 @@ aws:
   zonesDiscovery: %t
   machinesVersions:
     mi.{size}: m7i.{size}
+  regionsSupportingMachine:
+    ri: {}
 `, zonesDiscovery)
 	providerSpec, err := configuration.NewProviderSpec(strings.NewReader(spec))
 	require.NoError(t, err)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix error message in `checkUnsupportedMachines` to handle machine types not supported in any region (instead of joining an empty slice)
- Document Landscaper compatibility for `regionsSupportingMachine` — explain why bare null keys are dropped under strategic merge patch and how to use `[]` and `{}` instead
- Add the test cases described in the issue

**Related issue(s)**
See also #3152