### PR TITLE
Track CIS Requests Per HTTP Call in Subaccount Sync Metrics

### DIFF
--- a/internal/subaccountsync/cis_accounts.go
+++ b/internal/subaccountsync/cis_accounts.go
@@ -22,7 +22,7 @@ func (c *RateLimitedCisClient) GetSubaccountData(subaccountID string) (CisStateT
 		return CisStateType{}, fmt.Errorf("while building request for accounts technical service: %w", err)
 	}
 
-	response, err := c.httpClient.Do(request)
+	response, err := c.Do(request)
 	if err != nil {
 		c.incRequest("failure")
 		return CisStateType{}, fmt.Errorf("while executing request to accounts technical service: %w", err)

--- a/internal/subaccountsync/cis_accounts.go
+++ b/internal/subaccountsync/cis_accounts.go
@@ -24,6 +24,7 @@ func (c *RateLimitedCisClient) GetSubaccountData(subaccountID string) (CisStateT
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
+		c.incRequest("failure")
 		return CisStateType{}, fmt.Errorf("while executing request to accounts technical service: %w", err)
 	}
 	defer func() {
@@ -34,18 +35,22 @@ func (c *RateLimitedCisClient) GetSubaccountData(subaccountID string) (CisStateT
 	}()
 
 	if response.StatusCode == http.StatusNotFound {
+		c.incRequest("success")
 		return CisStateType{}, nil
 	}
 
 	if response.StatusCode != http.StatusOK {
+		c.incRequest("failure")
 		return CisStateType{}, fmt.Errorf("while processing response: %s", c.handleErrorStatusCode(response))
 	}
 
 	var cisResponse CisStateType
 	err = json.NewDecoder(response.Body).Decode(&cisResponse)
 	if err != nil {
+		c.incRequest("failure")
 		return CisStateType{}, fmt.Errorf("while decoding CIS account response: %w", err)
 	}
 
+	c.incRequest("success")
 	return cisResponse, nil
 }

--- a/internal/subaccountsync/cis_accounts.go
+++ b/internal/subaccountsync/cis_accounts.go
@@ -35,7 +35,7 @@ func (c *RateLimitedCisClient) GetSubaccountData(subaccountID string) (CisStateT
 	}()
 
 	if response.StatusCode == http.StatusNotFound {
-		c.incRequest("success")
+		c.incRequest("notfound")
 		return CisStateType{}, nil
 	}
 

--- a/internal/subaccountsync/cis_events.go
+++ b/internal/subaccountsync/cis_events.go
@@ -108,6 +108,7 @@ func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string) (CisEventsRespon
 	}
 	response, err := c.httpClient.Do(request)
 	if err != nil {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while executing v2 request to event service: %v", err)
 	}
 	defer func() {
@@ -116,12 +117,15 @@ func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string) (CisEventsRespon
 		}
 	}()
 	if response.StatusCode != http.StatusOK {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while processing v2 response: %s", c.handleErrorStatusCode(response))
 	}
 	var cisResponse CisEventsResponse
 	if err := json.NewDecoder(response.Body).Decode(&cisResponse); err != nil {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while decoding CIS v2 events response: %v", err)
 	}
+	c.incRequest("success")
 	return cisResponse, nil
 }
 
@@ -133,6 +137,7 @@ func (c *RateLimitedCisClient) fetchEventsPage(page int, fromActionTime int64) (
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while executing request to event service: %v", err)
 	}
 	defer func() {
@@ -143,30 +148,33 @@ func (c *RateLimitedCisClient) fetchEventsPage(page int, fromActionTime int64) (
 	}()
 
 	if response.StatusCode != http.StatusOK {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while processing response: %s", c.handleErrorStatusCode(response))
 	}
 
 	var cisResponse CisEventsResponse
 	err = json.NewDecoder(response.Body).Decode(&cisResponse)
 	if err != nil {
+		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while decoding CIS events response: %v", err)
 	}
 
+	c.incRequest("success")
 	return cisResponse, nil
 }
 
 func (c *RateLimitedCisClient) getEventsForSubaccounts(fromActionTime int64, logs slog.Logger, subaccountsMap subaccountsSetType) ([]Event, error) {
 	rawEvents, err := c.FetchEventsWindow(fromActionTime)
-	if err != nil && len(rawEvents) == 0 {
+	if err != nil {
 		logs.Error(fmt.Sprintf("while getting events: %s", err))
-		return nil, err
+		return filterEvents(rawEvents, subaccountsMap), err
 	}
 
 	// filter events to get only the ones in subaccounts map
 	filteredEventsFromCis := filterEvents(rawEvents, subaccountsMap)
 	logs.Info(fmt.Sprintf("Raw events: %d, filtered: %d", len(rawEvents), len(filteredEventsFromCis)))
 
-	return filteredEventsFromCis, err
+	return filteredEventsFromCis, nil
 }
 
 func filterEvents(rawEvents []Event, subaccounts subaccountsSetType) []Event {

--- a/internal/subaccountsync/cis_events.go
+++ b/internal/subaccountsync/cis_events.go
@@ -106,7 +106,7 @@ func (c *RateLimitedCisClient) fetchEventsPageV2(cursor string) (CisEventsRespon
 	if err != nil {
 		return CisEventsResponse{}, fmt.Errorf("while building v2 request for event service: %v", err)
 	}
-	response, err := c.httpClient.Do(request)
+	response, err := c.Do(request)
 	if err != nil {
 		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while executing v2 request to event service: %v", err)
@@ -135,7 +135,7 @@ func (c *RateLimitedCisClient) fetchEventsPage(page int, fromActionTime int64) (
 		return CisEventsResponse{}, fmt.Errorf("while building request for event service: %v", err)
 	}
 
-	response, err := c.httpClient.Do(request)
+	response, err := c.Do(request)
 	if err != nil {
 		c.incRequest("failure")
 		return CisEventsResponse{}, fmt.Errorf("while executing request to event service: %v", err)
@@ -166,7 +166,6 @@ func (c *RateLimitedCisClient) fetchEventsPage(page int, fromActionTime int64) (
 func (c *RateLimitedCisClient) getEventsForSubaccounts(fromActionTime int64, logs slog.Logger, subaccountsMap subaccountsSetType) ([]Event, error) {
 	rawEvents, err := c.FetchEventsWindow(fromActionTime)
 	if err != nil {
-		logs.Error(fmt.Sprintf("while getting events: %s", err))
 		return filterEvents(rawEvents, subaccountsMap), err
 	}
 

--- a/internal/subaccountsync/rate_limited_client.go
+++ b/internal/subaccountsync/rate_limited_client.go
@@ -54,7 +54,7 @@ func NewRateLimitedCisClient(ctx context.Context, config CisEndpointConfig, log 
 
 func (c *RateLimitedCisClient) incRequest(status string) {
 	if c.cisRequests != nil {
-		c.cisRequests.With(prometheus.Labels{"endpoint": c.endpoint, "status": status}).Inc()
+		c.cisRequests.WithLabelValues(c.endpoint, status).Inc()
 	}
 }
 

--- a/internal/subaccountsync/rate_limited_client.go
+++ b/internal/subaccountsync/rate_limited_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/time/rate"
 )
@@ -20,13 +21,15 @@ type RateLimitedCisClient struct {
 	RateLimiter          *rate.Limiter
 	eventsServiceVersion string
 	eventsWindowSize     time.Duration
+	cisRequests          *prometheus.CounterVec
+	endpoint             string
 }
 
 type RateLimiter interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func NewRateLimitedCisClient(ctx context.Context, config CisEndpointConfig, log *slog.Logger, eventsServiceVersion string, eventsWindowSize time.Duration) *RateLimitedCisClient {
+func NewRateLimitedCisClient(ctx context.Context, config CisEndpointConfig, log *slog.Logger, eventsServiceVersion string, eventsWindowSize time.Duration, cisRequests *prometheus.CounterVec, endpoint string) *RateLimitedCisClient {
 	cfg := clientcredentials.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
@@ -44,6 +47,14 @@ func NewRateLimitedCisClient(ctx context.Context, config CisEndpointConfig, log 
 		RateLimiter:          rl,
 		eventsServiceVersion: eventsServiceVersion,
 		eventsWindowSize:     eventsWindowSize,
+		cisRequests:          cisRequests,
+		endpoint:             endpoint,
+	}
+}
+
+func (c *RateLimitedCisClient) incRequest(status string) {
+	if c.cisRequests != nil {
+		c.cisRequests.With(prometheus.Labels{"endpoint": c.endpoint, "status": status}).Inc()
 	}
 }
 

--- a/internal/subaccountsync/state_reconciler.go
+++ b/internal/subaccountsync/state_reconciler.go
@@ -120,13 +120,14 @@ func (reconciler *stateReconcilerType) setMetrics() {
 	reconciler.metrics.states.With(prometheus.Labels{"type": usedForProductionLabel, "value": "others"}).Set(float64(others))
 }
 
-func (reconciler *stateReconcilerType) periodicAccountsSync() (found int, notfound int, failures int) {
+func (reconciler *stateReconcilerType) periodicAccountsSync() {
 	logs := reconciler.logger
 
 	// get distinct subaccounts from inMemoryState
 	subaccountsSet := reconciler.getAllSubaccountIDsFromState()
 	logs.Info(fmt.Sprintf("Running CIS accounts synchronization for %d subaccounts", len(subaccountsSet)))
 
+	var found, notfound, failures int
 	for subaccountID := range subaccountsSet {
 		subaccountDataFromCis, err := reconciler.accountsClient.GetSubaccountData(string(subaccountID))
 		if subaccountDataFromCis == (CisStateType{}) && err == nil {
@@ -143,21 +144,18 @@ func (reconciler *stateReconcilerType) periodicAccountsSync() (found int, notfou
 		}
 	}
 	logs.Debug(fmt.Sprintf("Accounts synchronization finished: found: %d, notfound %d, failures: %d", found, notfound, failures))
-	return found, notfound, failures
 }
 
-func (reconciler *stateReconcilerType) periodicEventsSync(fromActionTime int64) (success bool) {
+func (reconciler *stateReconcilerType) periodicEventsSync(fromActionTime int64) {
 
 	logs := reconciler.logger
 	eventsClient := reconciler.eventsClient
 	subaccountsSet := reconciler.getAllSubaccountIDsFromState()
-	success = true
 
 	logs.Info(fmt.Sprintf("Running CIS events synchronization from epoch: %d for %d subaccounts", fromActionTime, len(subaccountsSet)))
 
 	eventsOfInterest, err := eventsClient.getEventsForSubaccounts(fromActionTime, *logs, subaccountsSet)
 	if err != nil {
-		success = false
 		logs.Error(fmt.Sprintf("while getting subaccount events: %s", err))
 		// we will retry in the next run
 	}
@@ -166,8 +164,7 @@ func (reconciler *stateReconcilerType) periodicEventsSync(fromActionTime int64) 
 		reconciler.reconcileCisEvent(event)
 		reconciler.eventWindow.UpdateToTime(event.ActionTime)
 	}
-	logs.Debug(fmt.Sprintf("Events synchronization finished with succcess==%t, the most recent reconciled event time: %d", success, reconciler.eventWindow.lastToTime))
-	return success
+	logs.Debug(fmt.Sprintf("Events synchronization finished, the most recent reconciled event time: %d", reconciler.eventWindow.lastToTime))
 }
 
 func (reconciler *stateReconcilerType) getAllSubaccountIDsFromState() subaccountsSetType {
@@ -187,12 +184,7 @@ func (reconciler *stateReconcilerType) runCronJobs(cfg Config, ctx context.Conte
 		// establish actual time window
 		eventsFrom := reconciler.eventWindow.GetNextFromTime()
 
-		ok := reconciler.periodicEventsSync(eventsFrom)
-		if ok {
-			reconciler.metrics.cisRequests.With(prometheus.Labels{"endpoint": "events", "status": "success"}).Inc()
-		} else {
-			reconciler.metrics.cisRequests.With(prometheus.Labels{"endpoint": "events", "status": "failure"}).Inc()
-		}
+		reconciler.periodicEventsSync(eventsFrom)
 
 		reconciler.eventWindow.UpdateFromTime(eventsFrom)
 		logs.Debug(fmt.Sprintf("Running events synchronization from epoch: %d, lastFromTime: %d, lastToTime: %d", eventsFrom, reconciler.eventWindow.lastFromTime, reconciler.eventWindow.lastToTime))
@@ -202,12 +194,7 @@ func (reconciler *stateReconcilerType) runCronJobs(cfg Config, ctx context.Conte
 	}
 
 	_, err = s.Every(cfg.AccountsSyncInterval).Do(func() {
-		found, notfound, failures := reconciler.periodicAccountsSync()
-
-		reconciler.metrics.cisRequests.With(prometheus.Labels{"endpoint": "accounts", "status": "failure"}).Add(float64(failures))
-		reconciler.metrics.cisRequests.With(prometheus.Labels{"endpoint": "accounts", "status": "success"}).Add(float64(found + notfound))
-		reconciler.metrics.cisRequests.With(prometheus.Labels{"endpoint": "accounts", "status": "notfound"}).Add(float64(notfound))
-
+		reconciler.periodicAccountsSync()
 	})
 	if err != nil {
 		logs.Error(fmt.Sprintf("while scheduling accounts sync job: %s", err))

--- a/internal/subaccountsync/subaccount_sync_service.go
+++ b/internal/subaccountsync/subaccount_sync_service.go
@@ -89,10 +89,6 @@ func (s *SyncService) Run() {
 	logger := slog.Default()
 	logger.Info(fmt.Sprintf("%s service started", s.appName))
 
-	// create CIS clients
-	eventsClient := CreateEventsClient(s.ctx, s.cfg.CisEvents, logger, s.cfg.EventsServiceVersion, s.cfg.EventsWindowSize)
-	accountsClient := CreateAccountsClient(s.ctx, s.cfg.CisAccounts, logger)
-
 	metrics := NewMetrics(s.metricsRegistry, s.appName)
 	promHandler := promhttp.HandlerFor(s.metricsRegistry, promhttp.HandlerOpts{Registry: s.metricsRegistry})
 	http.Handle("/metrics", promHandler)
@@ -104,6 +100,10 @@ func (s *SyncService) Run() {
 			logger.Error(fmt.Sprintf("while serving metrics: %s", err))
 		}
 	}()
+
+	// create CIS clients
+	eventsClient := CreateEventsClient(s.ctx, s.cfg.CisEvents, logger, s.cfg.EventsServiceVersion, s.cfg.EventsWindowSize, metrics.cisRequests)
+	accountsClient := CreateAccountsClient(s.ctx, s.cfg.CisAccounts, logger, metrics.cisRequests)
 
 	// create priority queue
 	priorityQueue := queues.NewPriorityQueueWithCallbacks(logger, &queues.EventHandler{
@@ -179,12 +179,12 @@ func (s *SyncService) Run() {
 	informer.Run(s.ctx.Done())
 }
 
-func CreateAccountsClient(ctx context.Context, accountsConfig CisEndpointConfig, logger *slog.Logger) *RateLimitedCisClient {
-	return NewRateLimitedCisClient(ctx, accountsConfig, logger.With("component", "CIS-Accounts-client"), "", 0)
+func CreateAccountsClient(ctx context.Context, accountsConfig CisEndpointConfig, logger *slog.Logger, cisRequests *prometheus.CounterVec) *RateLimitedCisClient {
+	return NewRateLimitedCisClient(ctx, accountsConfig, logger.With("component", "CIS-Accounts-client"), "", 0, cisRequests, "accounts")
 }
 
-func CreateEventsClient(ctx context.Context, eventsConfig CisEndpointConfig, logger *slog.Logger, eventsServiceVersion string, eventsWindowSize time.Duration) *RateLimitedCisClient {
-	return NewRateLimitedCisClient(ctx, eventsConfig, logger.With("component", "CIS-Events-client"), eventsServiceVersion, eventsWindowSize)
+func CreateEventsClient(ctx context.Context, eventsConfig CisEndpointConfig, logger *slog.Logger, eventsServiceVersion string, eventsWindowSize time.Duration, cisRequests *prometheus.CounterVec) *RateLimitedCisClient {
+	return NewRateLimitedCisClient(ctx, eventsConfig, logger.With("component", "CIS-Events-client"), eventsServiceVersion, eventsWindowSize, cisRequests, "events")
 }
 
 func getDataFromLabels(u *unstructured.Unstructured) (subaccountID string, runtimeID string, betaEnabled string) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `cisRequests *prometheus.CounterVec` and `endpoint string` fields to `RateLimitedCisClient` so each client instance records metrics with the correct endpoint label
- Add `incRequest(status)` helper that increments the counter per HTTP request, guarded by nil-check for tests that omit the counter
- Increment the counter on each HTTP response outcome (success, failure) in `GetSubaccountData`, `fetchEventsPage`, and `fetchEventsPageV2`
- Fix `getEventsForSubaccounts` to propagate errors unconditionally, so partial pagination failures (error after at least one successful page) are no longer silently treated as success
- Remove cycle-level metric increments from `runCronJobs` and return-value tracking from `periodicEventsSync` / `periodicAccountsSync`
- Move `NewMetrics` call before CIS client construction in `SyncService.Run` so the counter is available when clients are created

**Related issue(s)**
See also #3245