### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/Dockerfile.job
+++ b/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/Dockerfile.keb
+++ b/Dockerfile.keb
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/Dockerfile.keb-analytics
+++ b/Dockerfile.keb-analytics
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/Dockerfile.runtimereconciler
+++ b/Dockerfile.runtimereconciler
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/Dockerfile.schemamigrator
+++ b/Dockerfile.schemamigrator
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/Dockerfile.subaccountsync
+++ b/Dockerfile.subaccountsync
@@ -1,5 +1,5 @@
 # Build image
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS build
 
 WORKDIR /go/src/github.com/kyma-project/kyma-environment-broker
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/testing/e2e/provisioning/Dockerfile
+++ b/testing/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/kyma-environment-broker/tests/e2e/provisioning
 

--- a/testing/e2e/provisioning/go.mod
+++ b/testing/e2e/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/provisioning
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/testing/e2e/skr/provisioning-service-test/go.mod
+++ b/testing/e2e/skr/provisioning-service-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma-environment-broker/testing/e2e/skr/provisioning-service-test
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump Go from `1.26.4` to `1.26.5` in `go.mod`
- Update base image from `golang:1.26.4-alpine3.22` to `golang:1.26.5-alpine3.24` in all Dockerfiles