### PR TITLE
Log SHA256 Digest of System CA Bundle at Startup

### DIFF
--- a/cmd/broker/ca_bundle_test.go
+++ b/cmd/broker/ca_bundle_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogCACertBundleDigest_FindsNonEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-certificates.crt")
+	content := []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+	require.NoError(t, os.WriteFile(certPath, content, 0644))
+
+	sum := sha256.Sum256(content)
+	expectedDigest := fmt.Sprintf("%x", sum)
+
+	var logged []map[string]any
+	logger := slog.New(newCapturingHandler(&logged))
+
+	overrideCertFiles := []string{certPath}
+	logCACertBundleDigestFromPaths(logger, overrideCertFiles)
+
+	require.Len(t, logged, 1)
+	assert.Equal(t, slog.LevelInfo, logged[0]["level"])
+	assert.Equal(t, certPath, logged[0]["path"])
+	assert.Equal(t, expectedDigest, logged[0]["sha256"])
+}
+
+func TestLogCACertBundleDigest_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca-certificates.crt")
+	require.NoError(t, os.WriteFile(certPath, []byte{}, 0644))
+
+	var logged []map[string]any
+	logger := slog.New(newCapturingHandler(&logged))
+
+	logCACertBundleDigestFromPaths(logger, []string{certPath})
+
+	require.Len(t, logged, 1)
+	assert.Equal(t, slog.LevelWarn, logged[0]["level"])
+}
+
+func TestLogCACertBundleDigest_MissingFile(t *testing.T) {
+	var logged []map[string]any
+	logger := slog.New(newCapturingHandler(&logged))
+
+	logCACertBundleDigestFromPaths(logger, []string{"/nonexistent/ca.crt"})
+
+	require.Len(t, logged, 1)
+	assert.Equal(t, slog.LevelWarn, logged[0]["level"])
+}
+
+func TestLogCACertBundleDigest_SkipsEmptyUsesNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	emptyPath := filepath.Join(dir, "empty.crt")
+	goodPath := filepath.Join(dir, "good.crt")
+	content := []byte("cert data")
+	require.NoError(t, os.WriteFile(emptyPath, []byte{}, 0644))
+	require.NoError(t, os.WriteFile(goodPath, content, 0644))
+
+	sum := sha256.Sum256(content)
+	expectedDigest := fmt.Sprintf("%x", sum)
+
+	var logged []map[string]any
+	logger := slog.New(newCapturingHandler(&logged))
+
+	logCACertBundleDigestFromPaths(logger, []string{emptyPath, goodPath})
+
+	require.Len(t, logged, 1)
+	assert.Equal(t, slog.LevelInfo, logged[0]["level"])
+	assert.Equal(t, goodPath, logged[0]["path"])
+	assert.Equal(t, expectedDigest, logged[0]["sha256"])
+}
+
+// capturingHandler captures slog records for assertions.
+type capturingHandler struct {
+	records *[]map[string]any
+}
+
+func newCapturingHandler(out *[]map[string]any) *capturingHandler {
+	return &capturingHandler{records: out}
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := map[string]any{"level": r.Level, "msg": r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		entry[a.Key] = a.Value.Any()
+		return true
+	})
+	*h.records = append(*h.records, entry)
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(name string) slog.Handler       { return h }

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/fips140"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -504,6 +505,55 @@ func logConfiguration(logs *slog.Logger, cfg Config) {
 	logs.Info(fmt.Sprintf("Metrics.OperationResultFinishedOperationRetentionPeriod: %s", cfg.Metrics.OperationResultFinishedOperationRetentionPeriod))
 	logs.Info(fmt.Sprintf("Metrics.BindingsStatsPollingInterval: %s", cfg.Metrics.BindingsStatsPollingInterval))
 
+	logCACertBundleDigest(logs)
+}
+
+// systemCertFiles mirrors the search order of crypto/x509/root_linux.go.
+var systemCertFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",
+	"/etc/pki/tls/certs/ca-bundle.crt",
+	"/etc/ssl/ca-bundle.pem",
+	"/etc/pki/tls/cacert.pem",
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+	"/etc/ssl/cert.pem",
+}
+
+func logCACertBundleDigest(logs *slog.Logger) {
+	logCACertBundleDigestFromPaths(logs, systemCertFiles)
+}
+
+func logCACertBundleDigestFromPaths(logs *slog.Logger, paths []string) {
+	type pathStatus struct {
+		path   string
+		status string
+	}
+	var statuses []pathStatus
+
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				statuses = append(statuses, pathStatus{p, "missing"})
+			} else {
+				statuses = append(statuses, pathStatus{p, fmt.Sprintf("error:%s", err.Error())})
+			}
+			continue
+		}
+		if len(data) == 0 {
+			statuses = append(statuses, pathStatus{p, "empty"})
+			continue
+		}
+		sum := sha256.Sum256(data)
+		logs.Info("CA bundle digest", slog.String("path", p), slog.String("sha256", fmt.Sprintf("%x", sum)))
+		return
+	}
+
+	// No usable bundle found — enumerate all paths with their status.
+	args := []any{slog.String("msg_detail", "no usable system cert bundle found")}
+	for _, s := range statuses {
+		args = append(args, slog.String(s.path, s.status))
+	}
+	logs.Warn("CA bundle digest", args...)
 }
 
 func createAPI(router *httputil.Router, schemaService *broker.SchemaService, servicesConfig broker.ServicesConfig, cfg *Config, db storage.BrokerStorage,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `logCACertBundleDigestFromPaths` helper that iterates the cert file paths searched by Go's `crypto/x509` on Linux, finds the first non-empty file, and logs its path and SHA256 digest
- Log a warning with per-path status (missing/empty/error) if no usable CA bundle is found
- Call the helper at the end of `logConfiguration()` so it appears alongside other startup config logs

**Related issue(s)**