### PR TITLE
Simplify matchState by Returning Conditions Directly

### DIFF
--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -80,15 +80,9 @@ func parseRule(s string) (Rule, error) {
 			val := strings.TrimSpace(tok[bangIdx+2:])
 			switch key {
 			case "GA":
-				if val == "" {
-					return Rule{}, fmt.Errorf("empty GA value in rule %q", s)
-				}
-				parts := strings.Split(val, ",")
-				for i, p := range parts {
-					parts[i] = strings.TrimSpace(p)
-					if parts[i] == "" {
-						return Rule{}, fmt.Errorf("empty GA segment in rule %q", s)
-					}
+				parts, err := parseGAList(val, s)
+				if err != nil {
+					return Rule{}, err
 				}
 				r.ExcludeGlobalAccounts = parts
 			default:
@@ -114,15 +108,9 @@ func parseRule(s string) (Rule, error) {
 			}
 			r.Plan = val
 		case "GA":
-			if val == "" {
-				return Rule{}, fmt.Errorf("empty GA value in rule %q", s)
-			}
-			parts := strings.Split(val, ",")
-			for i, p := range parts {
-				parts[i] = strings.TrimSpace(p)
-				if parts[i] == "" {
-					return Rule{}, fmt.Errorf("empty GA segment in rule %q", s)
-				}
+			parts, err := parseGAList(val, s)
+			if err != nil {
+				return Rule{}, err
 			}
 			r.IncludeGlobalAccounts = parts
 		default:
@@ -133,6 +121,22 @@ func parseRule(s string) (Rule, error) {
 		return Rule{}, fmt.Errorf("GA filter requires plan= in rule %q", s)
 	}
 	return r, nil
+}
+
+// parseGAList splits a comma-separated GA value, trims spaces, and validates
+// that no segment is empty. Used for both GA= and GA!= filter tokens.
+func parseGAList(val, rule string) ([]string, error) {
+	if val == "" {
+		return nil, fmt.Errorf("empty GA value in rule %q", rule)
+	}
+	parts := strings.Split(val, ",")
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+		if parts[i] == "" {
+			return nil, fmt.Errorf("empty GA segment in rule %q", rule)
+		}
+	}
+	return parts, nil
 }
 
 // splitQuotedTokens splits a string into tokens separated by commas that are

--- a/internal/storage/driver/memory/instance.go
+++ b/internal/storage/driver/memory/instance.go
@@ -358,41 +358,23 @@ func (s *instances) matchInstanceState(instanceID string, states []dbmodel.Insta
 func (s *instances) matchState(state dbmodel.InstanceState, op *internal.Operation) bool {
 	switch state {
 	case dbmodel.InstanceSucceeded:
-		if op.State == domain.Succeeded && op.Type != internal.OperationTypeDeprovision {
-			return true
-		}
+		return op.State == domain.Succeeded && op.Type != internal.OperationTypeDeprovision
 	case dbmodel.InstanceFailed:
-		if op.State == domain.Failed && (op.Type == internal.OperationTypeProvision || op.Type == internal.OperationTypeDeprovision) {
-			return true
-		}
+		return op.State == domain.Failed && (op.Type == internal.OperationTypeProvision || op.Type == internal.OperationTypeDeprovision)
 	case dbmodel.InstanceError:
-		if op.State == domain.Failed && op.Type != internal.OperationTypeProvision && op.Type != internal.OperationTypeDeprovision {
-			return true
-		}
+		return op.State == domain.Failed && op.Type != internal.OperationTypeProvision && op.Type != internal.OperationTypeDeprovision
 	case dbmodel.InstanceProvisioning:
-		if op.Type == internal.OperationTypeProvision && op.State == domain.InProgress {
-			return true
-		}
+		return op.Type == internal.OperationTypeProvision && op.State == domain.InProgress
 	case dbmodel.InstanceDeprovisioning:
-		if op.Type == internal.OperationTypeDeprovision && op.State == domain.InProgress {
-			return true
-		}
+		return op.Type == internal.OperationTypeDeprovision && op.State == domain.InProgress
 	case dbmodel.InstanceUpgrading:
-		if op.Type == internal.OperationTypeUpgradeCluster && op.State == domain.InProgress {
-			return true
-		}
+		return op.Type == internal.OperationTypeUpgradeCluster && op.State == domain.InProgress
 	case dbmodel.InstanceUpdating:
-		if op.Type == internal.OperationTypeUpdate && op.State == domain.InProgress {
-			return true
-		}
+		return op.Type == internal.OperationTypeUpdate && op.State == domain.InProgress
 	case dbmodel.InstanceDeprovisioned:
-		if op.State == domain.Succeeded && op.Type == internal.OperationTypeDeprovision {
-			return true
-		}
+		return op.State == domain.Succeeded && op.Type == internal.OperationTypeDeprovision
 	case dbmodel.InstanceNotDeprovisioned:
-		if op.State != domain.Succeeded || op.Type != internal.OperationTypeDeprovision {
-			return true
-		}
+		return op.State != domain.Succeeded || op.Type != internal.OperationTypeDeprovision
 	}
 	return false
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Simplify `(*instances).matchState` in the in-memory storage driver by replacing
  `if <condition> { return true }` patterns with direct `return <condition>` in each
  switch case
- Reduce cyclomatic complexity of `matchState` from 30 to 21

**Related issue(s)**