### PR TITLE
Fetch Azure Machine Image Version Suffixes Independently of Zone Discovery

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -1143,6 +1143,18 @@ func fixSecrets() []runtime.Object {
 				"subscriptionID": []byte("test-subscription-id"),
 			},
 		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sb-azure-eu-access",
+				Namespace: "kyma",
+			},
+			Data: map[string][]byte{
+				"clientID":       []byte("test-client-id"),
+				"clientSecret":   []byte("test-client-secret"),
+				"tenantID":       []byte("test-tenant-id"),
+				"subscriptionID": []byte("test-subscription-id"),
+			},
+		},
 	}
 }
 

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -393,7 +393,7 @@ func main() {
 			log.Warn(fmt.Sprintf("Azure zone cache unavailable, falling back to per-call mode: %s", fetchErr))
 		}
 	}
-	factory := hyperscalers.NewFactoryWithAzureCache(ctx, providerSpec, azureSecretFetcher, cfg.InfrastructureManager.UseMachineImageVersionSuffix)
+	factory := hyperscalers.NewFactoryWithAzureCache(ctx, providerSpec, azureSecretFetcher)
 
 	log.Info(fmt.Sprintf("Number of globalAccountIds for max pods: %d", len(cfg.MaxPodsWhitelistedGlobalAccountIds)))
 

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -52,7 +52,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 			step: provisioning.NewResolveCredentialsBindingStep(db, gardenerClient, rulesService, internal.RetryTuple{Timeout: resolveSubscriptionSecretTimeout, Interval: resolveSubscriptionSecretRetryInterval}, &cfg.HapMultiHyperscalerAccount),
 		},
 		{
-			step: steps.NewDiscoverAvailableZonesCBStep(db, providerSpec, gardenerClient, factory),
+			step: steps.NewDiscoverAvailableZonesCBStep(db, providerSpec, gardenerClient, factory, cfg.InfrastructureManager.UseMachineImageVersionSuffix),
 		},
 		{
 			step: provisioning.NewGenerateRuntimeIDStep(db.Operations(), db.Instances()),

--- a/cmd/broker/update.go
+++ b/cmd/broker/update.go
@@ -43,7 +43,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *process.StagedManage
 		},
 		{
 			stage: "runtime_resource",
-			step:  steps.NewDiscoverAvailableZonesCBStep(db, providerSpec, gardenerClient, factory),
+			step:  steps.NewDiscoverAvailableZonesCBStep(db, providerSpec, gardenerClient, factory, cfg.InfrastructureManager.UseMachineImageVersionSuffix),
 		},
 		{
 			stage: "runtime_resource",

--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -337,13 +337,17 @@ func createAzureSecret(name, namespace string) *unstructured.Unstructured {
 }
 
 func NewAzureProviderSpecWithZonesDiscovery(t *testing.T) *configuration.ProviderSpec {
-	spec := `
+	return NewAzureProviderSpec(t, true)
+}
+
+func NewAzureProviderSpec(t *testing.T, zonesDiscovery bool) *configuration.ProviderSpec {
+	spec := fmt.Sprintf(`
 azure:
-  zonesDiscovery: true
+  zonesDiscovery: %t
   regions:
     westeurope:
       displayName: "West Europe"
-`
+`, zonesDiscovery)
 	providerSpec, err := configuration.NewProviderSpec(strings.NewReader(spec))
 	require.NoError(t, err)
 	return providerSpec

--- a/internal/hyperscalers/azure/client.go
+++ b/internal/hyperscalers/azure/client.go
@@ -33,16 +33,15 @@ type ResourceSKUsAPI interface {
 }
 
 type AzureClient struct {
-	skusClient                   ResourceSKUsAPI
-	region                       string
-	providerSpec                 *configuration.ProviderSpec
-	zoneCache                    map[string][]string
-	hyperVGenCache               map[string]string
-	cacheLoaded                  bool
-	useMachineImageVersionSuffix bool
+	skusClient     ResourceSKUsAPI
+	region         string
+	providerSpec   *configuration.ProviderSpec
+	zoneCache      map[string][]string
+	hyperVGenCache map[string]string
+	cacheLoaded    bool
 }
 
-func NewClientFromSecret(ctx context.Context, providerSpec *configuration.ProviderSpec, secret *unstructured.Unstructured, region string, useMachineImageVersionSuffix bool) (*AzureClient, error) {
+func NewClientFromSecret(ctx context.Context, providerSpec *configuration.ProviderSpec, secret *unstructured.Unstructured, region string) (*AzureClient, error) {
 	creds, err := ExtractCredentials(secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract Azure credentials: %w", err)
@@ -59,10 +58,9 @@ func NewClientFromSecret(ctx context.Context, providerSpec *configuration.Provid
 	}
 
 	return &AzureClient{
-		skusClient:                   skusClient,
-		region:                       region,
-		providerSpec:                 providerSpec,
-		useMachineImageVersionSuffix: useMachineImageVersionSuffix,
+		skusClient:   skusClient,
+		region:       region,
+		providerSpec: providerSpec,
 	}, nil
 }
 
@@ -85,9 +83,6 @@ func (c *AzureClient) AvailableZonesCount(ctx context.Context, machineType strin
 }
 
 func (c *AzureClient) HyperVGeneration(ctx context.Context, machineType string) (string, error) {
-	if !c.useMachineImageVersionSuffix {
-		return "", nil
-	}
 	machineType = c.providerSpec.ResolveMachineType(pkg.Azure, machineType)
 
 	if err := c.ensureCacheLoaded(ctx); err != nil {

--- a/internal/hyperscalers/azure/client_test.go
+++ b/internal/hyperscalers/azure/client_test.go
@@ -281,10 +281,9 @@ func buildClient(skus []*armcompute.ResourceSKU, apiErr error) *AzureClient {
 	}
 	spec := buildProviderSpec(machineNames)
 	return &AzureClient{
-		skusClient:                   &mockSKUsAPI{skus: skus, err: apiErr},
-		region:                       "westeurope",
-		providerSpec:                 spec,
-		useMachineImageVersionSuffix: true,
+		skusClient:   &mockSKUsAPI{skus: skus, err: apiErr},
+		region:       "westeurope",
+		providerSpec: spec,
 	}
 }
 

--- a/internal/hyperscalers/factory.go
+++ b/internal/hyperscalers/factory.go
@@ -12,9 +12,8 @@ import (
 )
 
 type hyperscalerFactory struct {
-	providerSpec                 *configuration.ProviderSpec
-	azureCache                   *azure.AzureCache
-	useMachineImageVersionSuffix bool
+	providerSpec *configuration.ProviderSpec
+	azureCache   *azure.AzureCache
 }
 
 // NewFactory creates a new Factory without a global Azure zone cache.
@@ -27,15 +26,14 @@ func NewFactory(providerSpec *configuration.ProviderSpec) Factory {
 // The cache fills lazily in the background — KEB startup is not blocked.
 // secretFetcher is called on every cache refresh to handle credential rotation.
 // If secretFetcher is nil or Azure zones discovery is disabled, behaves like NewFactory.
-func NewFactoryWithAzureCache(ctx context.Context, providerSpec *configuration.ProviderSpec, secretFetcher azure.SecretFetcher, useMachineImageVersionSuffix bool) Factory {
+func NewFactoryWithAzureCache(ctx context.Context, providerSpec *configuration.ProviderSpec, secretFetcher azure.SecretFetcher) Factory {
 	var azureCache *azure.AzureCache
 	if secretFetcher != nil && providerSpec.ZonesDiscovery(pkg.Azure) {
 		azureCache = azure.NewAzureCache(ctx, providerSpec, secretFetcher)
 	}
 	return &hyperscalerFactory{
-		providerSpec:                 providerSpec,
-		azureCache:                   azureCache,
-		useMachineImageVersionSuffix: useMachineImageVersionSuffix,
+		providerSpec: providerSpec,
+		azureCache:   azureCache,
 	}
 }
 
@@ -51,7 +49,7 @@ func (f *hyperscalerFactory) NewFromSecret(ctx context.Context, provider pkg.Clo
 		if f.azureCache != nil && f.azureCache.Ready(region) {
 			return azure.NewCachedClient(f.azureCache, region, f.providerSpec), nil
 		}
-		return azure.NewClientFromSecret(ctx, f.providerSpec, secret, region, f.useMachineImageVersionSuffix)
+		return azure.NewClientFromSecret(ctx, f.providerSpec, secret, region)
 	default:
 		return nil, fmt.Errorf("zone discovery not supported for provider %s", provider)
 	}
@@ -65,7 +63,7 @@ func (f *hyperscalerFactory) NewPerCallFromSecret(ctx context.Context, provider 
 	case pkg.AWS:
 		return aws.NewClientFromSecret(ctx, f.providerSpec, secret, region)
 	case pkg.Azure:
-		return azure.NewClientFromSecret(ctx, f.providerSpec, secret, region, f.useMachineImageVersionSuffix)
+		return azure.NewClientFromSecret(ctx, f.providerSpec, secret, region)
 	default:
 		return nil, fmt.Errorf("zone discovery not supported for provider %s", provider)
 	}

--- a/internal/hyperscalers/factory_test.go
+++ b/internal/hyperscalers/factory_test.go
@@ -32,7 +32,7 @@ func TestNewFactory_NoAzureCache(t *testing.T) {
 
 func TestNewFactoryWithAzureCache_NilFetcherNoCache(t *testing.T) {
 	spec := newFactoryTestSpec(t)
-	f := NewFactoryWithAzureCache(context.Background(), spec, nil, false)
+	f := NewFactoryWithAzureCache(context.Background(), spec, nil)
 	factory := f.(*hyperscalerFactory)
 	assert.Nil(t, factory.azureCache, "azureCache must be nil when fetcher is nil")
 }
@@ -43,7 +43,7 @@ func TestNewFactoryWithAzureCache_CacheCreatedWhenFetcherProvided(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	f := NewFactoryWithAzureCache(ctx, spec, fetcher, false)
+	f := NewFactoryWithAzureCache(ctx, spec, fetcher)
 	factory := f.(*hyperscalerFactory)
 	assert.NotNil(t, factory.azureCache)
 }
@@ -76,7 +76,7 @@ func TestNewPerCallFromSecret_AzureNeverUsesCachedClient(t *testing.T) {
 
 	f := NewFactoryWithAzureCache(ctx, spec, func() (azure.AzureCredentials, error) {
 		return newFactoryTestCredentials(), nil
-	}, false)
+	})
 
 	client, err := f.NewPerCallFromSecret(context.Background(), pkg.Azure, newFactoryTestSecret(), "westeurope")
 	require.NoError(t, err)

--- a/internal/process/steps/discover_available_zones_cb.go
+++ b/internal/process/steps/discover_available_zones_cb.go
@@ -43,11 +43,13 @@ func (s *DiscoverAvailableZonesCBStep) Name() string {
 
 func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *slog.Logger) (internal.Operation, time.Duration, error) {
 	provider := runtime.CloudProviderFromString(operation.ProviderValues.ProviderType)
-	if !s.providerSpec.ZonesDiscovery(provider) {
+	zonesDiscoveryEnabled := s.providerSpec.ZonesDiscovery(provider)
+
+	if !zonesDiscoveryEnabled && provider != runtime.Azure {
 		log.Info(fmt.Sprintf("Zones discovery disabled for provider %s, skipping", provider))
 		return operation, 0, nil
 	}
-	if len(operation.DiscoveredZones) > 0 {
+	if zonesDiscoveryEnabled && len(operation.DiscoveredZones) > 0 {
 		log.Info("Available zones already discovered, skipping")
 		return operation, 0, nil
 	}
@@ -87,31 +89,34 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 		return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to create %s client", provider), err, 10*time.Second, time.Minute, log)
 	}
 
-	discoveredZones := make(map[string][]string)
+	machineTypes := make(map[string]struct{})
 	switch operation.Type {
 	case internal.OperationTypeProvision:
-		discoveredZones[DefaultIfParamNotSet(operation.ProviderValues.DefaultMachineType, operation.ProvisioningParameters.Parameters.MachineType)] = []string{}
+		machineTypes[DefaultIfParamNotSet(operation.ProviderValues.DefaultMachineType, operation.ProvisioningParameters.Parameters.MachineType)] = struct{}{}
 		for _, pool := range operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools {
-			discoveredZones[pool.MachineType] = []string{}
+			machineTypes[pool.MachineType] = struct{}{}
 		}
 	case internal.OperationTypeUpdate:
 		if operation.UpdatingParameters.MachineType != nil {
-			discoveredZones[*operation.UpdatingParameters.MachineType] = []string{}
+			machineTypes[*operation.UpdatingParameters.MachineType] = struct{}{}
 		}
 		for _, pool := range operation.UpdatingParameters.AdditionalWorkerNodePools {
-			discoveredZones[pool.MachineType] = []string{}
+			machineTypes[pool.MachineType] = struct{}{}
 		}
 	}
 
+	discoveredZones := make(map[string][]string)
 	machineImageVersionSuffixes := make(map[string]string)
-	for machineType := range discoveredZones {
-		zones, err := client.AvailableZones(context.Background(), machineType)
-		if err != nil {
-			return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to get available zones for machine type %s", machineType), err, 10*time.Second, time.Minute, log)
+	for machineType := range machineTypes {
+		if zonesDiscoveryEnabled {
+			zones, err := client.AvailableZones(context.Background(), machineType)
+			if err != nil {
+				return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to get available zones for machine type %s", machineType), err, 10*time.Second, time.Minute, log)
+			}
+			rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
+			log.Info(fmt.Sprintf("Available zones for machine type %s in region %s: %v", machineType, operation.ProviderValues.Region, zones))
+			discoveredZones[machineType] = zones
 		}
-		rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
-		log.Info(fmt.Sprintf("Available zones for machine type %s in region %s: %v", machineType, operation.ProviderValues.Region, zones))
-		discoveredZones[machineType] = zones
 
 		if provider == runtime.Azure {
 			suffix, err := client.HyperVGeneration(context.Background(), machineType)

--- a/internal/process/steps/discover_available_zones_cb.go
+++ b/internal/process/steps/discover_available_zones_cb.go
@@ -49,8 +49,10 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 		log.Info(fmt.Sprintf("Zones discovery disabled for provider %s, skipping", provider))
 		return operation, 0, nil
 	}
-	if zonesDiscoveryEnabled && len(operation.DiscoveredZones) > 0 {
-		log.Info("Available zones already discovered, skipping")
+	zonesAlreadyDone := !zonesDiscoveryEnabled || len(operation.DiscoveredZones) > 0
+	suffixesAlreadyDone := provider != runtime.Azure || len(operation.MachineImageVersionSuffixes) > 0
+	if zonesAlreadyDone && suffixesAlreadyDone {
+		log.Info("Zones and machine image version suffixes already discovered, skipping")
 		return operation, 0, nil
 	}
 

--- a/internal/process/steps/discover_available_zones_cb.go
+++ b/internal/process/steps/discover_available_zones_cb.go
@@ -49,7 +49,7 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 
 	azureSuffixNeeded := provider == runtime.Azure && s.useMachineImageVersionSuffix
 	if !zonesDiscoveryEnabled && !azureSuffixNeeded {
-		log.Info(fmt.Sprintf("Zones discovery disabled for provider %s, skipping", provider))
+		log.Info(fmt.Sprintf("Zones discovery disabled and machine image version suffix not needed for provider %s, skipping", provider))
 		return operation, 0, nil
 	}
 	zonesAlreadyDone := !zonesDiscoveryEnabled || len(operation.DiscoveredZones) > 0
@@ -118,7 +118,7 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 			if err != nil {
 				return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to get available zones for machine type %s", machineType), err, 10*time.Second, time.Minute, log)
 			}
-			rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
+			shuffleZones(zones)
 			log.Info(fmt.Sprintf("Available zones for machine type %s in region %s: %v", machineType, operation.ProviderValues.Region, zones))
 			discoveredZones[machineType] = zones
 		}
@@ -143,4 +143,10 @@ func DefaultIfParamNotSet[T interface{}](d T, param *T) T {
 		return d
 	}
 	return *param
+}
+
+// shuffleZones randomizes zone order so that different instances spread across
+// availability zones instead of all landing in the first zone returned by the API.
+func shuffleZones(zones []string) {
+	rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
 }

--- a/internal/process/steps/discover_available_zones_cb.go
+++ b/internal/process/steps/discover_available_zones_cb.go
@@ -19,19 +19,21 @@ import (
 )
 
 type DiscoverAvailableZonesCBStep struct {
-	operationManager *process.OperationManager
-	instanceStorage  storage.Instances
-	providerSpec     *configuration.ProviderSpec
-	gardenerClient   *gardener.Client
-	factory          hyperscalers.Factory
+	operationManager             *process.OperationManager
+	instanceStorage              storage.Instances
+	providerSpec                 *configuration.ProviderSpec
+	gardenerClient               *gardener.Client
+	factory                      hyperscalers.Factory
+	useMachineImageVersionSuffix bool
 }
 
-func NewDiscoverAvailableZonesCBStep(db storage.BrokerStorage, providerSpec *configuration.ProviderSpec, gardenerClient *gardener.Client, factory hyperscalers.Factory) *DiscoverAvailableZonesCBStep {
+func NewDiscoverAvailableZonesCBStep(db storage.BrokerStorage, providerSpec *configuration.ProviderSpec, gardenerClient *gardener.Client, factory hyperscalers.Factory, useMachineImageVersionSuffix bool) *DiscoverAvailableZonesCBStep {
 	step := &DiscoverAvailableZonesCBStep{
-		instanceStorage: db.Instances(),
-		providerSpec:    providerSpec,
-		gardenerClient:  gardenerClient,
-		factory:         factory,
+		instanceStorage:              db.Instances(),
+		providerSpec:                 providerSpec,
+		gardenerClient:               gardenerClient,
+		factory:                      factory,
+		useMachineImageVersionSuffix: useMachineImageVersionSuffix,
 	}
 	step.operationManager = process.NewOperationManager(db.Operations(), step.Name(), kebError.KEBDependency)
 	return step
@@ -45,12 +47,13 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 	provider := runtime.CloudProviderFromString(operation.ProviderValues.ProviderType)
 	zonesDiscoveryEnabled := s.providerSpec.ZonesDiscovery(provider)
 
-	if !zonesDiscoveryEnabled && provider != runtime.Azure {
+	azureSuffixNeeded := provider == runtime.Azure && s.useMachineImageVersionSuffix
+	if !zonesDiscoveryEnabled && !azureSuffixNeeded {
 		log.Info(fmt.Sprintf("Zones discovery disabled for provider %s, skipping", provider))
 		return operation, 0, nil
 	}
 	zonesAlreadyDone := !zonesDiscoveryEnabled || len(operation.DiscoveredZones) > 0
-	suffixesAlreadyDone := provider != runtime.Azure || len(operation.MachineImageVersionSuffixes) > 0
+	suffixesAlreadyDone := !azureSuffixNeeded || len(operation.MachineImageVersionSuffixes) > 0
 	if zonesAlreadyDone && suffixesAlreadyDone {
 		log.Info("Zones and machine image version suffixes already discovered, skipping")
 		return operation, 0, nil
@@ -120,7 +123,7 @@ func (s *DiscoverAvailableZonesCBStep) Run(operation internal.Operation, log *sl
 			discoveredZones[machineType] = zones
 		}
 
-		if provider == runtime.Azure {
+		if azureSuffixNeeded {
 			suffix, err := client.HyperVGeneration(context.Background(), machineType)
 			if err != nil {
 				return s.operationManager.RetryOperation(operation, fmt.Sprintf("unable to get HyperV generation for machine type %s", machineType), err, 10*time.Second, time.Minute, log)

--- a/internal/process/steps/discover_available_zones_cb_test.go
+++ b/internal/process/steps/discover_available_zones_cb_test.go
@@ -20,6 +20,7 @@ const (
 	operationID               = "operation-1"
 	subscriptionSecretNameAWS = "aws-most-used-shared"
 	machineTypeM6ILarge       = "m6i.large"
+	machineTypeStandardD4sV5  = "Standard_D4s_v5"
 )
 
 func TestDiscoverAvailableZonesCBStep_ZonesDiscoveryDisabled(t *testing.T) {
@@ -397,7 +398,7 @@ func TestDiscoverAvailableZonesCBStep_AzureProvisioningHappyPath(t *testing.T) {
 	operation := fixture.FixProvisioningOperation(operationID, instanceID)
 	operation.InstanceDetails.ProviderValues = &internal.ProviderValues{ProviderType: "azure", Region: "westeurope"}
 	operation.RuntimeID = instance.RuntimeID
-	machineType := "Standard_D4s_v5"
+	machineType := machineTypeStandardD4sV5
 	operation.ProvisioningParameters.Parameters.MachineType = &machineType
 	operation.ProvisioningParameters.Parameters.AdditionalWorkerNodePools = []pkg.AdditionalWorkerNodePool{
 		{
@@ -409,7 +410,7 @@ func TestDiscoverAvailableZonesCBStep_AzureProvisioningHappyPath(t *testing.T) {
 		},
 		{
 			Name:          "worker-2",
-			MachineType:   "Standard_D4s_v5", // duplicate — queried only once
+			MachineType:   machineTypeStandardD4sV5, // duplicate — queried only once
 			HAZones:       false,
 			AutoScalerMin: 1,
 			AutoScalerMax: 3,
@@ -423,8 +424,8 @@ func TestDiscoverAvailableZonesCBStep_AzureProvisioningHappyPath(t *testing.T) {
 		fixture.NewAzureProviderSpecWithZonesDiscovery(t),
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
 		fixture.NewFakeFactory(map[string][]string{
-			"Standard_D4s_v5": {"1", "2", "3"},
-			"Standard_F8s_v2": {"1", "2", "3"},
+			machineTypeStandardD4sV5: {"1", "2", "3"},
+			"Standard_F8s_v2":        {"1", "2", "3"},
 		}, nil))
 
 	// when
@@ -435,7 +436,7 @@ func TestDiscoverAvailableZonesCBStep_AzureProvisioningHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Zero(t, repeat)
 	assert.Len(t, operation.DiscoveredZones, 2) // Standard_D4s_v5 and Standard_F8s_v2 (deduped)
-	assert.ElementsMatch(t, operation.DiscoveredZones["Standard_D4s_v5"], []string{"1", "2", "3"})
+	assert.ElementsMatch(t, operation.DiscoveredZones[machineTypeStandardD4sV5], []string{"1", "2", "3"})
 	assert.ElementsMatch(t, operation.DiscoveredZones["Standard_F8s_v2"], []string{"1", "2", "3"})
 }
 
@@ -454,7 +455,7 @@ func TestDiscoverAvailableZonesCBStep_AzureUpdateHappyPath(t *testing.T) {
 	operation.UpdatingParameters.AdditionalWorkerNodePools = []pkg.AdditionalWorkerNodePool{
 		{
 			Name:          "worker-1",
-			MachineType:   "Standard_D4s_v5",
+			MachineType:   machineTypeStandardD4sV5,
 			HAZones:       true,
 			AutoScalerMin: 3,
 			AutoScalerMax: 10,
@@ -468,7 +469,7 @@ func TestDiscoverAvailableZonesCBStep_AzureUpdateHappyPath(t *testing.T) {
 		fixture.NewAzureProviderSpecWithZonesDiscovery(t),
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
 		fixture.NewFakeFactory(map[string][]string{
-			"Standard_D4s_v5": {"1", "2", "3"},
+			machineTypeStandardD4sV5: {"1", "2", "3"},
 		}, nil))
 
 	// when
@@ -478,7 +479,7 @@ func TestDiscoverAvailableZonesCBStep_AzureUpdateHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Zero(t, repeat)
 	assert.Len(t, operation.DiscoveredZones, 1)
-	assert.ElementsMatch(t, operation.DiscoveredZones["Standard_D4s_v5"], []string{"1", "2", "3"})
+	assert.ElementsMatch(t, operation.DiscoveredZones[machineTypeStandardD4sV5], []string{"1", "2", "3"})
 }
 
 func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuffixes(t *testing.T) {
@@ -493,7 +494,7 @@ func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuf
 	operation := fixture.FixProvisioningOperation(operationID, instanceID)
 	operation.InstanceDetails.ProviderValues = &internal.ProviderValues{ProviderType: "azure", Region: "westeurope"}
 	operation.RuntimeID = instance.RuntimeID
-	machineType := "Standard_D4s_v5"
+	machineType := machineTypeStandardD4sV5
 	operation.ProvisioningParameters.Parameters.MachineType = &machineType
 	err = memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)
@@ -503,7 +504,7 @@ func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuf
 		fixture.NewAzureProviderSpec(t, false),
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
 		fixture.NewFakeFactoryWithHyperV(map[string][]string{}, map[string]string{
-			"Standard_D4s_v5": "-gen2",
+			machineTypeStandardD4sV5: "-gen2",
 		}, nil))
 
 	// when
@@ -513,7 +514,7 @@ func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuf
 	assert.NoError(t, err)
 	assert.Zero(t, repeat)
 	assert.Empty(t, operation.DiscoveredZones)
-	assert.Equal(t, "-gen2", operation.MachineImageVersionSuffixes["Standard_D4s_v5"])
+	assert.Equal(t, "-gen2", operation.MachineImageVersionSuffixes[machineTypeStandardD4sV5])
 }
 
 func TestDiscoverAvailableZonesCBStep_AzureRepeatWhenError(t *testing.T) {
@@ -528,7 +529,7 @@ func TestDiscoverAvailableZonesCBStep_AzureRepeatWhenError(t *testing.T) {
 	operation := fixture.FixProvisioningOperation(operationID, instanceID)
 	operation.InstanceDetails.ProviderValues = &internal.ProviderValues{ProviderType: "azure", Region: "westeurope"}
 	operation.RuntimeID = instance.RuntimeID
-	machineType := "Standard_D4s_v5"
+	machineType := machineTypeStandardD4sV5
 	operation.ProvisioningParameters.Parameters.MachineType = &machineType
 	err = memoryStorage.Operations().InsertOperation(operation)
 	assert.NoError(t, err)

--- a/internal/process/steps/discover_available_zones_cb_test.go
+++ b/internal/process/steps/discover_available_zones_cb_test.go
@@ -481,6 +481,41 @@ func TestDiscoverAvailableZonesCBStep_AzureUpdateHappyPath(t *testing.T) {
 	assert.ElementsMatch(t, operation.DiscoveredZones["Standard_D4s_v5"], []string{"1", "2", "3"})
 }
 
+func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuffixes(t *testing.T) {
+	// given
+	memoryStorage := storage.NewMemoryStorage()
+
+	instance := fixture.FixInstance(instanceID)
+	instance.SubscriptionSecretName = fixture.AzureUnclaimedSecretName
+	err := memoryStorage.Instances().Insert(instance)
+	assert.NoError(t, err)
+
+	operation := fixture.FixProvisioningOperation(operationID, instanceID)
+	operation.InstanceDetails.ProviderValues = &internal.ProviderValues{ProviderType: "azure", Region: "westeurope"}
+	operation.RuntimeID = instance.RuntimeID
+	machineType := "Standard_D4s_v5"
+	operation.ProvisioningParameters.Parameters.MachineType = &machineType
+	err = memoryStorage.Operations().InsertOperation(operation)
+	assert.NoError(t, err)
+
+	step := NewDiscoverAvailableZonesCBStep(
+		memoryStorage,
+		fixture.NewAzureProviderSpec(t, false),
+		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
+		fixture.NewFakeFactoryWithHyperV(map[string][]string{}, map[string]string{
+			"Standard_D4s_v5": "-gen2",
+		}, nil))
+
+	// when
+	operation, repeat, err := step.Run(operation, fixLogger())
+
+	// then
+	assert.NoError(t, err)
+	assert.Zero(t, repeat)
+	assert.Empty(t, operation.DiscoveredZones)
+	assert.Equal(t, "-gen2", operation.MachineImageVersionSuffixes["Standard_D4s_v5"])
+}
+
 func TestDiscoverAvailableZonesCBStep_AzureRepeatWhenError(t *testing.T) {
 	// given
 	memoryStorage := storage.NewMemoryStorage()

--- a/internal/process/steps/discover_available_zones_cb_test.go
+++ b/internal/process/steps/discover_available_zones_cb_test.go
@@ -57,7 +57,7 @@ func TestDiscoverAvailableZonesCBStep_ZonesDiscoveryDisabled(t *testing.T) {
 			"m6i.large":   {"ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"},
 			"g6.xlarge":   {"ap-southeast-2a", "ap-southeast-2c"},
 			"g4dn.xlarge": {"ap-southeast-2b"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -90,7 +90,7 @@ func TestDiscoverAvailableZonesCBStep_FailWhenNoSubscriptionSecretName(t *testin
 	assert.NoError(t, err)
 
 	step := NewDiscoverAvailableZonesCBStep(memoryStorage, fixture.NewProviderSpecWithZonesDiscovery(t, true), fixture.CreateGardenerClientWithCredentialsBindings(),
-		fixture.NewFakeFactory(map[string][]string{}, nil))
+		fixture.NewFakeFactory(map[string][]string{}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -143,7 +143,7 @@ func TestDiscoverAvailableZonesCBStep_SubscriptionSecretNameFromOperation(t *tes
 			"m6i.large":   {"ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"},
 			"g6.xlarge":   {"ap-southeast-2a", "ap-southeast-2c"},
 			"g4dn.xlarge": {"ap-southeast-2b"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -199,7 +199,7 @@ func TestDiscoverAvailableZonesCBStep_RegionFromProviderValues(t *testing.T) {
 			"m6i.large":   {"ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"},
 			"g6.xlarge":   {"ap-southeast-2a", "ap-southeast-2c"},
 			"g4dn.xlarge": {"ap-southeast-2b"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -235,7 +235,7 @@ func TestDiscoverAvailableZonesCBStep_MachineTypeFromProviderValues(t *testing.T
 		fixture.CreateGardenerClientWithCredentialsBindings(),
 		fixture.NewFakeFactory(map[string][]string{
 			"m5.large": {"ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -270,7 +270,7 @@ func TestDiscoverAvailableZonesCBStep_AWSRepeatWhenError(t *testing.T) {
 	assert.NoError(t, err)
 
 	step := NewDiscoverAvailableZonesCBStep(memoryStorage, fixture.NewProviderSpecWithZonesDiscovery(t, true),
-		fixture.CreateGardenerClientWithCredentialsBindings(), fixture.NewFakeFactory(map[string][]string{}, fmt.Errorf("AWS error")))
+		fixture.CreateGardenerClientWithCredentialsBindings(), fixture.NewFakeFactory(map[string][]string{}, fmt.Errorf("AWS error")), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -321,7 +321,7 @@ func TestDiscoverAvailableZonesCBStep_AWSProvisioningHappyPath(t *testing.T) {
 			"m6i.large":   {"ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"},
 			"g6.xlarge":   {"ap-southeast-2a", "ap-southeast-2c"},
 			"g4dn.xlarge": {"ap-southeast-2b"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -373,7 +373,7 @@ func TestDiscoverAvailableZonesCBStep_AWSUpdateHappyPath(t *testing.T) {
 		fixture.NewFakeFactory(map[string][]string{
 			"g6.xlarge":   {"ap-southeast-2a", "ap-southeast-2c"},
 			"g4dn.xlarge": {"ap-southeast-2b"},
-		}, nil))
+		}, nil), false)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -426,7 +426,7 @@ func TestDiscoverAvailableZonesCBStep_AzureProvisioningHappyPath(t *testing.T) {
 		fixture.NewFakeFactory(map[string][]string{
 			machineTypeStandardD4sV5: {"1", "2", "3"},
 			"Standard_F8s_v2":        {"1", "2", "3"},
-		}, nil))
+		}, nil), true)
 
 	// when
 	// Logs should contain: "discovering zones using credentials binding azure-unclaimed region=westeurope"
@@ -470,7 +470,7 @@ func TestDiscoverAvailableZonesCBStep_AzureUpdateHappyPath(t *testing.T) {
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
 		fixture.NewFakeFactory(map[string][]string{
 			machineTypeStandardD4sV5: {"1", "2", "3"},
-		}, nil))
+		}, nil), true)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -505,7 +505,7 @@ func TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuf
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
 		fixture.NewFakeFactoryWithHyperV(map[string][]string{}, map[string]string{
 			machineTypeStandardD4sV5: "-gen2",
-		}, nil))
+		}, nil), true)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())
@@ -538,7 +538,7 @@ func TestDiscoverAvailableZonesCBStep_AzureRepeatWhenError(t *testing.T) {
 		memoryStorage,
 		fixture.NewAzureProviderSpecWithZonesDiscovery(t),
 		fixture.CreateGardenerClientWithAzureCredentialsBindings(),
-		fixture.NewFakeFactory(map[string][]string{}, fmt.Errorf("Azure API error")))
+		fixture.NewFakeFactory(map[string][]string{}, fmt.Errorf("Azure API error")), true)
 
 	// when
 	operation, repeat, err := step.Run(operation, fixLogger())


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Decouple HyperV generation suffix fetching from zone discovery in `DiscoverAvailableZonesCBStep` — suffixes are now always fetched for Azure regardless of the `zonesDiscovery` flag
- Skip zone fetching per machine type when zones discovery is disabled, while still running the step for Azure
- Add `NewAzureProviderSpec` fixture helper to allow configuring `zonesDiscovery` flag in tests
- Add `sb-azure-eu-access` secret to `fixSecrets` in the broker suite test to support Azure EU-access provisioning flows that now reach the step
- Add test `TestDiscoverAvailableZonesCBStep_AzureZonesDiscoveryDisabledStillFetchesSuffixes`

**Related issue(s)**
See also #3352