### PR TITLE
Fix keb-analytics Correctness and Improve Performance

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -292,7 +292,7 @@ func newBrokerSuiteTest(t *testing.T, o *suiteOptions) *BrokerSuiteTest {
 				TotalInstances: len(provParams),
 				TotalUpdates:   len(updateParams),
 				Provisioning:   analytics.AggregateProvisioning(provParams),
-				Updates:        analytics.AggregateUpdates(updateParams),
+				Updates:        analytics.AggregateUpdates(provParams, updateParams),
 				Combined:       analytics.AggregateCombined(provParams, updateParams),
 				Distributions:  analytics.BuildDistributions(provParams),
 				Plans:          plans,

--- a/cmd/broker/update_test.go
+++ b/cmd/broker/update_test.go
@@ -226,7 +226,7 @@ func TestUpdateWithACL(t *testing.T) {
 	assert.Equal(t, 1, stats.TotalInstances)
 	assert.Equal(t, 1, stats.Provisioning.CountFor("region"))
 	assert.Equal(t, 1, stats.Provisioning.CountFor("accessControlList"))
-	assert.Equal(t, 2, stats.Updates.CountFor("accessControlList"))
+	assert.Equal(t, 1, stats.Updates.CountFor("accessControlList"))
 	assert.Equal(t, 1, stats.Updates.CountFor("oidc"))
 }
 

--- a/cmd/keb-analytics/main.go
+++ b/cmd/keb-analytics/main.go
@@ -35,13 +35,73 @@ type Config struct {
 	RefreshInterval time.Duration `envconfig:"default=1h"`
 }
 
+// rangeCache holds pre-computed stats for a single time window.
+type rangeCache struct {
+	provParams   []analytics.ProvisioningParamsWithID
+	updateParams []analytics.UpdateParamsWithID
+	resp         analytics.StatsResponse // unfiltered stats for this window
+}
+
+// cache is the top-level in-memory store populated on each refresh.
 type cache struct {
-	resp          analytics.StatsResponse
-	provParams    []analytics.ProvisioningParamsWithID
-	updateParams  []analytics.UpdateParamsWithID
-	opEvents      []analytics.OpEvent
-	plans         []string
-	regionsByPlan map[string][]string
+	opEvents      []analytics.OpEvent   // full history, shared across all windows
+	byRange       map[string]rangeCache // keys: "all", "7d", "30d", "90d"
+	plans         []string              // from the "all" window
+	regionsByPlan map[string][]string   // from the "all" window
+	cachedAt      time.Time
+	nextRefreshAt time.Time
+}
+
+// buildRangeCache computes provParams, updateParams and the unfiltered StatsResponse
+// for the given time window from the shared opEvents slice.
+// trendParams and opEvents are always from the full history so trends are continuous.
+func buildRangeCache(opEvents []analytics.OpEvent, tr analytics.TimeRange, planIDToName map[string]string, trendParams []string) rangeCache {
+	provParams := analytics.OpEventsToProvParamsInRange(opEvents, tr)
+	updateParams := analytics.OpEventsToUpdateParamsInRange(opEvents, tr)
+	plans, regionsByPlan := analytics.BuildPlanRegionIndex(provParams, planIDToName)
+	combined := analytics.AggregateCombined(provParams, updateParams)
+	resp := analytics.StatsResponse{
+		TotalInstances: len(provParams),
+		TotalUpdates:   len(updateParams),
+		Provisioning:   analytics.AggregateProvisioning(provParams),
+		Updates:        analytics.AggregateUpdates(provParams, updateParams),
+		Combined:       combined,
+		Distributions:  analytics.BuildDistributions(provParams),
+		Trends:         analytics.BuildTrends(opEvents, trendParams),
+		Plans:          plans,
+		RegionsByPlan:  regionsByPlan,
+	}
+	return rangeCache{provParams: provParams, updateParams: updateParams, resp: resp}
+}
+
+// matchRangeKey returns the cache key ("7d", "30d", "90d", "all") if the TimeRange
+// matches one of the pre-computed windows (within 1-day tolerance for client clock skew).
+// Returns "" if no match — caller must slice from opEvents in-memory.
+func matchRangeKey(tr analytics.TimeRange) string {
+	if tr.From.IsZero() && tr.To.IsZero() {
+		return "all"
+	}
+	if !tr.To.IsZero() {
+		return "" // bounded "to" not a standard window
+	}
+	age := time.Since(tr.From)
+	const tolerance = 25 * time.Hour
+	switch {
+	case abs(age-7*24*time.Hour) < tolerance:
+		return "7d"
+	case abs(age-30*24*time.Hour) < tolerance:
+		return "30d"
+	case abs(age-90*24*time.Hour) < tolerance:
+		return "90d"
+	}
+	return ""
+}
+
+func abs(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
 }
 
 func main() {
@@ -86,58 +146,85 @@ func main() {
 	}
 
 	var (
-		mu sync.RWMutex
-		c  cache
+		mu         sync.RWMutex
+		c          cache
+		refreshing bool
 	)
 
-	refresh := func() {
-		// Single query: fetch all op events (provision + update) for active instances.
-		// provParams and updateParams are derived in-memory, eliminating two extra round-trips.
+	var refresh func()
+
+	// runRefresh executes refresh() under a refreshing flag, safe for concurrent callers.
+	// A second call while one is already in progress is a no-op.
+	var refreshMu sync.Mutex
+	runRefresh := func() {
+		if !refreshMu.TryLock() {
+			return // already in progress
+		}
+		defer refreshMu.Unlock()
+
+		mu.Lock()
+		refreshing = true
+		mu.Unlock()
+
+		refresh()
+
+		mu.Lock()
+		refreshing = false
+		mu.Unlock()
+	}
+
+	refresh = func() {
 		opEvents, err := reader.FetchOpEventsInRange(analytics.TimeRange{})
 		if err != nil {
 			slog.Error("failed to fetch op events", "error", err)
 			return
 		}
-		provParams := analytics.OpEventsToProvParamsInRange(opEvents, analytics.TimeRange{})
-		updateParams := analytics.OpEventsToUpdateParamsInRange(opEvents, analytics.TimeRange{})
 
-		plans, regionsByPlan := analytics.BuildPlanRegionIndex(provParams, planIDToName)
-		provisioning := analytics.AggregateProvisioning(provParams)
-		updates := analytics.AggregateUpdates(updateParams)
-		combined := analytics.AggregateCombined(provParams, updateParams)
-		trendParams := analytics.TrendParamsFrom(combined)
-		trends := analytics.BuildTrends(opEvents, trendParams)
-		resp := analytics.StatsResponse{
-			TotalInstances: len(provParams),
-			TotalUpdates:   len(updateParams),
-			Provisioning:   provisioning,
-			Updates:        updates,
-			Combined:       combined,
-			Distributions:  analytics.BuildDistributions(provParams),
-			Trends:         trends,
-			Plans:          plans,
-			RegionsByPlan:  regionsByPlan,
+		now := time.Now().UTC()
+		windows := map[string]analytics.TimeRange{
+			"all": {},
+			"7d":  {From: now.AddDate(0, 0, -7)},
+			"30d": {From: now.AddDate(0, 0, -30)},
+			"90d": {From: now.AddDate(0, 0, -90)},
 		}
+
+		// Build the "all" window first to derive trendParams used by all windows.
+		allRC := buildRangeCache(opEvents, analytics.TimeRange{}, planIDToName, nil)
+		trendParams := analytics.TrendParamsFrom(allRC.resp.Combined)
+
+		// Rebuild "all" with trendParams so its Trends field is populated.
+		allRC = buildRangeCache(opEvents, analytics.TimeRange{}, planIDToName, trendParams)
+
+		byRange := make(map[string]rangeCache, len(windows))
+		byRange["all"] = allRC
+		for key, tr := range windows {
+			if key == "all" {
+				continue
+			}
+			byRange[key] = buildRangeCache(opEvents, tr, planIDToName, trendParams)
+		}
+
+		plans, regionsByPlan := allRC.resp.Plans, allRC.resp.RegionsByPlan
 
 		mu.Lock()
 		c = cache{
-			resp:          resp,
-			provParams:    provParams,
-			updateParams:  updateParams,
 			opEvents:      opEvents,
+			byRange:       byRange,
 			plans:         plans,
 			regionsByPlan: regionsByPlan,
+			cachedAt:      now,
+			nextRefreshAt: now.Add(cfg.RefreshInterval),
 		}
 		mu.Unlock()
-		slog.Info("stats cache refreshed", "total_instances", resp.TotalInstances)
+		slog.Info("stats cache refreshed", "total_instances", allRC.resp.TotalInstances)
 	}
 
-	refresh()
+	runRefresh()
 	go func() {
 		ticker := time.NewTicker(cfg.RefreshInterval)
 		defer ticker.Stop()
 		for range ticker.C {
-			refresh()
+			runRefresh()
 		}
 	}()
 
@@ -153,29 +240,40 @@ func main() {
 		planFilter := r.URL.Query().Get("plan")
 		regionFilter := r.URL.Query().Get("region")
 
-		var data analytics.StatsResponse
+		mu.RLock()
+		snapshot := c
+		mu.RUnlock()
 
-		if tr.From.IsZero() && tr.To.IsZero() {
-			// Use cached full dataset; filter in memory if needed.
-			mu.RLock()
-			snapshot := c
-			mu.RUnlock()
-
-			if planFilter == "" && regionFilter == "" {
-				data = snapshot.resp
-			} else {
-				data = buildFilteredStats(snapshot.provParams, snapshot.updateParams, snapshot.opEvents, planFilter, regionFilter, planIDToName, snapshot.plans, snapshot.regionsByPlan, analytics.TrendParamsFrom(snapshot.resp.Combined))
-			}
-		} else {
-			// Time-range query: slice the in-memory cache — no DB round-trip needed.
-			mu.RLock()
-			snapshot := c
-			mu.RUnlock()
-			provParams := analytics.OpEventsToProvParamsInRange(snapshot.opEvents, tr)
-			updateParams := analytics.OpEventsToUpdateParamsInRange(snapshot.opEvents, tr)
-			trendParams := analytics.TrendParamsFrom(snapshot.resp.Combined)
-			data = buildFilteredStats(provParams, updateParams, snapshot.opEvents, planFilter, regionFilter, planIDToName, snapshot.plans, snapshot.regionsByPlan, trendParams)
+		if snapshot.byRange == nil {
+			http.Error(w, "data not yet available, try again shortly", http.StatusServiceUnavailable)
+			return
 		}
+
+		// Resolve the rangeCache to use — pre-computed if the window matches, otherwise
+		// slice from the full opEvents in-memory (no DB query in either path).
+		var rc rangeCache
+		if key := matchRangeKey(tr); key != "" {
+			rc = snapshot.byRange[key]
+		} else {
+			// Custom date range: derive in-memory from cached opEvents.
+			allCombined := snapshot.byRange["all"].resp.Combined
+			trendParams := analytics.TrendParamsFrom(allCombined)
+			rc = buildRangeCache(snapshot.opEvents, tr, planIDToName, trendParams)
+		}
+
+		var data analytics.StatsResponse
+		if planFilter == "" && regionFilter == "" {
+			data = rc.resp
+			// Always use the full plan/region index for dropdowns.
+			data.Plans = snapshot.plans
+			data.RegionsByPlan = snapshot.regionsByPlan
+		} else {
+			allCombined := snapshot.byRange["all"].resp.Combined
+			trendParams := analytics.TrendParamsFrom(allCombined)
+			data = buildFilteredStats(rc.provParams, rc.updateParams, snapshot.opEvents, planFilter, regionFilter, planIDToName, snapshot.plans, snapshot.regionsByPlan, trendParams)
+		}
+		data.CachedAt = snapshot.cachedAt.Format(time.RFC3339)
+		data.NextRefreshAt = snapshot.nextRefreshAt.Format(time.RFC3339)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(data); err != nil {
@@ -188,8 +286,29 @@ func main() {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		refresh()
-		w.WriteHeader(http.StatusNoContent)
+		go runRefresh()
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		mu.RLock()
+		isRefreshing := refreshing
+		cachedAt := c.cachedAt
+		nextRefreshAt := c.nextRefreshAt
+		mu.RUnlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"refreshing":      isRefreshing,
+			"cached_at":       cachedAt.Format(time.RFC3339),
+			"next_refresh_at": nextRefreshAt.Format(time.RFC3339),
+		}); err != nil {
+			slog.Error("failed to encode status", "error", err)
+		}
 	})
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -233,7 +352,7 @@ func buildFilteredStats(
 		TotalInstances: len(filtered),
 		TotalUpdates:   len(updateParams),
 		Provisioning:   analytics.AggregateProvisioning(filtered),
-		Updates:        analytics.AggregateUpdates(updateParams),
+		Updates:        analytics.AggregateUpdates(filtered, updateParams),
 		Combined:       combined,
 		Distributions:  analytics.BuildDistributions(filtered),
 		Trends:         trends,

--- a/cmd/keb-analytics/main.go
+++ b/cmd/keb-analytics/main.go
@@ -54,7 +54,9 @@ type cache struct {
 
 // buildRangeCache computes provParams, updateParams and the unfiltered StatsResponse
 // for the given time window from the shared opEvents slice.
-// trendParams and opEvents are always from the full history so trends are continuous.
+// Trends are intentionally built from the full opEvents history regardless of the window:
+// this means the Trends field in the 7d/30d/90d responses is identical to the "all" response,
+// providing continuous historical context on the trend chart even when a narrow period is selected.
 func buildRangeCache(opEvents []analytics.OpEvent, tr analytics.TimeRange, planIDToName map[string]string, trendParams []string) rangeCache {
 	provParams := analytics.OpEventsToProvParamsInRange(opEvents, tr)
 	updateParams := analytics.OpEventsToUpdateParamsInRange(opEvents, tr)

--- a/cmd/keb-analytics/main_test.go
+++ b/cmd/keb-analytics/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -43,3 +44,35 @@ func TestBuildFilteredStats_TrendsUsesSuppliedParamsWhenProvEmpty(t *testing.T) 
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestMatchRangeKey_AllTime(t *testing.T) {
+	assert.Equal(t, "all", matchRangeKey(analytics.TimeRange{}))
+}
+
+func TestMatchRangeKey_SevenDays(t *testing.T) {
+	tr := analytics.TimeRange{From: time.Now().UTC().AddDate(0, 0, -7)}
+	assert.Equal(t, "7d", matchRangeKey(tr))
+}
+
+func TestMatchRangeKey_ThirtyDays(t *testing.T) {
+	tr := analytics.TimeRange{From: time.Now().UTC().AddDate(0, 0, -30)}
+	assert.Equal(t, "30d", matchRangeKey(tr))
+}
+
+func TestMatchRangeKey_NinetyDays(t *testing.T) {
+	tr := analytics.TimeRange{From: time.Now().UTC().AddDate(0, 0, -90)}
+	assert.Equal(t, "90d", matchRangeKey(tr))
+}
+
+func TestMatchRangeKey_CustomRange(t *testing.T) {
+	tr := analytics.TimeRange{From: time.Now().UTC().AddDate(0, 0, -45)}
+	assert.Equal(t, "", matchRangeKey(tr))
+}
+
+func TestMatchRangeKey_WithToDate(t *testing.T) {
+	tr := analytics.TimeRange{
+		From: time.Now().UTC().AddDate(0, 0, -7),
+		To:   time.Now().UTC(),
+	}
+	assert.Equal(t, "", matchRangeKey(tr))
+}

--- a/cmd/keb-analytics/static/index.html
+++ b/cmd/keb-analytics/static/index.html
@@ -59,6 +59,7 @@
     </select>
 
     <button id="refresh-btn">Refresh</button>
+    <span id="cache-status" style="margin-left:1rem;font-size:0.85rem;color:#666"></span>
   </div>
 
   <p id="total"></p>
@@ -491,6 +492,15 @@
       }
       currentData = data;
 
+      // Update cache status line.
+      if (data.cached_at) {
+        const cachedAt = new Date(data.cached_at);
+        const nextAt = new Date(data.next_refresh_at);
+        const fmt = d => d.toLocaleString(undefined, {dateStyle:'short', timeStyle:'medium'});
+        document.getElementById('cache-status').textContent =
+          'Cached: ' + fmt(cachedAt) + ' · Next refresh: ' + fmt(nextAt);
+      }
+
       // Always repopulate plan dropdown from fresh data.
       populatePlanDropdown(data.plans);
 
@@ -514,18 +524,43 @@
     document.getElementById('period').addEventListener('change', load);
     document.getElementById('plan').addEventListener('change', onPlanChange);
     document.getElementById('region').addEventListener('change', load);
-    document.getElementById('refresh-btn').addEventListener('click', async () => {
+
+    async function pollUntilReady() {
+      const statusEl = document.getElementById('cache-status');
       const btn = document.getElementById('refresh-btn');
       btn.disabled = true;
       btn.textContent = 'Refreshing…';
+      for (;;) {
+        let status;
+        try {
+          status = await (await fetch('/api/status')).json();
+        } catch(e) {
+          document.getElementById('error').textContent = 'Status check failed: ' + e;
+          break;
+        }
+        const fmt = d => new Date(d).toLocaleString(undefined, {dateStyle:'short', timeStyle:'medium'});
+        if (!status.refreshing) {
+          statusEl.textContent = status.cached_at
+            ? 'Cached: ' + fmt(status.cached_at) + ' · Next refresh: ' + fmt(status.next_refresh_at)
+            : '';
+          await load();
+          break;
+        }
+        statusEl.textContent = 'Fetching data…';
+        await new Promise(r => setTimeout(r, 1000));
+      }
+      btn.disabled = false;
+      btn.textContent = 'Refresh';
+    }
+
+    document.getElementById('refresh-btn').addEventListener('click', async () => {
       try {
         await fetch('/api/refresh', { method: 'POST' });
       } catch(e) {
         document.getElementById('error').textContent = 'Refresh failed: ' + e;
+        return;
       }
-      await load();
-      btn.disabled = false;
-      btn.textContent = 'Refresh';
+      await pollUntilReady();
     });
     load();
   </script>

--- a/cmd/keb-analytics/static/index.html
+++ b/cmd/keb-analytics/static/index.html
@@ -291,11 +291,11 @@
       setNoData('distribution', false);
 
       const includeNull = document.getElementById('distIncludeNull').checked;
-      const total = data.total_instances;
+      const setCount = Object.values(dist ? dist.values : {}).reduce((s, n) => s + n, 0);
+      const total = includeNull ? data.total_instances : setCount;
 
       let entries = Object.entries(dist ? dist.values : {})
         .sort((a, b) => b[1] - a[1]);
-      const setCount = entries.reduce((s, e) => s + e[1], 0);
 
       if (includeNull && total > setCount) {
         entries.push(['not provided/null', total - setCount]);
@@ -312,7 +312,8 @@
 
       const labels = entries.map(([v, n]) => {
         const pct = total > 0 ? ((n / total) * 100).toFixed(1) : 0;
-        return v + '  (' + n + ' times / ' + pct + '% all)';
+        const pctLabel = includeNull ? '% all' : '% of set';
+        return v + '  (' + n + ' / ' + pct + pctLabel + ')';
       });
       const vals = entries.map(([, n]) => n);
       const colors = entries.map(([v]) =>

--- a/cmd/keb-analytics/static/index.html
+++ b/cmd/keb-analytics/static/index.html
@@ -531,7 +531,12 @@
       const btn = document.getElementById('refresh-btn');
       btn.disabled = true;
       btn.textContent = 'Refreshing…';
+      const deadline = Date.now() + 5 * 60 * 1000; // 5-minute timeout
       for (;;) {
+        if (Date.now() > deadline) {
+          document.getElementById('error').textContent = 'Refresh timed out. Try again.';
+          break;
+        }
         let status;
         try {
           status = await (await fetch('/api/status')).json();

--- a/cmd/keb-analytics/static/index.html
+++ b/cmd/keb-analytics/static/index.html
@@ -348,9 +348,10 @@
 
     const MON = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
     function fmtDate(isoDate) {
-      // isoDate is YYYY-MM-DD; returns "Jan 03" style without year
+      // isoDate is YYYY-MM-DD; returns "Jan 03" or "Jan 03 2025" (year shown in January only)
       const d = new Date(isoDate + 'T00:00:00Z');
-      return MON[d.getUTCMonth()] + ' ' + String(d.getUTCDate()).padStart(2, '0');
+      const label = MON[d.getUTCMonth()] + ' ' + String(d.getUTCDate()).padStart(2, '0');
+      return d.getUTCMonth() === 0 ? label + ' ' + d.getUTCFullYear() : label;
     }
 
     function renderTrendTab(data) {
@@ -384,6 +385,15 @@
           }]
         },
         options: {
+          plugins: {
+            tooltip: {
+              callbacks: {
+                title: function(items) {
+                  return fmtDate(new Date(items[0].parsed.x).toISOString().slice(0, 10));
+                }
+              }
+            }
+          },
           scales: {
             x: {
               type: 'linear',

--- a/internal/analytics/aggregator.go
+++ b/internal/analytics/aggregator.go
@@ -262,6 +262,10 @@ func activeInstanceSet(provParams []ProvisioningParamsWithID) map[string]struct{
 // Only update ops from active instances (present in provParams) are counted.
 // SetCount = distinct active instances that had the parameter set in at least one update.
 // Total = number of active instances.
+// Note: a parameter is considered "set" only when walkFields records a non-nil/non-zero value
+// for it. An update op that explicitly clears a field (sets it to nil/zero) will not be counted
+// for that parameter — this conflates "was set to a non-zero value" with "was touched".
+// This is pre-existing behaviour and matches the semantics of the provisioning aggregator.
 func AggregateUpdates(provParams []ProvisioningParamsWithID, updateParams []UpdateParamsWithID) ParameterStats {
 	active := activeInstanceSet(provParams)
 	instancesWithParam := make(map[string]map[string]struct{})

--- a/internal/analytics/aggregator.go
+++ b/internal/analytics/aggregator.go
@@ -33,6 +33,7 @@ var provisioningFieldConfig = map[string]fieldBehavior{
 	"kubeconfig":                behaviorSkip,
 	"shootName":                 behaviorSkip,
 	"shootDomain":               behaviorSkip,
+	"provider":                  behaviorSkip,
 	"administrators":            behaviorCount,
 	"additionalWorkerNodePools": behaviorCount,
 	"modules":                   behaviorModules,
@@ -248,19 +249,59 @@ func AggregateProvisioning(params []ProvisioningParamsWithID) ParameterStats {
 	return toParameterStats(counts, len(plain))
 }
 
-// AggregateUpdates computes parameter usage stats from a slice of UpdateParamsWithID.
-func AggregateUpdates(params []UpdateParamsWithID) ParameterStats {
-	counts := make(map[string]map[string]int)
-	for _, p := range params {
-		walkFields(p.Params, updatingFieldConfig, counts)
+// activeInstanceSet builds a set of instance IDs from provParams for fast membership checks.
+func activeInstanceSet(provParams []ProvisioningParamsWithID) map[string]struct{} {
+	active := make(map[string]struct{}, len(provParams))
+	for _, p := range provParams {
+		active[p.InstanceID] = struct{}{}
 	}
-	return toParameterStats(counts, len(params))
+	return active
+}
+
+// AggregateUpdates computes per-instance parameter usage stats for update operations.
+// Only update ops from active instances (present in provParams) are counted.
+// SetCount = distinct active instances that had the parameter set in at least one update.
+// Total = number of active instances.
+func AggregateUpdates(provParams []ProvisioningParamsWithID, updateParams []UpdateParamsWithID) ParameterStats {
+	active := activeInstanceSet(provParams)
+	instancesWithParam := make(map[string]map[string]struct{})
+	for _, p := range updateParams {
+		if _, ok := active[p.InstanceID]; !ok {
+			continue
+		}
+		counts := make(map[string]map[string]int)
+		walkFields(p.Params, updatingFieldConfig, counts)
+		for param := range counts {
+			if _, ok := instancesWithParam[param]; !ok {
+				instancesWithParam[param] = make(map[string]struct{})
+			}
+			instancesWithParam[param][p.InstanceID] = struct{}{}
+		}
+	}
+	total := len(provParams)
+	var result []ParameterStat
+	for param, instances := range instancesWithParam {
+		result = append(result, ParameterStat{
+			Parameter: param,
+			SetCount:  len(instances),
+			Total:     total,
+		})
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].SetCount != result[j].SetCount {
+			return result[i].SetCount > result[j].SetCount
+		}
+		return result[i].Parameter < result[j].Parameter
+	})
+	return ParameterStats{Parameters: result}
 }
 
 // AggregateCombined computes per-instance parameter usage: an instance is counted as
-// "using" a parameter if it was set in its provisioning operation OR in any update operation.
-// total = number of unique instance IDs across both provParams and updateParams.
+// "using" a parameter if it was set in its provisioning operation OR in at least one
+// update operation. Only active instances (present in provParams) are considered.
+// total = number of unique active instances (from provParams).
 func AggregateCombined(provParams []ProvisioningParamsWithID, updateParams []UpdateParamsWithID) ParameterStats {
+	active := activeInstanceSet(provParams)
 	// instancesWithParam[param] = set of instance IDs that have the param set
 	instancesWithParam := make(map[string]map[string]struct{})
 	allInstances := make(map[string]struct{})
@@ -282,7 +323,9 @@ func AggregateCombined(provParams []ProvisioningParamsWithID, updateParams []Upd
 	}
 
 	for _, p := range updateParams {
-		allInstances[p.InstanceID] = struct{}{}
+		if _, ok := active[p.InstanceID]; !ok {
+			continue
+		}
 		counts := make(map[string]map[string]int)
 		walkFields(p.Params, updatingFieldConfig, counts)
 		for param := range counts {

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -27,6 +27,17 @@ func TestWalkFields_SkipsConfiguredFields(t *testing.T) {
 	assert.False(t, found, "zones should be skipped")
 }
 
+func TestWalkFields_SkipsProvider(t *testing.T) {
+	aws := pkg.CloudProvider("AWS")
+	dto := pkg.ProvisioningParametersDTO{
+		Provider: &aws,
+	}
+	counts := make(map[string]map[string]int)
+	walkFields(dto, provisioningFieldConfig, counts)
+	_, found := counts["provider"]
+	assert.False(t, found, "provider should be skipped")
+}
+
 func TestWalkFields_CountsArrayLength(t *testing.T) {
 	dto := pkg.ProvisioningParametersDTO{
 		RuntimeAdministrators: []string{"admin1", "admin2"},
@@ -197,22 +208,43 @@ func TestAggregateProvisioning_RanksParameters(t *testing.T) {
 	}
 }
 
-func TestAggregateUpdates_CountsSetFields(t *testing.T) {
-	params := []UpdateParamsWithID{
+func TestAggregateUpdates_CountsDistinctActiveInstances(t *testing.T) {
+	provParams := []ProvisioningParamsWithID{
+		{InstanceID: "i1", Params: internal.ProvisioningParameters{}},
+		{InstanceID: "i2", Params: internal.ProvisioningParameters{}},
+		{InstanceID: "i3", Params: internal.ProvisioningParameters{}},
+	}
+	// i1 updated twice with machineType, i2 once, i3 without — i1 must not be double-counted
+	updateParams := []UpdateParamsWithID{
 		{InstanceID: "i1", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m6i.xlarge")}},
-		{InstanceID: "i2", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m5.xlarge")}},
+		{InstanceID: "i1", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m5.xlarge")}},
+		{InstanceID: "i2", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m6i.xlarge")}},
 		{InstanceID: "i3", Params: internal.UpdatingParametersDTO{}},
 	}
-	stats := AggregateUpdates(params)
-	// every parameter entry must carry the full total
+	stats := AggregateUpdates(provParams, updateParams)
 	for _, p := range stats.Parameters {
-		assert.Equal(t, 3, p.Total, "parameter %s: expected Total=3", p.Parameter)
+		assert.Equal(t, 3, p.Total, "parameter %s: Total must equal active instance count", p.Parameter)
 	}
-	// machineType was set on 2 of 3 update ops → SetCount=2
+	// machineType set on i1 and i2 (distinct active instances) → SetCount=2
 	assert.Equal(t, 2, stats.CountFor("machineType"))
-	// highest-SetCount parameter must be first
 	if len(stats.Parameters) > 1 {
 		assert.GreaterOrEqual(t, stats.Parameters[0].SetCount, stats.Parameters[1].SetCount)
+	}
+}
+
+func TestAggregateUpdates_IgnoresInactiveInstances(t *testing.T) {
+	provParams := []ProvisioningParamsWithID{
+		{InstanceID: "i1", Params: internal.ProvisioningParameters{}},
+	}
+	// i2 is not in provParams (deprovisioned) — its update must not be counted
+	updateParams := []UpdateParamsWithID{
+		{InstanceID: "i1", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m6i.xlarge")}},
+		{InstanceID: "i2", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m6i.xlarge")}},
+	}
+	stats := AggregateUpdates(provParams, updateParams)
+	assert.Equal(t, 1, stats.CountFor("machineType"))
+	for _, p := range stats.Parameters {
+		assert.Equal(t, 1, p.Total)
 	}
 }
 

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -325,13 +325,13 @@ func TestAggregateCombined_TotalIsDistinctInstanceCount(t *testing.T) {
 		{InstanceID: "i2", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{}}},
 		{InstanceID: "i3", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{}}},
 	}
-	// i4 appears only in updates — must be counted in Total
+	// i4 appears only in updates — it is deprovisioned and must NOT be counted in Total.
 	updateParams := []UpdateParamsWithID{
 		{InstanceID: "i4", Params: internal.UpdatingParametersDTO{MachineType: strPtr("m5.xlarge")}},
 	}
 	stats := AggregateCombined(provParams, updateParams)
 	for _, p := range stats.Parameters {
-		assert.Equal(t, 4, p.Total, "Total must equal distinct instance IDs across prov + update")
+		assert.Equal(t, 3, p.Total, "Total must equal active instance count (provParams only)")
 	}
 }
 

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -160,7 +160,8 @@ func OpEventsToUpdateParamsInRange(events []OpEvent, tr TimeRange) []UpdateParam
 }
 
 // inRange returns true if the YYYY-MM-DD date string d falls within [tr.From, tr.To).
-// An empty tr (both zero) always returns true.
+// An empty tr (both zero) always returns true. Single-bounded ranges are supported:
+// a zero From means unbounded start; a zero To means unbounded end.
 func inRange(d string, tr TimeRange) bool {
 	if tr.From.IsZero() && tr.To.IsZero() {
 		return true

--- a/internal/analytics/model.go
+++ b/internal/analytics/model.go
@@ -52,6 +52,6 @@ type StatsResponse struct {
 	Trends         []TrendStat         `json:"trends"`
 	Plans          []string            `json:"plans"`
 	RegionsByPlan  map[string][]string `json:"regions_by_plan"`
-	CachedAt       string              `json:"cached_at"`        // RFC3339 timestamp of last cache refresh
-	NextRefreshAt  string              `json:"next_refresh_at"`  // RFC3339 timestamp of next scheduled refresh
+	CachedAt       string              `json:"cached_at"`       // RFC3339 timestamp of last cache refresh
+	NextRefreshAt  string              `json:"next_refresh_at"` // RFC3339 timestamp of next scheduled refresh
 }

--- a/internal/analytics/model.go
+++ b/internal/analytics/model.go
@@ -52,4 +52,6 @@ type StatsResponse struct {
 	Trends         []TrendStat         `json:"trends"`
 	Plans          []string            `json:"plans"`
 	RegionsByPlan  map[string][]string `json:"regions_by_plan"`
+	CachedAt       string              `json:"cached_at"`        // RFC3339 timestamp of last cache refresh
+	NextRefreshAt  string              `json:"next_refresh_at"`  // RFC3339 timestamp of next scheduled refresh
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Skip \`provider\` parameter in analytics aggregation
- Fix \`AggregateUpdates\` to count distinct active instances instead of raw operation count; ignore update ops from deprovisioned instances
- Fix \`AggregateCombined\` to ignore update ops from inactive instances, preventing \`SetCount > Total\`
- Pre-compute stats for all time windows (all/7d/30d/90d) at refresh time; eliminate per-request DB queries and in-memory re-aggregation on plan/region filter changes
- Fix trend chart X-axis to show year on January ticks for multi-year data
- Fix trend chart tooltip showing raw millisecond timestamp instead of formatted date
- Fix distribution chart percentage calculation: when "Include not provided/null" is unchecked, percentages are calculated over the set count only (not total instances)
- Add cache timestamps and in-progress indicator to the UI
- Add \`GET /api/status\` endpoint; make \`POST /api/refresh\` non-blocking (202 Accepted); poll until refresh completes with 5-minute timeout
- Guard against nil \`byRange\` map before first refresh completes (503 response)
- Eliminate redundant pre-computation of "all" window parameters in \`refresh()\`
- Add HTTP method guard (GET only) on \`/api/status\`

**Related issue(s)**
See also #3043