### PR TITLE
Fix Version Validation Bugs in Release Label Validator

### DIFF
--- a/scripts/python/release_label_validator.py
+++ b/scripts/python/release_label_validator.py
@@ -59,8 +59,13 @@ if force:
     print("\nforce=true: skipping version increment and kind/feature checks")
     sys.exit(0)
 
+name_input = os.getenv('NAME')
+if not name_input:
+    print("Error: NAME environment variable is not set")
+    sys.exit(1)
+
 latest_release_name = latest_release['name'].lstrip('v').split(".")
-new_release_name = os.getenv('NAME').lstrip('v').split(".")
+new_release_name = name_input.lstrip('v').split(".")
 
 # Check that the new version doesn't skip more than one increment.
 # Compare major, minor, patch independently and ensure no segment jumps by more than 1.
@@ -75,6 +80,9 @@ try:
         skip_detected = False
         if new_major > latest_major + 1:
             skip_detected = True
+        elif new_major == latest_major + 1:
+            if new_minor > 0 or new_patch > 0:
+                skip_detected = True
         elif new_major == latest_major:
             if new_minor > latest_minor + 1:
                 skip_detected = True
@@ -83,15 +91,18 @@ try:
 
         if skip_detected:
             latest_ver = latest_release['name']
-            new_ver = os.getenv('NAME')
-            print(f"\nVersion {new_ver} skips more than one increment over the latest release {latest_ver}.")
+            print(f"\nVersion {name_input} skips more than one increment over the latest release {latest_ver}.")
             print("If this is intentional, re-run the workflow with force=true.")
             sys.exit(1)
 
-        if new_parts <= latest_parts:
-            new_ver = os.getenv('NAME')
+        if tuple(new_parts) < tuple(latest_parts):
             latest_ver = latest_release['name']
-            print(f"\nVersion {new_ver} does not increment over the latest release {latest_ver}.")
+            print(f"\nVersion {name_input} is not newer than the latest release {latest_ver}.")
+            print("If this is intentional, re-run the workflow with force=true.")
+            sys.exit(1)
+        if tuple(new_parts) == tuple(latest_parts):
+            latest_ver = latest_release['name']
+            print(f"\nVersion {name_input} does not increment over the latest release {latest_ver}.")
             print("If this is intentional, re-run the workflow with force=true.")
             sys.exit(1)
 except ValueError:
@@ -99,7 +110,7 @@ except ValueError:
 
 if feature_prs:
     latest_release_name = latest_release['name'].split(".")
-    new_release_name = os.getenv('NAME').split(".")
+    new_release_name = name_input.split(".")
     if latest_release_name[0] == new_release_name[0] and latest_release_name[1] == new_release_name[1]:
         print("\nThese PRs have kind/feature label, but only the patch version number was bumped:\n" + '\n'.join([f"PR: {pr}" for pr in feature_prs]))
         sys.exit(1)

--- a/scripts/python/release_label_validator.py
+++ b/scripts/python/release_label_validator.py
@@ -81,7 +81,7 @@ try:
         if new_major > latest_major + 1:
             skip_detected = True
         elif new_major == latest_major + 1:
-            if new_minor > 0 or new_patch > 0:
+            if new_minor != 0 or new_patch != 0:
                 skip_detected = True
         elif new_major == latest_major:
             if new_minor > latest_minor + 1:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Guard against `None` dereference when `NAME` env var is unset — validate early and exit with a clear error
- Add missing major-version skip detection case (e.g. `1.9.5 → 2.3.0`)
- Replace ambiguous list comparison with explicit `tuple()` checks for version regression detection

**Related issue(s)**
See also #3247
See also kyma-project/btp-manager#1608