### PR TITLE
Fix Subaccount-Sync v2 eventType by Issuing One Request per Event Type

### DIFF
--- a/internal/subaccountsync/cis_events.go
+++ b/internal/subaccountsync/cis_events.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func (c *RateLimitedCisClient) buildEventRequest(page int, fromActionTime int64, cursor string) (*http.Request, error) {
+func (c *RateLimitedCisClient) buildEventRequest(page int, fromActionTime int64, cursor string, eventType string) (*http.Request, error) {
 	if c.eventsServiceVersion == "v2" {
 		request, err := http.NewRequest(http.MethodGet, fmt.Sprintf(eventServicePathV2, c.config.ServiceURL), nil)
 		if err != nil {
@@ -79,13 +79,25 @@ func (c *RateLimitedCisClient) fetchEventsWindowV1(fromActionTime int64) ([]Even
 }
 
 func (c *RateLimitedCisClient) fetchEventsWindowV2() ([]Event, error) {
+	var all []Event
+	for _, et := range eventTypes {
+		events, err := c.fetchEventsWindowV2ForType(et)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, events...)
+	}
+	return all, nil
+}
+
+func (c *RateLimitedCisClient) fetchEventsWindowV2ForType(et string) ([]Event, error) {
 	var events []Event
 	var cursor string
 	var page int
 	for {
-		cisResponse, err := c.fetchEventsPageV2(cursor)
+		cisResponse, err := c.fetchEventsPageV2(cursor, et)
 		if err != nil {
-			c.log.Error(fmt.Sprintf("while getting subaccount events (v2) page %d: %v", page, err))
+			c.log.Error(fmt.Sprintf("while getting subaccount events (v2) page %d for type %s: %v", page, et, err))
 			return events, err
 		}
 		events = append(events, cisResponse.Events...)
@@ -95,12 +107,12 @@ func (c *RateLimitedCisClient) fetchEventsWindowV2() ([]Event, error) {
 		}
 		cursor = cisResponse.NextCursor
 	}
-	c.log.Debug(fmt.Sprintf("Event window fetched (v2) - pages: %d, events: %d", page, len(events)))
+	c.log.Debug(fmt.Sprintf("Event window fetched (v2) for type %s - pages: %d, events: %d", et, page, len(events)))
 	return events, nil
 }
 
-func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string) (CisEventsResponse, error) {
-	request, err := c.buildEventRequest(0, 0, cursor)
+func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string, et string) (CisEventsResponse, error) {
+	request, err := c.buildEventRequest(0, 0, cursor, et)
 	if err != nil {
 		return CisEventsResponse{}, fmt.Errorf("while building v2 request for event service: %v", err)
 	}
@@ -124,7 +136,7 @@ func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string) (CisEventsRespon
 }
 
 func (c *RateLimitedCisClient) fetchEventsPage(page int, fromActionTime int64) (CisEventsResponse, error) {
-	request, err := c.buildEventRequest(page, fromActionTime, "")
+	request, err := c.buildEventRequest(page, fromActionTime, "", eventType)
 	if err != nil {
 		return CisEventsResponse{}, fmt.Errorf("while building request for event service: %v", err)
 	}

--- a/internal/subaccountsync/cis_events_test.go
+++ b/internal/subaccountsync/cis_events_test.go
@@ -38,12 +38,13 @@ func TestBuildEventRequest_V2_FirstCall(t *testing.T) {
 		ctx:                  context.Background(),
 		RateLimiter:          rate.NewLimiter(rate.Every(time.Millisecond), 1000),
 	}
-	req, err := c.buildEventRequest(0, 0, "")
+	req, err := c.buildEventRequest(0, 0, "", "Subaccount_Creation")
 	require.NoError(t, err)
 	q := req.URL.Query()
 	assert.Equal(t, "1H", q.Get("since"))
 	assert.Equal(t, "Subaccount", q.Get("entityType"))
-	assert.Equal(t, eventType, q.Get("eventType"))
+	assert.Equal(t, "Subaccount_Creation", q.Get("eventType"))
+	assert.Equal(t, 1, len(q["eventType"]), "v2 must send exactly one eventType per request")
 	assert.Equal(t, "10", q.Get("pageSize"))
 	assert.Equal(t, "", q.Get("cursor"))
 	assert.Equal(t, "", q.Get("pageNum"))
@@ -59,7 +60,7 @@ func TestBuildEventRequest_V2_SubsequentCall(t *testing.T) {
 		ctx:                  context.Background(),
 		RateLimiter:          rate.NewLimiter(rate.Every(time.Millisecond), 1000),
 	}
-	req, err := c.buildEventRequest(0, 0, "cursor-abc")
+	req, err := c.buildEventRequest(0, 0, "cursor-abc", "Subaccount_Creation")
 	require.NoError(t, err)
 	q := req.URL.Query()
 	assert.Equal(t, "cursor-abc", q.Get("cursor"))
@@ -74,7 +75,7 @@ func TestBuildEventRequest_V1(t *testing.T) {
 		ctx:                  context.Background(),
 		RateLimiter:          rate.NewLimiter(rate.Every(time.Millisecond), 1000),
 	}
-	req, err := c.buildEventRequest(2, 1710748500000, "")
+	req, err := c.buildEventRequest(2, 1710748500000, "", eventType)
 	require.NoError(t, err)
 	q := req.URL.Query()
 	assert.Equal(t, "2", q.Get("pageNum"))
@@ -92,17 +93,26 @@ func TestFetchEventsWindow_V2_CursorPagination(t *testing.T) {
 		{ActionTime: 2000, SubaccountID: "sa2", Type: "Subaccount_Creation"},
 	}
 
+	// The v2 client issues one request per eventType. Each type gets its own
+	// cursor-based pagination sequence. The mock returns one page per type.
 	callCount := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callCount++
+		cursor := r.URL.Query().Get("cursor")
+		et := r.URL.Query().Get("eventType")
 		var resp CisEventsResponse
-		if callCount == 1 {
-			assert.Equal(t, "", r.URL.Query().Get("cursor"), "first call must not have cursor")
+		if cursor == "" {
 			assert.NotEmpty(t, r.URL.Query().Get("since"))
-			resp = CisEventsResponse{Events: page1Events, NextCursor: "cursor-page2"}
+			switch et {
+			case "Subaccount_Creation":
+				resp = CisEventsResponse{Events: page2Events, NextCursor: "cursor-creation-p2"}
+			case "Subaccount_Update":
+				resp = CisEventsResponse{Events: page1Events, NextCursor: ""}
+			}
 		} else {
-			assert.Equal(t, "cursor-page2", r.URL.Query().Get("cursor"))
-			resp = CisEventsResponse{Events: page2Events, NextCursor: ""}
+			// second page for Subaccount_Creation
+			assert.Equal(t, "cursor-creation-p2", cursor)
+			resp = CisEventsResponse{Events: []Event{}, NextCursor: ""}
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
@@ -121,7 +131,5 @@ func TestFetchEventsWindow_V2_CursorPagination(t *testing.T) {
 	events, err := c.FetchEventsWindow(0)
 	require.NoError(t, err)
 	require.Len(t, events, 2)
-	assert.Equal(t, "sa1", events[0].SubaccountID)
-	assert.Equal(t, "sa2", events[1].SubaccountID)
-	assert.Equal(t, 2, callCount)
+	assert.Equal(t, 3, callCount) // Subaccount_Creation: 2 pages, Subaccount_Update: 1 page
 }

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -27,8 +27,10 @@ const (
 	eventServicePath      = "%s/events/v1/events/central"
 	eventServicePathV2    = "%s/events/v2/events/central"
 	subaccountServicePath = "%s/accounts/v1/technical/subaccounts/%s"
-	eventType             = "Subaccount_Creation,Subaccount_Update"
+	eventType             = "Subaccount_Creation,Subaccount_Update" // used for v1 (comma-separated string)
 )
+
+var eventTypes = []string{"Subaccount_Creation", "Subaccount_Update"} // used for v2 (one request per type)
 
 type (
 	subaccountIDType string


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix 400 error from the v2 Events API: the `eventType` parameter does not support multiple values in v2, so sending `Subaccount_Creation,Subaccount_Update` as a single (or repeated) parameter is rejected
- Issue one v2 request per event type (`Subaccount_Creation`, `Subaccount_Update`) and merge the results
- Update fake CIS server v2 handler to use `query.Get("eventType")` (single value) matching the corrected client behavior
- Update unit tests to assert exactly one `eventType` per v2 request and reflect the two-request pagination flow

**Related issue(s)**