### PR TITLE
Increase Service Binding Cleanup Job Request Timeout to 10s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ debug
 __pycache__/
 .pytest_cache/
 docs/superpowers/
+.worktrees/

--- a/cmd/servicebindingcleanup/main.go
+++ b/cmd/servicebindingcleanup/main.go
@@ -22,7 +22,7 @@ type Config struct {
 
 type JobConfig struct {
 	DryRun         bool          `envconfig:"default=true"`
-	RequestTimeout time.Duration `envconfig:"default=2s"`
+	RequestTimeout time.Duration `envconfig:"default=10s"`
 	RequestRetries int           `envconfig:"default=2"`
 }
 

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -253,7 +253,7 @@
 | serviceBindingCleanup.<br>dryRun | If true, the Job only logs what would be deleted without actually removing any bindings. | `False` |
 | serviceBindingCleanup.<br>enabled | If true, enables the Service Binding Cleanup CronJob. | `True` |
 | serviceBindingCleanup.<br>requestRetries | Number of times to retry a failed DELETE request for a binding. | `2` |
-| serviceBindingCleanup.<br>requestTimeout | Timeout for each DELETE request to the broker. | `2s` |
+| serviceBindingCleanup.<br>requestTimeout | Timeout for each DELETE request to the broker. | `10s` |
 | serviceBindingCleanup.<br>schedule | - | `0 2,14 * * *` |
 | subaccountCleanup.<br>enabled | - | `true` |
 | subaccountCleanup.<br>schedule | - | `0 1 * * *` |

--- a/docs/contributor/06-70-service-binding-cleanup-cronjob.md
+++ b/docs/contributor/06-70-service-binding-cleanup-cronjob.md
@@ -42,5 +42,5 @@ Use the following environment variables to configure the Job:
 | **APP_DATABASE_USER** | None | Specifies the username for the database. |
 | **APP_JOB_DRY_RUN** | <code>false</code> | If true, the Job only logs what would be deleted without actually removing any bindings. |
 | **APP_JOB_REQUEST_&#x200b;RETRIES** | <code>2</code> | Number of times to retry a failed DELETE request for a binding. |
-| **APP_JOB_REQUEST_&#x200b;TIMEOUT** | <code>2s</code> | Timeout for each DELETE request to the broker. |
+| **APP_JOB_REQUEST_&#x200b;TIMEOUT** | <code>10s</code> | Timeout for each DELETE request to the broker. |
 | **DATABASE_EMBEDDED** | <code>true</code> | - |

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -666,7 +666,7 @@ serviceBindingCleanup:
   # Number of times to retry a failed DELETE request for a binding.
   requestRetries: 2
   # Timeout for each DELETE request to the broker.
-  requestTimeout: 2s
+  requestTimeout: 10s
   schedule: "0 2,14 * * *"
 # =================================================
 


### PR DESCRIPTION
## Description

- Increase `APP_JOB_REQUEST_TIMEOUT` default from `2s` to `10s` in the service binding cleanup job
- Update `requestTimeout` in `values.yaml` accordingly
- Regenerate environment variable documentation

The cleanup job's 2s HTTP timeout was too tight for KEB's unbind handler, which makes 3 sequential DELETE calls to the SKR (ClusterRoleBinding, ClusterRole, ServiceAccount). Occasional API latency spikes push the 3-call sequence past 2s, the job's context deadline fires mid-flight, and KEB returns HTTP 500. The same binding IDs fail on every run, so the backlog never drains and `kcp_keb_v2_minutes_since_earliest_binding_expiration` keeps growing until the alert fires.

See also https://github.tools.sap/kyma/backlog/issues/9603

**Related issue(s)**

## Testing

- [ ] Verified `APP_JOB_REQUEST_TIMEOUT` default is `10s` in `cmd/servicebindingcleanup/main.go`
- [ ] Verified `requestTimeout: 10s` in `resources/keb/values.yaml`
- [ ] Documentation regenerated