### PR TITLE
Add Volume Size And Documentation Link To Machine Type Display Names

### DIFF
--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -706,7 +706,7 @@ func NewProvisioningProperties(machineTypesDisplay, additionalMachineTypesDispla
 				Type:            "string",
 				Enum:            ToInterfaceSlice(machineTypes),
 				EnumDisplayName: machineTypesDisplay,
-				Description:     "Specifies the type of the virtual machine.",
+				Description:     "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
 			},
 			AdditionalWorkerNodePools: NewAdditionalWorkerNodePoolsSchema(additionalMachineTypesDisplay, additionalMachineTypes, rejectUnsupportedParameters),
 		},
@@ -858,7 +858,7 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					MinLength:       1,
 					Enum:            ToInterfaceSlice(machineTypes),
 					EnumDisplayName: machineTypesDisplay,
-					Description:     "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+					Description:     "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
 				},
 				HAZones: &Type{
 					Type:        "boolean",

--- a/internal/broker/schemas.go
+++ b/internal/broker/schemas.go
@@ -433,7 +433,7 @@ func insertVolumeSize(displayName string, volGb int) string {
 	// Find last ')' — may have trailing text after it (e.g. " - note")
 	idx := strings.LastIndex(name, ")")
 	if idx < 0 {
-		return fmt.Sprintf("%s, %dGi volume%s", displayName, volGb, suffix)
+		return fmt.Sprintf("%s, %dGi volume%s", name, volGb, suffix)
 	}
 	return fmt.Sprintf("%s, %dGi volume)%s%s", name[:idx], volGb, name[idx+1:], suffix)
 }

--- a/internal/broker/schemas.go
+++ b/internal/broker/schemas.go
@@ -413,17 +413,27 @@ func (s *SchemaService) machineDisplayNames(cp pkg.CloudProvider, machines []str
 	for machineType, displayName := range names {
 		resolved := strings.ToLower(s.providerSpec.ResolveMachineType(cp, machineType))
 		if volGb, ok := providerSizes[resolved]; ok {
-			switch {
-			case strings.HasSuffix(displayName, ")*"):
-				enriched[machineType] = fmt.Sprintf("%s, %dGi volume)*", strings.TrimSuffix(displayName, ")*"), volGb)
-			case strings.HasSuffix(displayName, ")"):
-				enriched[machineType] = fmt.Sprintf("%s, %dGi volume)", strings.TrimSuffix(displayName, ")"), volGb)
-			default:
-				enriched[machineType] = fmt.Sprintf("%s, %dGi volume", displayName, volGb)
-			}
+			enriched[machineType] = insertVolumeSize(displayName, volGb)
 		} else {
 			enriched[machineType] = displayName
 		}
 	}
 	return enriched
+}
+
+// insertVolumeSize inserts ", <n>Gi volume" before the last closing parenthesis in the display name.
+// If the name contains no parenthesis group it appends to the end.
+func insertVolumeSize(displayName string, volGb int) string {
+	suffix := ""
+	name := displayName
+	if strings.HasSuffix(name, "*") {
+		suffix = "*"
+		name = strings.TrimSuffix(name, "*")
+	}
+	// Find last ')' — may have trailing text after it (e.g. " - note")
+	idx := strings.LastIndex(name, ")")
+	if idx < 0 {
+		return fmt.Sprintf("%s, %dGi volume%s", displayName, volGb, suffix)
+	}
+	return fmt.Sprintf("%s, %dGi volume)%s%s", name[:idx], volGb, name[idx+1:], suffix)
 }

--- a/internal/broker/schemas_test.go
+++ b/internal/broker/schemas_test.go
@@ -144,3 +144,52 @@ aws,build-runtime-aws:
 	require.NoError(t, err)
 	assert.False(t, plansSpec.IsUpgradable("aws"))
 }
+
+func TestMachineDisplayNames(t *testing.T) {
+	providers, err := configuration.NewProviderSpec(strings.NewReader(`
+azure:
+  machines:
+    Standard_D4s: Standard_D4s (4vCPU, 16GB RAM)
+    Standard_D4s_v5: Standard_D4s_v5 (4vCPU, 16GB RAM) - use version-agnostic Standard_D4s
+    Standard_D4_v3: Standard_D4_v3 (4vCPU, 16GB RAM) - use version-agnostic Standard_D4s
+    Standard_F2s_v2: Standard_F2s_v2 (2vCPU, 4GB RAM)
+    Standard_NC4as_T4_v3: Standard_NC4as_T4_v3 (1GPU, 4vCPU, 28GB RAM)*
+    Standard_NC8as_T4_v3: Standard_NC4as_T4_v3 (1GPU, 4vCPU, 28GB RAM)* - test
+  machinesVersions:
+    Standard_D{size}s: Standard_D{size}s_v5
+    Standard_D{size}s_v5: Standard_D{size}s_v5
+    Standard_D{size}_v3: Standard_D{size}s_v5
+`))
+	require.NoError(t, err)
+
+	volumeProvider := &fixedVolumeSizeProvider{
+		sizes: map[runtime.CloudProvider]map[string]int{
+			runtime.Azure: {
+				"standard_d4s_v5":      80,
+				"standard_f2s_v2":      80,
+				"standard_nc4as_t4_v3": 80,
+				"standard_nc8as_t4_v3": 86,
+			},
+		},
+	}
+
+	svc := NewSchemaService(providers, nil, nil, Config{}, StringList{}, &fixture.FakeChannelResolver{}, volumeProvider)
+
+	// When
+	result := svc.machineDisplayNames(runtime.Azure, []string{
+		"Standard_D4s",
+		"Standard_D4s_v5",
+		"Standard_D4_v3",
+		"Standard_F2s_v2",
+		"Standard_NC4as_T4_v3",
+		"Standard_NC8as_T4_v3",
+	})
+
+	// Then
+	assert.Equal(t, "Standard_D4s (4vCPU, 16GB RAM, 80Gi volume)", result["Standard_D4s"])
+	assert.Equal(t, "Standard_D4s_v5 (4vCPU, 16GB RAM, 80Gi volume) - use version-agnostic Standard_D4s", result["Standard_D4s_v5"])
+	assert.Equal(t, "Standard_D4_v3 (4vCPU, 16GB RAM, 80Gi volume) - use version-agnostic Standard_D4s", result["Standard_D4_v3"])
+	assert.Equal(t, "Standard_F2s_v2 (2vCPU, 4GB RAM, 80Gi volume)", result["Standard_F2s_v2"])
+	assert.Equal(t, "Standard_NC4as_T4_v3 (1GPU, 4vCPU, 28GB RAM, 80Gi volume)*", result["Standard_NC4as_T4_v3"])
+	assert.Equal(t, "Standard_NC4as_T4_v3 (1GPU, 4vCPU, 28GB RAM, 86Gi volume)* - test", result["Standard_NC8as_T4_v3"])
+}

--- a/internal/broker/testdata/alicloud/alicloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/alicloud/alicloud-schema-additional-params-ingress.json
@@ -64,7 +64,7 @@
               "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
               "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "ecs.g9i.large",
               "ecs.g9i.xlarge",
@@ -215,7 +215,7 @@
         "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
         "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "ecs.g9i.large",
         "ecs.g9i.xlarge",

--- a/internal/broker/testdata/alicloud/update-alicloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/alicloud/update-alicloud-schema-additional-params-ingress.json
@@ -60,7 +60,7 @@
               "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
               "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "ecs.g9i.large",
               "ecs.g9i.xlarge",
@@ -203,7 +203,7 @@
         "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
         "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "ecs.g9i.large",
         "ecs.g9i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -244,7 +244,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -244,7 +244,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -238,7 +238,7 @@
         "m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
         "m6i.16xlarge": "m6i.16xlarge (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "m6i.large",
         "m6i.xlarge",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
@@ -50,7 +50,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -189,7 +189,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
@@ -50,7 +50,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -189,7 +189,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -257,7 +257,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -257,7 +257,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -46,7 +46,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -183,7 +183,7 @@
         "Standard_D4s_v5":"Standard_D4s_v5 (4vCPU, 16GB RAM)",
         "Standard_D4_v3":"Standard_D4_v3 (4vCPU, 16GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum":[
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -251,7 +251,7 @@
         "Standard_D48_v3":  "Standard_D48_v3 (48vCPU, 192GB RAM)",
         "Standard_D64_v3":  "Standard_D64_v3 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "Standard_D2s_v5",
         "Standard_D4s_v5",

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -73,7 +73,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -256,7 +256,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -69,7 +69,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -250,7 +250,7 @@
         "n2-standard-48": "n2-standard-48 (48vCPU, 192GB RAM)",
         "n2-standard-64": "n2-standard-64 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "n2-standard-2",
         "n2-standard-4",

--- a/internal/broker/testdata/gdch/gdch-schema.json
+++ b/internal/broker/testdata/gdch/gdch-schema.json
@@ -87,7 +87,7 @@
               "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
               "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "n3-standard-2-gdc",
               "n3-standard-4-gdc",
@@ -198,7 +198,7 @@
         "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
         "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "n3-standard-2-gdc",
         "n3-standard-4-gdc",

--- a/internal/broker/testdata/gdch/update-gdch-schema.json
+++ b/internal/broker/testdata/gdch/update-gdch-schema.json
@@ -84,7 +84,7 @@
               "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
               "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "n3-standard-2-gdc",
               "n3-standard-4-gdc",
@@ -193,7 +193,7 @@
         "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
         "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "n3-standard-2-gdc",
         "n3-standard-4-gdc",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -212,7 +212,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [
@@ -206,7 +206,7 @@
         "g_c32_m128": "g_c32_m128 (32vCPU, 128GB RAM)",
         "g_c64_m256": "g_c64_m256 (64vCPU, 256GB RAM)"
       },
-      "description": "Specifies the type of the virtual machine.",
+      "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>.",
       "enum": [
         "g_c2_m8",
         "g_c4_m16",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `insertVolumeSize` helper to insert volume size into machine type display names, handling trailing text and `*` suffix
- Update machine type description to include a link to documentation about version-agnostic machine types
- Update testdata JSON fixtures to reflect new descriptions

**Related issue(s)**
See also https://github.tools.sap/kyma/backlog/issues/10042