### PR TITLE
Fix Binding Create Returning 400 Instead of 500 on K8s Error

### DIFF
--- a/internal/broker/bind_create.go
+++ b/internal/broker/bind_create.go
@@ -273,7 +273,7 @@ func (b *BindEndpoint) createNewBinding(ctx context.Context, instanceID string, 
 	if err != nil {
 		message := fmt.Sprintf("failed to create a Kyma binding using service account's kubeconfig: %s", err)
 		b.log.Error(fmt.Sprintf("for instance %s %s", instanceID, message))
-		return domain.Binding{}, apiresponses.NewFailureResponse(errors.New(message), http.StatusBadRequest, message)
+		return domain.Binding{}, apiresponses.NewFailureResponse(errors.New(message), http.StatusInternalServerError, message)
 	}
 
 	binding.ExpiresAt = expiresAt

--- a/internal/broker/bind_create_test.go
+++ b/internal/broker/bind_create_test.go
@@ -118,6 +118,20 @@ func TestCreateBindingEndpoint_dbInsertionInCaseOfError(t *testing.T) {
 		require.NotNil(t, binding.ExpiresAt)
 		require.Empty(t, binding.Kubeconfig)
 	})
+
+	t.Run("should return 500 when k8s API call fails", func(t *testing.T) {
+		// when
+		_, err := bindEndpoint.Bind(context.Background(), instanceID1, "binding-id-k8s-error", domain.BindDetails{
+			ServiceID: "123",
+			PlanID:    fixture.PlanId,
+		}, false)
+
+		// then
+		require.Error(t, err)
+		apierr, ok := err.(*apiresponses.FailureResponse)
+		require.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, apierr.ValidatedStatusCode(nil))
+	})
 }
 
 func TestCreateBindingExceedsAllowedNumberOfNonExpiredBindings(t *testing.T) {

--- a/internal/broker/bind_create_test.go
+++ b/internal/broker/bind_create_test.go
@@ -132,6 +132,30 @@ func TestCreateBindingEndpoint_dbInsertionInCaseOfError(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, http.StatusInternalServerError, apierr.ValidatedStatusCode(nil))
 	})
+
+	t.Run("should return 422 when binding already exists in DB with empty kubeconfig", func(t *testing.T) {
+		// given - pre-insert a binding with the same ID, matching ExpirationSeconds, future ExpiresAt, no kubeconfig
+		// searchDbForBinding finds it, sees empty kubeconfig → "binding creation already in progress" → 422
+		err := db.Bindings().Insert(&internal.Binding{
+			ID:                "binding-id-duplicate",
+			InstanceID:        instanceID1,
+			ExpiresAt:         time.Now().Add(time.Hour),
+			ExpirationSeconds: int64(bindingCfg.ExpirationSeconds),
+		})
+		require.NoError(t, err)
+
+		// when
+		_, err = bindEndpoint.Bind(context.Background(), instanceID1, "binding-id-duplicate", domain.BindDetails{
+			ServiceID: "123",
+			PlanID:    fixture.PlanId,
+		}, false)
+
+		// then
+		require.Error(t, err)
+		apierr, ok := err.(*apiresponses.FailureResponse)
+		require.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, apierr.ValidatedStatusCode(nil))
+	})
 }
 
 func TestCreateBindingExceedsAllowedNumberOfNonExpiredBindings(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix `serviceAccountBindingManager.Create()` error path returning `http.StatusBadRequest` (400) instead of `http.StatusInternalServerError` (500) when a Kubernetes API error occurs during binding creation

**Related issue(s)**
See also #3262