### PR TITLE
Run Unit Tests Only After Release Validation Succeeds

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -97,6 +97,7 @@ jobs:
 
   run-unit-tests:
     name: Unit tests, go mod tidy
+    needs: [validate-release]
     uses: "./.github/workflows/run-unit-tests-reusable.yaml"
 
   build-keb-image:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add \`needs: [validate-release]\` to the \`run-unit-tests\` job so unit tests are skipped when release validation fails

**Related issue(s)**