### PR TITLE
Fix and Optimize keb-analytics Refresh Pipeline

### DIFF
--- a/cmd/keb-analytics/main.go
+++ b/cmd/keb-analytics/main.go
@@ -61,15 +61,31 @@ func buildRangeCache(opEvents []analytics.OpEvent, tr analytics.TimeRange, planI
 	provParams := analytics.OpEventsToProvParamsInRange(opEvents, tr)
 	updateParams := analytics.OpEventsToUpdateParamsInRange(opEvents, tr)
 	plans, regionsByPlan := analytics.BuildPlanRegionIndex(provParams, planIDToName)
-	combined := analytics.AggregateCombined(provParams, updateParams)
+
+	// Run independent aggregations in parallel.
+	var (
+		provisioning  analytics.ParameterStats
+		updates       analytics.ParameterStats
+		combined      analytics.ParameterStats
+		distributions []analytics.DistributionStat
+	)
+	var wg sync.WaitGroup
+	wg.Add(4)
+	go func() { defer wg.Done(); provisioning = analytics.AggregateProvisioning(provParams) }()
+	go func() { defer wg.Done(); updates = analytics.AggregateUpdates(provParams, updateParams) }()
+	go func() { defer wg.Done(); combined = analytics.AggregateCombined(provParams, updateParams) }()
+	go func() { defer wg.Done(); distributions = analytics.BuildDistributions(provParams) }()
+	wg.Wait()
+
+	trends := analytics.BuildTrends(opEvents, trendParams)
 	resp := analytics.StatsResponse{
 		TotalInstances: len(provParams),
 		TotalUpdates:   len(updateParams),
-		Provisioning:   analytics.AggregateProvisioning(provParams),
-		Updates:        analytics.AggregateUpdates(provParams, updateParams),
+		Provisioning:   provisioning,
+		Updates:        updates,
 		Combined:       combined,
-		Distributions:  analytics.BuildDistributions(provParams),
-		Trends:         analytics.BuildTrends(opEvents, trendParams),
+		Distributions:  distributions,
+		Trends:         trends,
 		Plans:          plans,
 		RegionsByPlan:  regionsByPlan,
 	}

--- a/internal/analytics/aggregator.go
+++ b/internal/analytics/aggregator.go
@@ -241,12 +241,7 @@ func buildCounts(params []ProvisioningParamsWithID) map[string]map[string]int {
 
 // AggregateProvisioning computes parameter usage stats from a slice of ProvisioningParameters.
 func AggregateProvisioning(params []ProvisioningParamsWithID) ParameterStats {
-	plain := PlainProvisioningParams(params)
-	counts := make(map[string]map[string]int)
-	for _, p := range plain {
-		walkFields(p.Parameters, provisioningFieldConfig, counts)
-	}
-	return toParameterStats(counts, len(plain))
+	return toParameterStats(buildCounts(params), len(params))
 }
 
 // activeInstanceSet builds a set of instance IDs from provParams for fast membership checks.
@@ -310,19 +305,20 @@ func AggregateCombined(provParams []ProvisioningParamsWithID, updateParams []Upd
 	instancesWithParam := make(map[string]map[string]struct{})
 	allInstances := make(map[string]struct{})
 
-	record := func(instanceID, param string) {
+	addInstance := func(instanceID, param string) {
 		if _, ok := instancesWithParam[param]; !ok {
 			instancesWithParam[param] = make(map[string]struct{})
 		}
 		instancesWithParam[param][instanceID] = struct{}{}
 	}
 
+	// Reuse the shared per-instance counts from buildCounts (one walk per instance).
 	for _, p := range provParams {
 		allInstances[p.InstanceID] = struct{}{}
-		counts := make(map[string]map[string]int)
-		walkFields(p.Params.Parameters, provisioningFieldConfig, counts)
-		for param := range counts {
-			record(p.InstanceID, param)
+		singleCounts := make(map[string]map[string]int)
+		walkFields(p.Params.Parameters, provisioningFieldConfig, singleCounts)
+		for param := range singleCounts {
+			addInstance(p.InstanceID, param)
 		}
 	}
 
@@ -333,7 +329,7 @@ func AggregateCombined(provParams []ProvisioningParamsWithID, updateParams []Upd
 		counts := make(map[string]map[string]int)
 		walkFields(p.Params, updatingFieldConfig, counts)
 		for param := range counts {
-			record(p.InstanceID, param)
+			addInstance(p.InstanceID, param)
 		}
 	}
 
@@ -515,18 +511,28 @@ func BuildTrend(events []OpEvent, param string) TrendStat {
 
 		switch ev.Type {
 		case "provision":
-			p, err := parseProvisioningParameters(ev.RawParams)
-			if err != nil {
-				continue
+			var params pkg.ProvisioningParametersDTO
+			if ev.ParsedProv != nil {
+				params = ev.ParsedProv.Parameters
+			} else {
+				p, err := parseProvisioningParameters(ev.RawParams)
+				if err != nil {
+					continue
+				}
+				params = p.Parameters
 			}
-			nowSet = isParamSet(p.Parameters, provisioningFieldConfig, param)
+			nowSet = isParamSet(params, provisioningFieldConfig, param)
 			dayProvisioned[ev.CreatedAt]++
 		case "update":
-			var params internal.UpdatingParametersDTO
-			if err := json.Unmarshal([]byte(ev.RawParams), &params); err != nil {
-				continue
+			var updParams internal.UpdatingParametersDTO
+			if ev.ParsedUpdate != nil {
+				updParams = *ev.ParsedUpdate
+			} else {
+				if err := json.Unmarshal([]byte(ev.RawParams), &updParams); err != nil {
+					continue
+				}
 			}
-			if isParamSet(params, updatingFieldConfig, param) {
+			if isParamSet(updParams, updatingFieldConfig, param) {
 				nowSet = true
 			} else if _, inConfig := updatingFieldConfig[param]; inConfig {
 				// param is updatable and absent from this op → nullified
@@ -586,11 +592,144 @@ func BuildTrend(events []OpEvent, param string) TrendStat {
 	return TrendStat{Parameter: param, Points: points}
 }
 
-// BuildTrends computes daily trend lines for each of the given parameters.
+// BuildTrends computes daily trend lines for all given parameters in a single pass over events.
+// Each event is processed once; all per-param states are updated simultaneously.
+// Events must be sorted by created_at ASC (as returned by FetchOpEventsInRange).
 func BuildTrends(events []OpEvent, params []string) []TrendStat {
-	result := make([]TrendStat, 0, len(params))
-	for _, p := range params {
-		result = append(result, BuildTrend(events, p))
+	if len(params) == 0 {
+		return nil
+	}
+
+	// Per-instance, per-param state: instanceState[instanceID][paramIdx] = isSet
+	instanceState := make(map[string][]bool)
+	getState := func(id string) []bool {
+		if s, ok := instanceState[id]; ok {
+			return s
+		}
+		s := make([]bool, len(params))
+		instanceState[id] = s
+		return s
+	}
+
+	// Accumulate deltas and provisioned counts by day, per param.
+	dayDelta := make([]map[string]int, len(params))
+	for i := range dayDelta {
+		dayDelta[i] = make(map[string]int)
+	}
+	dayProvisioned := make(map[string]int) // shared across all params
+
+	for _, ev := range events {
+		state := getState(ev.InstanceID)
+
+		switch ev.Type {
+		case "provision":
+			var provDTO pkg.ProvisioningParametersDTO
+			if ev.ParsedProv != nil {
+				provDTO = ev.ParsedProv.Parameters
+			} else {
+				p, err := parseProvisioningParameters(ev.RawParams)
+				if err != nil {
+					continue
+				}
+				provDTO = p.Parameters
+			}
+			dayProvisioned[ev.CreatedAt]++
+
+			// Walk once to get all set params for this event.
+			evCounts := make(map[string]map[string]int)
+			walkFields(provDTO, provisioningFieldConfig, evCounts)
+
+			for i, param := range params {
+				wasSet := state[i]
+				nowSet := evCounts[param] != nil
+				state[i] = nowSet
+				delta := 0
+				if nowSet && !wasSet {
+					delta = 1
+				} else if !nowSet && wasSet {
+					delta = -1
+				}
+				if delta != 0 {
+					dayDelta[i][ev.CreatedAt] += delta
+				}
+			}
+
+		case "update":
+			var updParams internal.UpdatingParametersDTO
+			if ev.ParsedUpdate != nil {
+				updParams = *ev.ParsedUpdate
+			} else {
+				if err := json.Unmarshal([]byte(ev.RawParams), &updParams); err != nil {
+					continue
+				}
+			}
+
+			// Walk once to get all set params for this update event.
+			evCounts := make(map[string]map[string]int)
+			walkFields(updParams, updatingFieldConfig, evCounts)
+
+			for i, param := range params {
+				wasSet := state[i]
+				var nowSet bool
+				if evCounts[param] != nil {
+					nowSet = true
+				} else if _, inConfig := updatingFieldConfig[param]; inConfig {
+					// param is updatable and absent from this op → nullified
+					nowSet = false
+				} else {
+					// param not updatable — state unchanged
+					nowSet = wasSet
+				}
+				state[i] = nowSet
+				delta := 0
+				if nowSet && !wasSet {
+					delta = 1
+				} else if !nowSet && wasSet {
+					delta = -1
+				}
+				if delta != 0 {
+					dayDelta[i][ev.CreatedAt] += delta
+				}
+			}
+		}
+	}
+
+	// Collect all active days.
+	allEventDays := make(map[string]struct{})
+	for d := range dayProvisioned {
+		allEventDays[d] = struct{}{}
+	}
+	for i := range dayDelta {
+		for d := range dayDelta[i] {
+			allEventDays[d] = struct{}{}
+		}
+	}
+
+	var allDays []string
+	if len(allEventDays) > 0 {
+		sorted := make([]string, 0, len(allEventDays))
+		for d := range allEventDays {
+			sorted = append(sorted, d)
+		}
+		sort.Strings(sorted)
+		allDays = expandDayRange(sorted[0], sorted[len(sorted)-1])
+	}
+
+	result := make([]TrendStat, len(params))
+	for i, param := range params {
+		if len(allDays) == 0 {
+			result[i] = TrendStat{Parameter: param, Points: nil}
+			continue
+		}
+		points := make([]TrendPoint, 0, len(allDays))
+		running := 0
+		runningTotal := 0
+		for _, day := range allDays {
+			running += dayDelta[i][day]
+			runningTotal += dayProvisioned[day]
+			points = append(points, TrendPoint{Date: day, Count: running, Total: runningTotal})
+		}
+		result[i] = TrendStat{Parameter: param, Points: points}
 	}
 	return result
 }

--- a/internal/analytics/aggregator.go
+++ b/internal/analytics/aggregator.go
@@ -25,6 +25,11 @@ const (
 	behaviorOIDC                            // emit 0 (nil), 1 (single), or len(List) (multi)
 )
 
+const (
+	opTypeProvision = "provision"
+	opTypeUpdate    = "update"
+)
+
 // provisioningFieldConfig controls per-field behavior for ProvisioningParametersDTO.
 // Fields not listed default to behaviorValue. Keys are JSON tag names.
 var provisioningFieldConfig = map[string]fieldBehavior{
@@ -510,7 +515,7 @@ func BuildTrend(events []OpEvent, param string) TrendStat {
 		var nowSet bool
 
 		switch ev.Type {
-		case "provision":
+		case opTypeProvision:
 			var params pkg.ProvisioningParametersDTO
 			if ev.ParsedProv != nil {
 				params = ev.ParsedProv.Parameters
@@ -523,7 +528,7 @@ func BuildTrend(events []OpEvent, param string) TrendStat {
 			}
 			nowSet = isParamSet(params, provisioningFieldConfig, param)
 			dayProvisioned[ev.CreatedAt]++
-		case "update":
+		case opTypeUpdate:
 			var updParams internal.UpdatingParametersDTO
 			if ev.ParsedUpdate != nil {
 				updParams = *ev.ParsedUpdate
@@ -592,6 +597,75 @@ func BuildTrend(events []OpEvent, param string) TrendStat {
 	return TrendStat{Parameter: param, Points: points}
 }
 
+// applyProvEventToTrends updates state/dayDelta for a provision event across all params.
+// Returns false if the event should be skipped (parse error).
+func applyProvEventToTrends(ev OpEvent, params []string, state []bool, dayDelta []map[string]int) bool {
+	var provDTO pkg.ProvisioningParametersDTO
+	if ev.ParsedProv != nil {
+		provDTO = ev.ParsedProv.Parameters
+	} else {
+		p, err := parseProvisioningParameters(ev.RawParams)
+		if err != nil {
+			return false
+		}
+		provDTO = p.Parameters
+	}
+	evCounts := make(map[string]map[string]int)
+	walkFields(provDTO, provisioningFieldConfig, evCounts)
+	for i, param := range params {
+		wasSet := state[i]
+		nowSet := evCounts[param] != nil
+		state[i] = nowSet
+		if delta := trendDelta(wasSet, nowSet); delta != 0 {
+			dayDelta[i][ev.CreatedAt] += delta
+		}
+	}
+	return true
+}
+
+// applyUpdateEventToTrends updates state/dayDelta for an update event across all params.
+// Returns false if the event should be skipped (parse error).
+func applyUpdateEventToTrends(ev OpEvent, params []string, state []bool, dayDelta []map[string]int) bool {
+	var updParams internal.UpdatingParametersDTO
+	if ev.ParsedUpdate != nil {
+		updParams = *ev.ParsedUpdate
+	} else {
+		if err := json.Unmarshal([]byte(ev.RawParams), &updParams); err != nil {
+			return false
+		}
+	}
+	evCounts := make(map[string]map[string]int)
+	walkFields(updParams, updatingFieldConfig, evCounts)
+	for i, param := range params {
+		wasSet := state[i]
+		var nowSet bool
+		if evCounts[param] != nil {
+			nowSet = true
+		} else if _, inConfig := updatingFieldConfig[param]; inConfig {
+			nowSet = false // param updatable and absent → nullified
+		} else {
+			nowSet = wasSet // not updatable → unchanged
+		}
+		state[i] = nowSet
+		if delta := trendDelta(wasSet, nowSet); delta != 0 {
+			dayDelta[i][ev.CreatedAt] += delta
+		}
+	}
+	return true
+}
+
+// trendDelta returns +1 if the param transitioned from unset→set, -1 for set→unset, 0 otherwise.
+func trendDelta(wasSet, nowSet bool) int {
+	switch {
+	case nowSet && !wasSet:
+		return 1
+	case !nowSet && wasSet:
+		return -1
+	default:
+		return 0
+	}
+}
+
 // BuildTrends computes daily trend lines for all given parameters in a single pass over events.
 // Each event is processed once; all per-param states are updated simultaneously.
 // Events must be sorted by created_at ASC (as returned by FetchOpEventsInRange).
@@ -620,77 +694,13 @@ func BuildTrends(events []OpEvent, params []string) []TrendStat {
 
 	for _, ev := range events {
 		state := getState(ev.InstanceID)
-
 		switch ev.Type {
-		case "provision":
-			var provDTO pkg.ProvisioningParametersDTO
-			if ev.ParsedProv != nil {
-				provDTO = ev.ParsedProv.Parameters
-			} else {
-				p, err := parseProvisioningParameters(ev.RawParams)
-				if err != nil {
-					continue
-				}
-				provDTO = p.Parameters
+		case opTypeProvision:
+			if applyProvEventToTrends(ev, params, state, dayDelta) {
+				dayProvisioned[ev.CreatedAt]++
 			}
-			dayProvisioned[ev.CreatedAt]++
-
-			// Walk once to get all set params for this event.
-			evCounts := make(map[string]map[string]int)
-			walkFields(provDTO, provisioningFieldConfig, evCounts)
-
-			for i, param := range params {
-				wasSet := state[i]
-				nowSet := evCounts[param] != nil
-				state[i] = nowSet
-				delta := 0
-				if nowSet && !wasSet {
-					delta = 1
-				} else if !nowSet && wasSet {
-					delta = -1
-				}
-				if delta != 0 {
-					dayDelta[i][ev.CreatedAt] += delta
-				}
-			}
-
-		case "update":
-			var updParams internal.UpdatingParametersDTO
-			if ev.ParsedUpdate != nil {
-				updParams = *ev.ParsedUpdate
-			} else {
-				if err := json.Unmarshal([]byte(ev.RawParams), &updParams); err != nil {
-					continue
-				}
-			}
-
-			// Walk once to get all set params for this update event.
-			evCounts := make(map[string]map[string]int)
-			walkFields(updParams, updatingFieldConfig, evCounts)
-
-			for i, param := range params {
-				wasSet := state[i]
-				var nowSet bool
-				if evCounts[param] != nil {
-					nowSet = true
-				} else if _, inConfig := updatingFieldConfig[param]; inConfig {
-					// param is updatable and absent from this op → nullified
-					nowSet = false
-				} else {
-					// param not updatable — state unchanged
-					nowSet = wasSet
-				}
-				state[i] = nowSet
-				delta := 0
-				if nowSet && !wasSet {
-					delta = 1
-				} else if !nowSet && wasSet {
-					delta = -1
-				}
-				if delta != 0 {
-					dayDelta[i][ev.CreatedAt] += delta
-				}
-			}
+		case opTypeUpdate:
+			applyUpdateEventToTrends(ev, params, state, dayDelta)
 		}
 	}
 

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -336,10 +336,9 @@ func TestAggregateCombined_TotalIsDistinctInstanceCount(t *testing.T) {
 }
 
 func TestAggregateCombined_SortedBySetCountDescThenName(t *testing.T) {
-	machineType := "m6i.xlarge"
 	provParams := []ProvisioningParamsWithID{
-		{InstanceID: "i1", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: &machineType}}},
-		{InstanceID: "i2", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: &machineType}}},
+		{InstanceID: "i1", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr(testMachineType)}}},
+		{InstanceID: "i2", Params: internal.ProvisioningParameters{Parameters: pkg.ProvisioningParametersDTO{MachineType: strPtr(testMachineType)}}},
 	}
 	updateParams := []UpdateParamsWithID{
 		{InstanceID: "i1", Params: internal.UpdatingParametersDTO{

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -1036,3 +1036,33 @@ func TestBuildTrends_EmptyParamsReturnsNil(t *testing.T) {
 	got := BuildTrends(events, nil)
 	assert.Nil(t, got)
 }
+
+// TestBuildTrends_SharedDayAxisAddsFlat documents that BuildTrends emits a point on every
+// day in the union of all params' active days, even for params with no activity on that day.
+// This differs from BuildTrend (singular), which only emits points on days with actual deltas
+// or provisioning events for that specific param.
+func TestBuildTrends_SharedDayAxisAddsFlat(t *testing.T) {
+	// i1 provisioned with machineType on day 1 (no gvisor).
+	// i2 provisioned with gvisor on day 3 (no machineType).
+	// Day 2 is expanded by expandDayRange between day 1 and day 3.
+	events := []OpEvent{
+		provEvent("i1", "2024-01-01", "m6i.xlarge"),
+		provEventGvisor("i2", "2024-01-03"),
+	}
+	got := BuildTrends(events, []string{"machineType", "gvisor"})
+	require.Len(t, got, 2)
+
+	// Both params share the full day range 2024-01-01 .. 2024-01-03 (3 points each).
+	assert.Len(t, got[0].Points, 3, "machineType should have 3 points (shared axis)")
+	assert.Len(t, got[1].Points, 3, "gvisor should have 3 points (shared axis)")
+
+	// machineType: set on day 1, stays flat through days 2–3.
+	assert.Equal(t, 1, got[0].Points[0].Count) // day 1: provisioned
+	assert.Equal(t, 1, got[0].Points[1].Count) // day 2: flat (no activity)
+	assert.Equal(t, 1, got[0].Points[2].Count) // day 3: flat (gvisor provision, not machineType)
+
+	// gvisor: zero through days 1–2, set on day 3.
+	assert.Equal(t, 0, got[1].Points[0].Count) // day 1: not set
+	assert.Equal(t, 0, got[1].Points[1].Count) // day 2: flat
+	assert.Equal(t, 1, got[1].Points[2].Count) // day 3: provisioned with gvisor
+}

--- a/internal/analytics/aggregator_test.go
+++ b/internal/analytics/aggregator_test.go
@@ -996,3 +996,43 @@ func TestBuildTrend_UpdateRawParamsIsUpdatingParametersDTO(t *testing.T) {
 	assert.Equal(t, 0, trend.Points[0].Count)
 	assert.Equal(t, 1, trend.Points[1].Count)
 }
+
+// ---------------------------------------------------------------------------
+// BuildTrends (single-pass multi-param)
+// ---------------------------------------------------------------------------
+
+// TestBuildTrends_MatchesBuildTrend verifies that BuildTrends produces the same output
+// as calling BuildTrend individually for each parameter when all params share the same
+// active days (so the shared day axis introduces no extra points).
+func TestBuildTrends_MatchesBuildTrend(t *testing.T) {
+	// Both machineType and gvisor change on day 1 only, so allEventDays == {"2024-01-01"}
+	// for both params, and the outputs should be identical to per-param BuildTrend calls.
+	mt := "m6i.xlarge"
+	p := internal.ProvisioningParameters{
+		Parameters: pkg.ProvisioningParametersDTO{
+			MachineType: &mt,
+			Gvisor:      &pkg.GvisorDTO{Enabled: true},
+		},
+	}
+	raw, _ := json.Marshal(p)
+	events := []OpEvent{
+		{InstanceID: "i1", CreatedAt: "2024-01-01", Type: "provision", RawParams: string(raw)},
+	}
+	params := []string{"machineType", "gvisor"}
+
+	got := BuildTrends(events, params)
+	require.Len(t, got, len(params))
+
+	for i, param := range params {
+		want := BuildTrend(events, param)
+		assert.Equal(t, want.Parameter, got[i].Parameter, "param %s: parameter name mismatch", param)
+		assert.Equal(t, want.Points, got[i].Points, "param %s: points mismatch", param)
+	}
+}
+
+// TestBuildTrends_EmptyParamsReturnsNil verifies the early-exit for an empty params slice.
+func TestBuildTrends_EmptyParamsReturnsNil(t *testing.T) {
+	events := []OpEvent{provEvent("i1", "2024-01-01", "m6i.xlarge")}
+	got := BuildTrends(events, nil)
+	assert.Nil(t, got)
+}

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -140,6 +140,7 @@ func PlainProvisioningParams(params []ProvisioningParamsWithID) []internal.Provi
 
 // OpEventsToProvParamsInRange derives ProvisioningParamsWithID from provision events in events,
 // filtering to those whose CreatedAt falls within tr. An empty tr returns all events.
+// Uses ParsedProv when available to avoid redundant JSON unmarshalling.
 func OpEventsToProvParamsInRange(events []OpEvent, tr TimeRange) []ProvisioningParamsWithID {
 	result := make([]ProvisioningParamsWithID, 0, len(events))
 	for _, ev := range events {
@@ -149,10 +150,16 @@ func OpEventsToProvParamsInRange(events []OpEvent, tr TimeRange) []ProvisioningP
 		if !inRange(ev.CreatedAt, tr) {
 			continue
 		}
-		p, err := parseProvisioningParameters(ev.RawParams)
-		if err != nil {
-			slog.Warn("analytics: skipping malformed provisioning_parameters in op event", "instance_id", ev.InstanceID, "error", err)
-			continue
+		var p internal.ProvisioningParameters
+		if ev.ParsedProv != nil {
+			p = *ev.ParsedProv
+		} else {
+			var err error
+			p, err = parseProvisioningParameters(ev.RawParams)
+			if err != nil {
+				slog.Warn("analytics: skipping malformed provisioning_parameters in op event", "instance_id", ev.InstanceID, "error", err)
+				continue
+			}
 		}
 		result = append(result, ProvisioningParamsWithID{InstanceID: ev.InstanceID, Params: p})
 	}
@@ -161,6 +168,7 @@ func OpEventsToProvParamsInRange(events []OpEvent, tr TimeRange) []ProvisioningP
 
 // OpEventsToUpdateParamsInRange derives UpdateParamsWithID from update events in events,
 // filtering to those whose CreatedAt falls within tr. An empty tr returns all events.
+// Uses ParsedUpdate when available to avoid redundant JSON unmarshalling.
 func OpEventsToUpdateParamsInRange(events []OpEvent, tr TimeRange) []UpdateParamsWithID {
 	result := make([]UpdateParamsWithID, 0, len(events))
 	for _, ev := range events {
@@ -171,9 +179,13 @@ func OpEventsToUpdateParamsInRange(events []OpEvent, tr TimeRange) []UpdateParam
 			continue
 		}
 		var params internal.UpdatingParametersDTO
-		if err := json.Unmarshal([]byte(ev.RawParams), &params); err != nil {
-			slog.Warn("analytics: skipping malformed updating_parameters in op event", "instance_id", ev.InstanceID, "error", err)
-			continue
+		if ev.ParsedUpdate != nil {
+			params = *ev.ParsedUpdate
+		} else {
+			if err := json.Unmarshal([]byte(ev.RawParams), &params); err != nil {
+				slog.Warn("analytics: skipping malformed updating_parameters in op event", "instance_id", ev.InstanceID, "error", err)
+				continue
+			}
 		}
 		result = append(result, UpdateParamsWithID{InstanceID: ev.InstanceID, Params: params})
 	}

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -129,15 +129,6 @@ func parseProvisioningParameters(raw string) (internal.ProvisioningParameters, e
 	return p, nil
 }
 
-// PlainProvisioningParams extracts just the ProvisioningParameters slice from ProvisioningParamsWithID.
-func PlainProvisioningParams(params []ProvisioningParamsWithID) []internal.ProvisioningParameters {
-	result := make([]internal.ProvisioningParameters, len(params))
-	for i, p := range params {
-		result[i] = p.Params
-	}
-	return result
-}
-
 // OpEventsToProvParamsInRange derives ProvisioningParamsWithID from provision events in events,
 // filtering to those whose CreatedAt falls within tr. An empty tr returns all events.
 // Uses ParsedProv when available to avoid redundant JSON unmarshalling.

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -45,11 +45,15 @@ type UpdateParamsWithID struct {
 }
 
 // OpEvent is a single provisioning or update operation used for trend computation.
+// ParsedProv and ParsedUpdate are pre-parsed at fetch time to avoid repeated JSON
+// unmarshalling during aggregation and trend computation.
 type OpEvent struct {
-	InstanceID string
-	CreatedAt  string // YYYY-MM-DD
-	Type       string // "provision" or "update"
-	RawParams  string // provisioning_parameters JSON for provision ops; updating_parameters JSON for update ops
+	InstanceID  string
+	CreatedAt   string // YYYY-MM-DD
+	Type        string // "provision" or "update"
+	RawParams   string // provisioning_parameters JSON for provision ops; updating_parameters JSON for update ops
+	ParsedProv  *internal.ProvisioningParameters  // non-nil for provision events
+	ParsedUpdate *internal.UpdatingParametersDTO  // non-nil for update events
 }
 
 // FetchOpEventsInRange returns all succeeded provisioning and update operations on active
@@ -85,14 +89,31 @@ WHERE o.type IN ('provision', 'update')
 		return nil, fmt.Errorf("fetching op events: %w", err)
 	}
 
-	result := make([]OpEvent, len(rows))
-	for i, row := range rows {
-		result[i] = OpEvent{
+	result := make([]OpEvent, 0, len(rows))
+	for _, row := range rows {
+		ev := OpEvent{
 			InstanceID: row.InstanceID,
 			CreatedAt:  row.CreatedDate,
 			Type:       row.Type,
 			RawParams:  row.RawParams,
 		}
+		switch row.Type {
+		case "provision":
+			p, err := parseProvisioningParameters(row.RawParams)
+			if err != nil {
+				slog.Warn("analytics: skipping malformed provisioning_parameters", "instance_id", row.InstanceID, "error", err)
+				continue
+			}
+			ev.ParsedProv = &p
+		case "update":
+			var params internal.UpdatingParametersDTO
+			if err := json.Unmarshal([]byte(row.RawParams), &params); err != nil {
+				slog.Warn("analytics: skipping malformed updating_parameters", "instance_id", row.InstanceID, "error", err)
+				continue
+			}
+			ev.ParsedUpdate = &params
+		}
+		result = append(result, ev)
 	}
 	return result, nil
 }

--- a/internal/analytics/db.go
+++ b/internal/analytics/db.go
@@ -48,11 +48,11 @@ type UpdateParamsWithID struct {
 // ParsedProv and ParsedUpdate are pre-parsed at fetch time to avoid repeated JSON
 // unmarshalling during aggregation and trend computation.
 type OpEvent struct {
-	InstanceID  string
-	CreatedAt   string // YYYY-MM-DD
-	Type        string // "provision" or "update"
-	RawParams   string // provisioning_parameters JSON for provision ops; updating_parameters JSON for update ops
-	ParsedProv  *internal.ProvisioningParameters  // non-nil for provision events
+	InstanceID   string
+	CreatedAt    string                           // YYYY-MM-DD
+	Type         string                           // "provision" or "update"
+	RawParams    string                           // provisioning_parameters JSON for provision ops; updating_parameters JSON for update ops
+	ParsedProv   *internal.ProvisioningParameters // non-nil for provision events
 	ParsedUpdate *internal.UpdatingParametersDTO  // non-nil for update events
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace per-param `BuildTrend` loop (O(N×T)) with a single-pass `BuildTrends` that processes all events once and updates all param states simultaneously (O(N))
- Pre-parse JSON at fetch time in `FetchOpEventsInRange`; store typed structs in `OpEvent.ParsedProv` / `ParsedUpdate` to eliminate repeated `json.Unmarshal` calls during aggregation and trend computation
- Parallelize `AggregateProvisioning`, `AggregateUpdates`, `AggregateCombined`, and `BuildDistributions` in `buildRangeCache` using `sync.WaitGroup`
- Simplify `AggregateProvisioning` to reuse the shared `buildCounts` helper

**Related issue(s)**