### PR TITLE
Update Machine Type Description for Worker Node Pools

### DIFF
--- a/internal/broker/plans_schema.go
+++ b/internal/broker/plans_schema.go
@@ -858,7 +858,7 @@ func NewAdditionalWorkerNodePoolsSchema(machineTypesDisplay map[string]string, m
 					MinLength:       1,
 					Enum:            ToInterfaceSlice(machineTypes),
 					EnumDisplayName: machineTypesDisplay,
-					Description:     "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+					Description:     "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
 				},
 				HAZones: &Type{
 					Type:        "boolean",

--- a/internal/broker/testdata/alicloud/alicloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/alicloud/alicloud-schema-additional-params-ingress.json
@@ -64,7 +64,7 @@
               "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
               "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "ecs.g9i.large",
               "ecs.g9i.xlarge",

--- a/internal/broker/testdata/alicloud/update-alicloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/alicloud/update-alicloud-schema-additional-params-ingress.json
@@ -60,7 +60,7 @@
               "ecs.g9i.large": "ecs.g9i.large (2vCPU, 8GB RAM)",
               "ecs.g9i.xlarge": "ecs.g9i.xlarge (4vCPU, 16GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "ecs.g9i.large",
               "ecs.g9i.xlarge",

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress-eu.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/aws-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/aws/update-aws-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress-eu.json
@@ -50,7 +50,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-lite-schema-additional-params-ingress.json
@@ -50,7 +50,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress-eu.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/azure-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-lite-schema-additional-params-ingress.json
@@ -46,7 +46,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/azure/update-azure-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/gcp-schema-additional-params-ingress.json
@@ -73,7 +73,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/gcp/update-gcp-schema-additional-params-ingress.json
@@ -69,7 +69,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/gdch/gdch-schema.json
+++ b/internal/broker/testdata/gdch/gdch-schema.json
@@ -87,7 +87,7 @@
               "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
               "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "n3-standard-2-gdc",
               "n3-standard-4-gdc",

--- a/internal/broker/testdata/gdch/update-gdch-schema.json
+++ b/internal/broker/testdata/gdch/update-gdch-schema.json
@@ -84,7 +84,7 @@
               "n3-standard-64-gdc": "n3-standard-64-gdc (64vCPU, 256GB RAM)",
               "n3-standard-8-gdc": "n3-standard-8-gdc (8vCPU, 32GB RAM)"
             },
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "enum": [
               "n3-standard-2-gdc",
               "n3-standard-4-gdc",

--- a/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/sap-converged-cloud-schema-additional-params-ingress.json
@@ -52,7 +52,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [

--- a/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
+++ b/internal/broker/testdata/sap-converged-cloud/update-sap-converged-cloud-schema-additional-params-ingress.json
@@ -48,7 +48,7 @@
             "pattern": "^(?!cpu-worker-0$)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "machineType": {
-            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. This setting is permanent, and you cannot change it later. To use a different machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
+            "description": "Specifies the type of the virtual machine. Where available, use the recommended version-agnostic machine type. For more information, see <a href=https://help.sap.com/docs/btp/sap-business-technology-platform/provisioning-and-update-parameters-in-kyma-environment#machine-type>Machine Type</a>. The machine type marked with “*” has limited availability and generates high cost. You can update your virtual machine type only within the general-purpose machine types. You cannot perform updates on compute-intensive machine types. To use a different compute-intensive machine type, you must create a new worker node pool, migrate workloads to it, and decommission the old one.",
             "type": "string",
             "minLength": 1,
             "enum": [


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the `machineType` field description for additional worker node pools to clarify that general-purpose machine types can be updated, while compute-intensive machine types require creating a new worker node pool

**Related issue(s)**