### PR TITLE
Extend release workflow validation with force flag and skip-version check

### DIFF
--- a/.github/workflows/create-and-promote-release.yaml
+++ b/.github/workflows/create-and-promote-release.yaml
@@ -8,6 +8,10 @@ on:
         description: 'Create release'
         default: ""
         required: true
+      force:
+        type: boolean
+        description: 'Skip version validation (use when intentionally skipping versions)'
+        default: false
 
 permissions:
   contents: write
@@ -19,6 +23,7 @@ jobs:
     uses: "./.github/workflows/create-release.yaml"
     with:
       name: ${{ inputs.name }}
+      force: ${{ inputs.force }}
       skip-sec-file-and-chart-bump: false
       dry-run: false
     secrets: inherit

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,6 +27,10 @@ on:
         type: boolean
         description: 'Do not publish'
         default: false
+      force:
+        type: boolean
+        description: 'Skip version validation (use when intentionally skipping versions)'
+        default: false
   workflow_call:
     inputs:
       name:
@@ -41,6 +45,10 @@ on:
       dry-run:
         type: boolean
         description: 'Do not publish'
+        default: false
+      force:
+        type: boolean
+        description: 'Skip version validation (use when intentionally skipping versions)'
         default: false
 
 jobs:
@@ -77,6 +85,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ env.KYMA_ENVIRONMENT_BROKER_REPO }}
           NAME: ${{ inputs.name }}
+          FORCE: ${{ inputs.force }}
         run: python3 scripts/python/release_label_validator.py
 
       - name: Validate notable changes

--- a/scripts/python/release_label_validator.py
+++ b/scripts/python/release_label_validator.py
@@ -87,6 +87,13 @@ try:
             print(f"\nVersion {new_ver} skips more than one increment over the latest release {latest_ver}.")
             print("If this is intentional, re-run the workflow with force=true.")
             sys.exit(1)
+
+        if new_parts <= latest_parts:
+            new_ver = os.getenv('NAME')
+            latest_ver = latest_release['name']
+            print(f"\nVersion {new_ver} does not increment over the latest release {latest_ver}.")
+            print("If this is intentional, re-run the workflow with force=true.")
+            sys.exit(1)
 except ValueError:
     print("\nWarning: could not parse version numbers for increment check, skipping")
 

--- a/scripts/python/release_label_validator.py
+++ b/scripts/python/release_label_validator.py
@@ -15,6 +15,7 @@ with open('.github/release.yml', 'r') as file:
 print(f"One of these labels is required on PR: {label_pool}")
 token = os.getenv('GITHUB_TOKEN')
 repo = os.getenv('REPOSITORY')
+force = os.getenv('FORCE', 'false').lower() == 'true'
 
 response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest', headers={'Authorization': f'token {token}'})
 response.raise_for_status()
@@ -50,9 +51,44 @@ print('\n'.join([f"PR: {pr}" for pr in valid_prs]))
 if invalid_prs:
     print("\nThese PRs don't have exactly one required label:")
     print('\n'.join([f"PR: {pr}" for pr in invalid_prs]))
-    sys.exit(1) 
+    sys.exit(1)
 
 print("\nAll PRs have exactly one required label")
+
+if force:
+    print("\nforce=true: skipping version increment and kind/feature checks")
+    sys.exit(0)
+
+latest_release_name = latest_release['name'].lstrip('v').split(".")
+new_release_name = os.getenv('NAME').lstrip('v').split(".")
+
+# Check that the new version doesn't skip more than one increment.
+# Compare major, minor, patch independently and ensure no segment jumps by more than 1.
+try:
+    latest_parts = [int(x) for x in latest_release_name]
+    new_parts = [int(x) for x in new_release_name]
+
+    if len(latest_parts) == 3 and len(new_parts) == 3:
+        latest_major, latest_minor, latest_patch = latest_parts
+        new_major, new_minor, new_patch = new_parts
+
+        skip_detected = False
+        if new_major > latest_major + 1:
+            skip_detected = True
+        elif new_major == latest_major:
+            if new_minor > latest_minor + 1:
+                skip_detected = True
+            elif new_minor == latest_minor and new_patch > latest_patch + 1:
+                skip_detected = True
+
+        if skip_detected:
+            latest_ver = latest_release['name']
+            new_ver = os.getenv('NAME')
+            print(f"\nVersion {new_ver} skips more than one increment over the latest release {latest_ver}.")
+            print("If this is intentional, re-run the workflow with force=true.")
+            sys.exit(1)
+except ValueError:
+    print("\nWarning: could not parse version numbers for increment check, skipping")
 
 if feature_prs:
     latest_release_name = latest_release['name'].split(".")


### PR DESCRIPTION
Add a `force` boolean input (default `false`) to the release workflows. When `force=true`, all version validation is skipped — for cases where an intentional version skip is needed.

Extend `release_label_validator.py` with a new check: if the provided version skips more than one increment over the latest release (e.g. `1.35.6` → `1.35.8`), the workflow fails with a message directing the user to set `force=true` if intentional.

The existing `kind/feature` → minor bump check is also bypassed by `force=true`.

#3247 