### PR TITLE
Bump Golang to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0

--- a/testing/e2e/provisioning/Dockerfile
+++ b/testing/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/kyma-environment-broker/tests/e2e/provisioning
 

--- a/testing/e2e/provisioning/go.mod
+++ b/testing/e2e/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/provisioning
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/testing/e2e/skr/provisioning-service-test/go.mod
+++ b/testing/e2e/skr/provisioning-service-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/skr/provisioning-service-test
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update Go version from 1.26.3 to 1.26.4 in `go.mod`
- Update Go version from 1.26.3 to 1.26.4 in `testing/e2e/provisioning/go.mod`
- Update Go version from 1.26.3 to 1.26.4 in `testing/e2e/skr/provisioning-service-test/go.mod`
- Update base Docker image from `golang:1.26.3-alpine3.22` to `golang:1.26.4-alpine3.22` in `testing/e2e/provisioning/Dockerfile`

**Related issue(s)**