### PR TITLE
Change MultiZoneCluster Default To True

### DIFF
--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -76,7 +76,7 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MACHINE_&#x200b;IMAGE** | None | Sets the default machine image name for nodes in provisioned clusters. If empty, the Gardener default value is used. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MACHINE_&#x200b;IMAGE_VERSION** | None | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MAX_PODS** | <code>200</code> | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. |
-| **APP_INFRASTRUCTURE_&#x200b;MANAGER_MULTI_ZONE_&#x200b;CLUSTER** | <code>false</code> | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. |
+| **APP_INFRASTRUCTURE_&#x200b;MANAGER_MULTI_ZONE_&#x200b;CLUSTER** | <code>true</code> | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_USE_SMALLER_&#x200b;MACHINE_TYPES** | <code>false</code> | If true, provisions trial and freemium clusters using smaller machine types. |
 | **APP_KUBECONFIG_&#x200b;ALLOW_ORIGINS** | <code>*</code> | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. |
 | **APP_KYMA_DASHBOARD_&#x200b;CONFIG_LANDSCAPE_URL** | <code>https://dashboard.dev.kyma.cloud.sap</code> | The base URL of the Kyma Dashboard used to generate links to the web UI for Kyma runtimes. |

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -166,7 +166,7 @@
 | infrastructureManager.<br>machineImage | Sets the default machine image name for nodes in provisioned clusters. If empty, the Gardener default value is used. | `` |
 | infrastructureManager.<br>machineImageVersion | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. | `` |
 | infrastructureManager.<br>maxPods | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. | `200` |
-| infrastructureManager.<br>multiZoneCluster | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. | `false` |
+| infrastructureManager.<br>multiZoneCluster | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. | `true` |
 | infrastructureManager.<br>useSmallerMachineTypes | If true, provisions trial and freemium clusters using smaller machine types. | `false` |
 | kubeconfig.<br>allowOrigins | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. | `*` |
 | kymaDashboardConfig.<br>landscapeURL | The base URL of the Kyma Dashboard used to generate links to the web UI for Kyma runtimes. | `https://dashboard.dev.kyma.cloud.sap` |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -164,7 +164,7 @@ type InfrastructureManager struct {
 	MachineImage                 string            `envconfig:"optional"`
 	MachineImageVersion          string            `envconfig:"optional"`
 	DefaultTrialProvider         pkg.CloudProvider `envconfig:"default=Azure"`
-	MultiZoneCluster             bool              `envconfig:"default=false"`
+	MultiZoneCluster             bool              `envconfig:"default=true"`
 	ControlPlaneFailureTolerance string            `envconfig:"optional"`
 	UseSmallerMachineTypes       bool              `envconfig:"default=false"`
 	IngressFilteringPlans        StringList        `envconfig:"default=no-plan"`

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -383,7 +383,7 @@ infrastructureManager:
   # Sets the maximum number of Pods per node for global accounts in the max Pods allowlist.
   maxPods: 200
   # If true, enables provisioning of clusters with nodes distributed across multiple availability zones.
-  multiZoneCluster: "false"
+  multiZoneCluster: "true"
   # If true, provisions trial and freemium clusters using smaller machine types.
   useSmallerMachineTypes: "false"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change the default value of `MultiZoneCluster` from `false` to `true` in the broker configuration
- Update the default value of `multiZoneCluster` in `resources/keb/values.yaml`
- Update the documented default values in `docs/contributor/02-30-keb-configuration.md` and `docs/contributor/02-70-chart-config.md`

**Related issue(s)**
See also #3152