### PR TITLE
Update Internal-Only Machine Types Notable Change to Mandatory/External

### DIFF
--- a/notable-changes/1.33.3/notable-change.md
+++ b/notable-changes/1.33.3/notable-change.md
@@ -1,9 +1,9 @@
-<!--{"metadata":{"requirement":"RECOMMENDED","type":"INTERNAL","category":"CONFIGURATION"}}-->
+<!--{"metadata":{"requirement":"MANDATORY","type":"EXTERNAL","category":"CONFIGURATION"}}-->
 
 # KEB: Internal-Only Machine Types
 
 > ### Note: 
-> This change is recommended. Without configuring **internalOnlyMachines**, machine types intended for internal SAP use — such as GPU-equipped instances — remain accessible to external customers.
+> This change is mandatory. Without configuring **internalOnlyMachines**, machine types intended for internal SAP use — such as GPU-equipped instances — remain accessible to external customers.
 
 ## What's Changed
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update notable change metadata from `RECOMMENDED/INTERNAL` to `MANDATORY/EXTERNAL`
- Update notable change note text to reflect that configuring `internalOnlyMachines` is mandatory

**Related issue(s)**
See also #3069