### PR TITLE
Add Queue Depth Metric to Process Queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/pivotal-cf/brokerapi/v12 v12.0.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -109,7 +110,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -66,7 +66,7 @@ func (q *Queue) Add(processId string) {
 func (q *Queue) AddAfter(processId string, duration time.Duration) {
 	q.queue.AddAfter(processId, duration)
 	q.queueDepthGauge.Set(float64(q.queue.Len()))
-	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %d, queue length is %d", processId, q.name, duration, q.queue.Len()))
+	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %s, queue length is %d", processId, q.name, duration, q.queue.Len()))
 }
 
 func (q *Queue) ShutDown() {

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -59,14 +59,16 @@ func NewQueue(executor Executor, log *slog.Logger, name string) *Queue {
 
 func (q *Queue) Add(processId string) {
 	q.queue.Add(processId)
-	q.queueDepthGauge.Set(float64(q.queue.Len()))
-	q.log.Info(fmt.Sprintf("added item %s to the queue %s, queue length is %d", processId, q.name, q.queue.Len()))
+	queueLen := q.queue.Len()
+	q.queueDepthGauge.Set(float64(queueLen))
+	q.log.Info(fmt.Sprintf("added item %s to the queue %s, queue length is %d", processId, q.name, queueLen))
 }
 
 func (q *Queue) AddAfter(processId string, duration time.Duration) {
 	q.queue.AddAfter(processId, duration)
-	q.queueDepthGauge.Set(float64(q.queue.Len()))
-	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %s, queue length is %d", processId, q.name, duration, q.queue.Len()))
+	queueLen := q.queue.Len()
+	q.queueDepthGauge.Set(float64(queueLen))
+	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %s, queue length is %d", processId, q.name, duration, queueLen))
 }
 
 func (q *Queue) ShutDown() {

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -26,6 +26,7 @@ type Queue struct {
 
 	speedFactor       int64
 	workersInUseGauge prometheus.Gauge
+	queueDepthGauge   prometheus.Gauge
 }
 
 var queueWorkersInUseMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -33,6 +34,13 @@ var queueWorkersInUseMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Subsystem: "keb_v2",
 	Name:      "queue_workers_in_use",
 	Help:      "Number of queue workers currently processing items",
+}, []string{"queue_name"})
+
+var queueDepthMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "kcp",
+	Subsystem: "keb_v2",
+	Name:      "queue_depth",
+	Help:      "Number of items currently waiting in the queue",
 }, []string{"queue_name"})
 
 func NewQueue(executor Executor, log *slog.Logger, name string) *Queue {
@@ -45,16 +53,19 @@ func NewQueue(executor Executor, log *slog.Logger, name string) *Queue {
 		speedFactor:       1,
 		name:              name,
 		workersInUseGauge: queueWorkersInUseMetric.WithLabelValues(name),
+		queueDepthGauge:   queueDepthMetric.WithLabelValues(name),
 	}
 }
 
 func (q *Queue) Add(processId string) {
 	q.queue.Add(processId)
+	q.queueDepthGauge.Set(float64(q.queue.Len()))
 	q.log.Info(fmt.Sprintf("added item %s to the queue %s, queue length is %d", processId, q.name, q.queue.Len()))
 }
 
 func (q *Queue) AddAfter(processId string, duration time.Duration) {
 	q.queue.AddAfter(processId, duration)
+	q.queueDepthGauge.Set(float64(q.queue.Len()))
 	q.log.Info(fmt.Sprintf("item %s will be added to the queue %s after duration of %d, queue length is %d", processId, q.name, duration, q.queue.Len()))
 }
 
@@ -110,6 +121,7 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 						workerLogger.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					queue.Done(key)
+					q.queueDepthGauge.Set(float64(q.queue.Len()))
 					workerLogger.Info("queue done processing")
 				}()
 

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -122,6 +122,7 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 						workerLogger.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					queue.Done(key)
+					q.queueDepthGauge.Set(float64(queue.Len()))
 					workerLogger.Info("queue done processing")
 				}()
 

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -111,6 +111,7 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 				}
 
 				q.workersInUseGauge.Inc()
+				q.queueDepthGauge.Set(float64(q.queue.Len()))
 				id := key
 				workerLogger := log.With("operationID", id)
 				workerLogger.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
@@ -121,7 +122,6 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 						workerLogger.Error(fmt.Sprintf("panic error from process: %v. Stacktrace: %s", err, debug.Stack()))
 					}
 					queue.Done(key)
-					q.queueDepthGauge.Set(float64(q.queue.Len()))
 					workerLogger.Info("queue done processing")
 				}()
 

--- a/internal/process/queue.go
+++ b/internal/process/queue.go
@@ -113,10 +113,11 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 				}
 
 				q.workersInUseGauge.Inc()
-				q.queueDepthGauge.Set(float64(q.queue.Len()))
+				queueLen := queue.Len()
+				q.queueDepthGauge.Set(float64(queueLen))
 				id := key
 				workerLogger := log.With("operationID", id)
-				workerLogger.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, q.queue.Len()))
+				workerLogger.Info(fmt.Sprintf("about to process item %s, queue length is %d", id, queueLen))
 
 				defer func() {
 					q.workersInUseGauge.Dec()
@@ -130,7 +131,7 @@ func (q *Queue) worker(queue workqueue.TypedRateLimitingInterface[string], proce
 
 				when, err := process(id)
 				if err == nil && when != 0 {
-					workerLogger.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, q.queue.Len()))
+					workerLogger.Info(fmt.Sprintf("Adding %q item after %s, queue length %d", id, when, queue.Len()))
 					afterDuration := time.Duration(int64(when) / q.speedFactor)
 					queue.AddAfter(key, afterDuration)
 					return false

--- a/internal/process/queue_test.go
+++ b/internal/process/queue_test.go
@@ -48,7 +48,6 @@ func TestQueueDepthMetric(t *testing.T) {
 	assert.Equal(t, 1.0, gaugeValue(t, name), "depth should be 1 after Add")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	q.Run(ctx.Done(), 1)
 
 	// wait until the worker picks up the item
@@ -56,6 +55,9 @@ func TestQueueDepthMetric(t *testing.T) {
 	assert.Equal(t, 0.0, gaugeValue(t, name), "depth should be 0 after Get")
 
 	close(release)
+	cancel()
+	q.ShutDown()
+	q.waitGroup.Wait()
 }
 
 func TestWorkerLogging(t *testing.T) {

--- a/internal/process/queue_test.go
+++ b/internal/process/queue_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +21,41 @@ type StdExecutor struct {
 func (e *StdExecutor) Execute(operationID string) (time.Duration, error) {
 	e.logger(fmt.Sprintf("executing operation %s", operationID))
 	return 0, nil
+}
+
+func gaugeValue(t *testing.T, queueName string) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, queueDepthMetric.WithLabelValues(queueName).Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func TestQueueDepthMetric(t *testing.T) {
+	name := fmt.Sprintf("depth-test-%d", time.Now().UnixNano())
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	processing := make(chan struct{})
+	release := make(chan struct{})
+
+	q := NewQueue(&StdExecutor{logger: func(_ string) {
+		close(processing)
+		<-release
+	}}, logger, name)
+
+	assert.Equal(t, 0.0, gaugeValue(t, name), "depth should be 0 before any items added")
+
+	q.Add("op-1")
+	assert.Equal(t, 1.0, gaugeValue(t, name), "depth should be 1 after Add")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	q.Run(ctx.Done(), 1)
+
+	// wait until the worker picks up the item
+	<-processing
+	assert.Equal(t, 0.0, gaugeValue(t, name), "depth should be 0 after Get")
+
+	close(release)
 }
 
 func TestWorkerLogging(t *testing.T) {
@@ -64,3 +101,4 @@ type captureWriter struct {
 func (c *captureWriter) Write(p []byte) (n int, err error) {
 	return c.buf.Write(p)
 }
+

--- a/internal/process/queue_test.go
+++ b/internal/process/queue_test.go
@@ -101,4 +101,3 @@ type captureWriter struct {
 func (c *captureWriter) Write(p []byte) (n int, err error) {
 	return c.buf.Write(p)
 }
-


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `kcp_keb_v2_queue_depth{queue_name}` gauge metric to `internal/process/Queue`
- The metric is updated on `Add`, `AddAfter`, and after each `queue.Done()` call
- Enables alert expressions based on sustained queue depth as the correct signal for worker pool exhaustion, replacing the broken `in_progress_total > workers_in_use` expressions

**Related issue(s)**
See also #3273