### PR TITLE
Default UseMachineImageVersionSuffix to True

### DIFF
--- a/docs/contributor/02-30-keb-configuration.md
+++ b/docs/contributor/02-30-keb-configuration.md
@@ -80,7 +80,7 @@ Kyma Environment Broker (KEB) binary allows you to override some configuration p
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MACHINE_&#x200b;IMAGE_VERSION** | None | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MAX_PODS** | <code>200</code> | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_MULTI_ZONE_&#x200b;CLUSTER** | <code>true</code> | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. |
-| **APP_INFRASTRUCTURE_&#x200b;MANAGER_USE_MACHINE_&#x200b;IMAGE_VERSION_SUFFIX** | <code>false</code> | If true, appends a machine-type-specific suffix (for example, "-gen2") to the machine image version for Azure workers. |
+| **APP_INFRASTRUCTURE_&#x200b;MANAGER_USE_MACHINE_&#x200b;IMAGE_VERSION_SUFFIX** | <code>true</code> | If true, appends a machine-type-specific suffix (for example, "-gen2") to the machine image version for Azure workers. |
 | **APP_INFRASTRUCTURE_&#x200b;MANAGER_USE_SMALLER_&#x200b;MACHINE_TYPES** | <code>false</code> | If true, provisions trial and freemium clusters using smaller machine types. |
 | **APP_KUBECONFIG_&#x200b;ALLOW_ORIGINS** | <code>*</code> | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. |
 | **APP_KYMA_DASHBOARD_&#x200b;CONFIG_LANDSCAPE_URL** | <code>https://dashboard.dev.kyma.cloud.sap</code> | The base URL of the Kyma Dashboard used to generate links to the web UI for Kyma runtimes. |

--- a/docs/contributor/02-70-chart-config.md
+++ b/docs/contributor/02-70-chart-config.md
@@ -172,7 +172,7 @@
 | infrastructureManager.<br>machineImageVersion | Sets the version of the machine image for nodes in provisioned clusters. If empty, the Gardener default value is used. | `` |
 | infrastructureManager.<br>maxPods | Sets the maximum number of Pods per node for global accounts in the max Pods allowlist. | `200` |
 | infrastructureManager.<br>multiZoneCluster | If true, enables provisioning of clusters with nodes distributed across multiple availability zones. | `true` |
-| infrastructureManager.<br>useMachineImageVersionSuffix | If true, appends a machine-type-specific suffix (for example, "-gen2") to the machine image version for Azure workers. | `False` |
+| infrastructureManager.<br>useMachineImageVersionSuffix | If true, appends a machine-type-specific suffix (for example, "-gen2") to the machine image version for Azure workers. | `True` |
 | infrastructureManager.<br>useSmallerMachineTypes | If true, provisions trial and freemium clusters using smaller machine types. | `false` |
 | kubeconfig.<br>allowOrigins | Specifies which origins are allowed for Cross-Origin Resource Sharing (CORS) on the /kubeconfig endpoint. | `*` |
 | kymaDashboardConfig.<br>landscapeURL | The base URL of the Kyma Dashboard used to generate links to the web UI for Kyma runtimes. | `https://dashboard.dev.kyma.cloud.sap` |

--- a/docs/contributor/03-87-hypervisor-generation.md
+++ b/docs/contributor/03-87-hypervisor-generation.md
@@ -39,9 +39,9 @@ The Azure ResourceSKUs API call is shared between zone discovery and hypervisor 
 
 ## Configuration
 
-| Environment Variable                                          | Helm Value                                           | Default | Description                                                         |
-|---------------------------------------------------------------|------------------------------------------------------|---------|---------------------------------------------------------------------|
-| **APP_INFRASTRUCTURE_MANAGER_USE_MACHINE_IMAGE_VERSION_SUFFIX** | `infrastructureManager.useMachineImageVersionSuffix` | `false` | Enables automatic machine image version suffix detection for Azure. |
+| Environment Variable                                            | Helm Value                                           | Default | Description                                                         |
+|-----------------------------------------------------------------|------------------------------------------------------|---------|---------------------------------------------------------------------|
+| **APP_INFRASTRUCTURE_MANAGER_USE_MACHINE_IMAGE_VERSION_SUFFIX** | `infrastructureManager.useMachineImageVersionSuffix` | `true`  | Enables automatic machine image version suffix detection for Azure. |
 
 ## Upgrading `machineImageVersion`
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -179,7 +179,7 @@ type InfrastructureManager struct {
 	ControlPlaneFailureTolerance string            `envconfig:"optional"`
 	UseSmallerMachineTypes       bool              `envconfig:"default=false"`
 	IngressFilteringPlans        StringList        `envconfig:"default=no-plan"`
-	UseMachineImageVersionSuffix bool              `envconfig:"default=false"`
+	UseMachineImageVersionSuffix bool              `envconfig:"default=true"`
 
 	GcpVolumeSizeGb   int `envconfig:"default=80"`
 	AwsVolumeSizeGb   int `envconfig:"default=80"`

--- a/resources/keb/values.yaml
+++ b/resources/keb/values.yaml
@@ -395,7 +395,7 @@ infrastructureManager:
   # If true, enables provisioning of clusters with nodes distributed across multiple availability zones.
   multiZoneCluster: "true"
   # If true, appends a machine-type-specific suffix (for example, "-gen2") to the machine image version for Azure workers.
-  useMachineImageVersionSuffix: false
+  useMachineImageVersionSuffix: true
   # If true, provisions trial and freemium clusters using smaller machine types.
   useSmallerMachineTypes: "false"
 

--- a/scripts/testing/configure_keb_values.sh
+++ b/scripts/testing/configure_keb_values.sh
@@ -40,3 +40,5 @@ fi
 if [[ -n "$DEPROVISIONING_WORKERS" ]]; then
   yq e ".deprovisioning.workersAmount = $DEPROVISIONING_WORKERS" -i "$VALUES_FILE"
 fi
+
+yq e ".infrastructureManager.useMachineImageVersionSuffix = false" -i "$VALUES_FILE"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Default `APP_INFRASTRUCTURE_MANAGER_USE_MACHINE_IMAGE_VERSION_SUFFIX` to `true` in broker configuration and Helm values
- Update documentation to reflect the new default value

**Related issue(s)**
See also #3352