### PR TITLE
Fix CredentialsBinding Not Released When Operation Fails Early

### DIFF
--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -233,7 +233,7 @@ func newBrokerSuiteTest(t *testing.T, o *suiteOptions) *BrokerSuiteTest {
 	deprovisionManager := process.NewStagedManager(db.Operations(), eventBroker, time.Hour, cfg.Deprovisioning, log.With("deprovisioning", "manager"))
 
 	deprovisioningQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, cfg, db,
-		k8sClientProvider, cli, configProvider, gardenerClient, "kyma", log)
+		k8sClientProvider, cli, configProvider, gardenerClientWithNamespace, "kyma", log)
 	deprovisionManager.SpeedUp(testSuiteSpeedUpFactor)
 
 	deprovisioningQueue.SpeedUp(testSuiteSpeedUpFactor)

--- a/cmd/broker/broker_suite_test.go
+++ b/cmd/broker/broker_suite_test.go
@@ -323,6 +323,9 @@ func createSubscriptions(t *testing.T, gardenerClient *dynamicFake.FakeDynamicCl
 		"sb-azure": {
 			"hyperscalerType": "azure",
 		},
+		"sb-azure-2": {
+			"hyperscalerType": "azure",
+		},
 		"sb-aws": {
 			"hyperscalerType": "aws",
 		},

--- a/cmd/broker/deprovisioning.go
+++ b/cmd/broker/deprovisioning.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"k8s.io/client-go/dynamic"
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 
 	"github.com/kyma-project/kyma-environment-broker/internal/config"
 
@@ -17,7 +17,7 @@ import (
 
 func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, deprovisionManager *process.StagedManager,
 	cfg *Config, db storage.BrokerStorage,
-	k8sClientProvider K8sClientProvider, kcpClient client.Client, configProvider config.Provider, gardenerClient dynamic.Interface, gardenerNamespace string, logs *slog.Logger) *process.Queue {
+	k8sClientProvider K8sClientProvider, kcpClient client.Client, configProvider config.Provider, gardenerClient *kebgardener.Client, gardenerNamespace string, logs *slog.Logger) *process.Queue {
 
 	deprovisioningSteps := []struct {
 		disabled bool
@@ -39,10 +39,10 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 			step: deprovisioning.NewDeleteRuntimeResourceStep(db, kcpClient),
 		},
 		{
-			step: deprovisioning.NewCheckRuntimeResourceDeletionStep(db, kcpClient, cfg.StepTimeouts.CheckRuntimeResourceDeletion),
+			step: deprovisioning.NewCheckRuntimeResourceDeletionStep(db, kcpClient, gardenerClient, cfg.StepTimeouts.CheckRuntimeResourceDeletion),
 		},
 		{
-			step: deprovisioning.NewFreeCredentialsBindingStep(db.Operations(), db.Instances(), gardenerClient, gardenerNamespace),
+			step: deprovisioning.NewFreeCredentialsBindingStep(db.Operations(), db.Instances(), gardenerClient.Interface, gardenerNamespace),
 		},
 		{
 			step: deprovisioning.NewArchivingStep(db),

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -409,7 +409,7 @@ func main() {
 
 	deprovisionManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.Broker.OperationTimeout, cfg.Deprovisioning, log.With("deprovisioning", "manager"))
 	deprovisionQueue := NewDeprovisioningProcessingQueue(ctx, cfg.Deprovisioning.WorkersAmount, deprovisionManager, &cfg, db,
-		skrK8sClientProvider, kcpK8sClient, configProvider, dynamicGardener, gardenerNamespace, log)
+		skrK8sClientProvider, kcpK8sClient, configProvider, gardenerClient, gardenerNamespace, log)
 
 	updateManager := process.NewStagedManager(db.Operations(), eventBroker, cfg.Broker.OperationTimeout, cfg.Update, log.With("update", "manager"))
 	updateQueue := NewUpdateProcessingQueue(ctx, updateManager, cfg.Update.WorkersAmount, db, cfg, kcpK8sClient, log, workersProvider, schemaService, plansSpec, configProvider, providerSpec, gardenerClient, factory, kcrVolumeProvider)

--- a/cmd/broker/provisioning.go
+++ b/cmd/broker/provisioning.go
@@ -61,14 +61,14 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *proce
 			step: provisioning.NewCreateResourceNamesStep(db.Operations()),
 		},
 		{
-			step: provisioning.NewCreateRuntimeResourceStep(db, k8sClient, cfg.InfrastructureManager, defaultOIDC, workersProvider, providerSpec, cfg.GlobalAccounts(), kcrVolumeProvider, cfg.Broker.AuditLogAccess),
+			step: provisioning.NewCreateRuntimeResourceStep(db, k8sClient, gardenerClient, cfg.InfrastructureManager, defaultOIDC, workersProvider, providerSpec, cfg.GlobalAccounts(), kcrVolumeProvider, cfg.Broker.AuditLogAccess),
 		},
 		{
-			step: steps.NewCheckRuntimeResourceProvisioningStep(db.Operations(), k8sClient, internal.RetryTuple{Timeout: cfg.StepTimeouts.CheckRuntimeResourceCreate, Interval: resourceStateRetryInterval}, provisioningTakesLongThreshold),
+			step: steps.NewCheckRuntimeResourceProvisioningStep(db.Operations(), k8sClient, gardenerClient, internal.RetryTuple{Timeout: cfg.StepTimeouts.CheckRuntimeResourceCreate, Interval: resourceStateRetryInterval}, provisioningTakesLongThreshold),
 		},
 		{
 			condition: provisioning.WhenBTPOperatorCredentialsProvided,
-			step:      provisioning.NewInjectBTPOperatorCredentialsStep(db.Operations(), k8sClientProvider),
+			step:      provisioning.NewInjectBTPOperatorCredentialsStep(db.Operations(), k8sClientProvider, gardenerClient),
 		},
 		{
 			step: provisioning.NewApplyKymaStep(db.Operations(), k8sClient),

--- a/common/gardener/client.go
+++ b/common/gardener/client.go
@@ -57,6 +57,28 @@ func (c *Client) GetCredentialsBinding(name string) (*CredentialsBinding, error)
 	return NewCredentialsBinding(*binding), err
 }
 
+func (c *Client) MarkCredentialsBindingDirty(ctx context.Context, name string, log interface{ Info(string, ...any) }) error {
+	if name == "" {
+		log.Info("MarkCredentialsBindingDirty: no credentials binding name, skipping")
+		return nil
+	}
+	binding, err := c.Resource(CredentialsBindingResource).Namespace(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting credentials binding %s: %w", name, err)
+	}
+	labels := binding.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[DirtyLabelKey] = "true"
+	binding.SetLabels(labels)
+	_, err = c.Resource(CredentialsBindingResource).Namespace(c.namespace).Update(ctx, binding, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating credentials binding %s: %w", name, err)
+	}
+	return nil
+}
+
 func (c *Client) GetCredentialsBindings(labelSelector string) (*unstructured.UnstructuredList, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()

--- a/internal/process/deprovisioning/check_runtime_resource_deletion_step.go
+++ b/internal/process/deprovisioning/check_runtime_resource_deletion_step.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"time"
 
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
+	"github.com/pivotal-cf/brokerapi/v12/domain"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal"
@@ -20,13 +22,17 @@ import (
 
 type CheckRuntimeResourceDeletionStep struct {
 	operationManager                        *process.OperationManager
+	instanceStorage                         storage.Instances
 	kcpClient                               client.Client
+	gardenerClient                          *kebgardener.Client
 	checkRuntimeResourceDeletionStepTimeout time.Duration
 }
 
-func NewCheckRuntimeResourceDeletionStep(db storage.BrokerStorage, kcpClient client.Client, checkRuntimeResourceDeletionStepTimeout time.Duration) *CheckRuntimeResourceDeletionStep {
+func NewCheckRuntimeResourceDeletionStep(db storage.BrokerStorage, kcpClient client.Client, gardenerClient *kebgardener.Client, checkRuntimeResourceDeletionStepTimeout time.Duration) *CheckRuntimeResourceDeletionStep {
 	step := &CheckRuntimeResourceDeletionStep{
 		kcpClient:                               kcpClient,
+		instanceStorage:                         db.Instances(),
+		gardenerClient:                          gardenerClient,
 		checkRuntimeResourceDeletionStepTimeout: checkRuntimeResourceDeletionStepTimeout,
 	}
 	step.operationManager = process.NewOperationManager(db.Operations(), step.Name(), kebError.InfrastructureManagerDependency)
@@ -67,7 +73,11 @@ func (step *CheckRuntimeResourceDeletionStep) Run(operation internal.Operation, 
 
 	if err == nil {
 		logger.Info("Runtime resource still exists")
-		return step.operationManager.RetryOperation(operation, "Runtime resource still exists", nil, 20*time.Second, step.checkRuntimeResourceDeletionStepTimeout, logger)
+		result, backoff, retryErr := step.operationManager.RetryOperation(operation, "Runtime resource still exists", nil, 20*time.Second, step.checkRuntimeResourceDeletionStepTimeout, logger)
+		if result.State == domain.Failed {
+			step.markCBDirty(operation, logger)
+		}
+		return result, backoff, retryErr
 	}
 
 	if !errors.IsNotFound(err) {
@@ -83,4 +93,15 @@ func (step *CheckRuntimeResourceDeletionStep) Run(operation internal.Operation, 
 	return step.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
 		op.RuntimeResourceName = ""
 	}, logger)
+}
+
+func (step *CheckRuntimeResourceDeletionStep) markCBDirty(operation internal.Operation, logger *slog.Logger) {
+	instance, err := step.instanceStorage.GetByID(operation.InstanceID)
+	if err != nil {
+		logger.Warn(fmt.Sprintf("failed to get instance for CB dirty marking: %s", err))
+		return
+	}
+	if err := step.gardenerClient.MarkCredentialsBindingDirty(context.Background(), instance.SubscriptionSecretName, logger); err != nil {
+		logger.Warn(fmt.Sprintf("failed to mark credentials binding dirty: %s", err))
+	}
 }

--- a/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
+++ b/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
@@ -32,7 +32,7 @@ func TestCheckRuntimeResourceDeletionStep_ResourceNotExists(t *testing.T) {
 	kcpClient := fake.NewClientBuilder().Build()
 
 	// when
-	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, time.Minute)
+	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), time.Minute)
 	_, backoff, err := step.Run(op, fixLogger())
 
 	// then
@@ -52,7 +52,7 @@ func TestCheckRuntimeResourceDeletionStep_Run(t *testing.T) {
 	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, "runtime-name")).Build()
 
 	// when
-	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, time.Minute)
+	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), time.Minute)
 	_, backoff, err := step.Run(op, fixLogger())
 
 	// then
@@ -94,7 +94,7 @@ func TestCheckRuntimeResourceDeletionStep_D1_CredentialsBindingMarkedDirtyOnTime
 	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
 
 	// Negative timeout forces immediate failure
-	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, -1*time.Second)
+	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, kgardener.NewClient(fakeGardenerClient, testNamespace), -1*time.Second)
 
 	// when
 	result, backoff, _ := step.Run(op, fixLogger())

--- a/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
+++ b/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	kgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	kgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
@@ -25,7 +25,7 @@ func TestCheckRuntimeResourceDeletionStep_ResourceNotExists(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	op := fixture.FixDeprovisioningOperationAsOperation(fixOperationID, fixInstanceID)
-	op.RuntimeResourceName = "runtime-name"
+	op.RuntimeResourceName = runtimeResourceName
 	op.KymaResourceNamespace = kymaNamespace
 	memoryStorage := storage.NewMemoryStorage()
 	assert.NoError(t, memoryStorage.Operations().InsertOperation(op))
@@ -45,11 +45,11 @@ func TestCheckRuntimeResourceDeletionStep_Run(t *testing.T) {
 	err := imv1.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)
 	op := fixture.FixDeprovisioningOperationAsOperation(fixOperationID, fixInstanceID)
-	op.RuntimeResourceName = "runtime-name"
+	op.RuntimeResourceName = runtimeResourceName
 	op.KymaResourceNamespace = kymaNamespace
 	memoryStorage := storage.NewMemoryStorage()
 	assert.NoError(t, memoryStorage.Operations().InsertOperation(op))
-	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, "runtime-name")).Build()
+	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, runtimeResourceName)).Build()
 
 	// when
 	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), time.Minute)
@@ -78,13 +78,13 @@ func TestCheckRuntimeResourceDeletionStep_D1_CredentialsBindingMarkedDirtyOnTime
 	assert.NoError(t, memoryStorage.Instances().Insert(instance))
 
 	op := fixture.FixDeprovisioningOperationAsOperation(fixOperationID, fixInstanceID)
-	op.RuntimeResourceName = "runtime-name"
+	op.RuntimeResourceName = runtimeResourceName
 	op.KymaResourceNamespace = kymaNamespace
 	op.CreatedAt = op.CreatedAt.Add(-2 * time.Hour) // force timeout
 	assert.NoError(t, memoryStorage.Operations().InsertOperation(op))
 
 	// Runtime still exists → step keeps retrying until timeout
-	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, "runtime-name")).Build()
+	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, runtimeResourceName)).Build()
 
 	// Claimed CB (tenantName set, not shared)
 	claimedCB := newDeletionCheckCBHelper(cbName, testNamespace, map[string]string{

--- a/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
+++ b/internal/process/deprovisioning/check_runtime_resource_deletion_step_test.go
@@ -1,13 +1,19 @@
 package deprovisioning
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	kgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
+	"github.com/pivotal-cf/brokerapi/v12/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -52,4 +58,62 @@ func TestCheckRuntimeResourceDeletionStep_Run(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.NotZero(t, backoff)
+}
+
+func TestCheckRuntimeResourceDeletionStep_D1_CredentialsBindingMarkedDirtyOnTimeout(t *testing.T) {
+	// D1 (RED): When CheckRuntimeResourceDeletionStep times out (OperationFailed), the
+	// claimed CredentialsBinding must be marked dirty=true.
+	// Currently fails because CheckRuntimeResourceDeletionStep has no gardener client.
+
+	// given
+	const cbName = "aws-claimed"
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+
+	memoryStorage := storage.NewMemoryStorage()
+
+	// Instance with claimed CB
+	instance := fixture.FixInstance(fixInstanceID)
+	instance.SubscriptionSecretName = cbName
+	assert.NoError(t, memoryStorage.Instances().Insert(instance))
+
+	op := fixture.FixDeprovisioningOperationAsOperation(fixOperationID, fixInstanceID)
+	op.RuntimeResourceName = "runtime-name"
+	op.KymaResourceNamespace = kymaNamespace
+	op.CreatedAt = op.CreatedAt.Add(-2 * time.Hour) // force timeout
+	assert.NoError(t, memoryStorage.Operations().InsertOperation(op))
+
+	// Runtime still exists → step keeps retrying until timeout
+	kcpClient := fake.NewClientBuilder().WithRuntimeObjects(fixRuntimeResource(kymaNamespace, "runtime-name")).Build()
+
+	// Claimed CB (tenantName set, not shared)
+	claimedCB := newDeletionCheckCBHelper(cbName, testNamespace, map[string]string{
+		"hyperscalerType": "aws",
+		"tenantName":      "some-ga",
+	})
+	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
+
+	// Negative timeout forces immediate failure
+	step := NewCheckRuntimeResourceDeletionStep(memoryStorage, kcpClient, -1*time.Second)
+
+	// when
+	result, backoff, _ := step.Run(op, fixLogger())
+
+	// then
+	assert.Zero(t, backoff)
+	assert.Equal(t, domain.Failed, result.State)
+
+	// RED assertion: claimed CB must be dirty after timeout — currently fails.
+	gotCB, err := fakeGardenerClient.Resource(kgardener.CredentialsBindingResource).Namespace(testNamespace).Get(context.Background(), cbName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotCB.GetLabels()["dirty"])
+}
+
+func newDeletionCheckCBHelper(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(labels)
+	u.SetGroupVersionKind(kgardener.CredentialsBindingGVK)
+	return u
 }

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -26,8 +26,8 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/workers"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/process/provisioning/create_runtime_resource_step.go
+++ b/internal/process/provisioning/create_runtime_resource_step.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kyma-project/kyma-environment-broker/internal/workers"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -43,6 +44,7 @@ type CreateRuntimeResourceStep struct {
 	operationManager  *process.OperationManager
 	instanceStorage   storage.Instances
 	k8sClient         client.Client
+	gardenerClient    *kebgardener.Client
 	config            broker.InfrastructureManager
 	oidcDefaultValues pkg.OIDCConfigDTO
 	workersProvider   *workers.Provider
@@ -53,12 +55,13 @@ type CreateRuntimeResourceStep struct {
 	auditLogAccess    bool
 }
 
-func NewCreateRuntimeResourceStep(db storage.BrokerStorage, k8sClient client.Client, infrastructureManagerConfig broker.InfrastructureManager,
+func NewCreateRuntimeResourceStep(db storage.BrokerStorage, k8sClient client.Client, gardenerClient *kebgardener.Client, infrastructureManagerConfig broker.InfrastructureManager,
 	oidcDefaultValues pkg.OIDCConfigDTO, workersProvider *workers.Provider, providerSpec *configuration.ProviderSpec, gaCfg config.GlobalAccountsConfig, kcrVolumeProvider *provider.KCRVolumeProvider,
 	auditLogAccess bool) *CreateRuntimeResourceStep {
 	step := &CreateRuntimeResourceStep{
 		instanceStorage:   db.Instances(),
 		k8sClient:         k8sClient,
+		gardenerClient:    gardenerClient,
 		config:            infrastructureManagerConfig,
 		oidcDefaultValues: oidcDefaultValues,
 		workersProvider:   workersProvider,
@@ -100,6 +103,7 @@ func (s *CreateRuntimeResourceStep) Run(operation internal.Operation, log *slog.
 			if kebError.IsTemporaryError(err) {
 				return s.operationManager.RetryOperation(operation, fmt.Sprintf("while creating Runtime CR object: %s", err), err, kcpRetryInterval, kcpRetryTimeout, log)
 			}
+			s.markCBDirty(context.Background(), operation, log)
 			return s.operationManager.OperationFailed(operation, fmt.Sprintf("while creating Runtime CR object: %s", err), err, log)
 		}
 		err = s.k8sClient.Create(context.Background(), runtimeCR)
@@ -502,6 +506,16 @@ func (s *CreateRuntimeResourceStep) createHighAvailabilityConfiguration(toleranc
 			Type: gardener.FailureToleranceType(*tolerance),
 		},
 	},
+	}
+}
+
+func (s *CreateRuntimeResourceStep) markCBDirty(ctx context.Context, operation internal.Operation, log *slog.Logger) {
+	cbName := ""
+	if operation.ProvisioningParameters.Parameters.TargetSecret != nil {
+		cbName = *operation.ProvisioningParameters.Parameters.TargetSecret
+	}
+	if err := s.gardenerClient.MarkCredentialsBindingDirty(ctx, cbName, log); err != nil {
+		log.Warn(fmt.Sprintf("failed to mark credentials binding dirty: %s", err))
 	}
 }
 

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	kgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	pkg "github.com/kyma-project/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2163,4 +2165,72 @@ func TestCreateRuntimeResourceStep_AdditionalVolumeSizeGi(t *testing.T) {
 	require.NotNil(t, gotRuntime.Spec.Shoot.Provider.Workers[0].Volume)
 	// AWS base volume is 80Gi; AdditionalVolumeSizeGi = 50 → expected 130Gi
 	assert.Equal(t, "130Gi", gotRuntime.Spec.Shoot.Provider.Workers[0].Volume.VolumeSize)
+}
+
+func TestCreateRuntimeResourceStep_P3_CredentialsBindingMarkedDirtyOnOperationFailed(t *testing.T) {
+	// P3 (RED): When CreateRuntimeResourceStep calls OperationFailed (because KCR volume
+	// lookup fails with a non-temporary error), the claimed CredentialsBinding must be
+	// marked dirty=true. Currently fails because the step has no gardener client.
+
+	// given
+	const cbName = "aws-claimed"
+	const gardenerNS = "test"
+
+	assert.NoError(t, imv1.AddToScheme(scheme.Scheme))
+	memoryStorage := storage.NewMemoryStorage()
+	inputConfig := broker.InfrastructureManager{MultiZoneCluster: true, ControlPlaneFailureTolerance: "zone"}
+
+	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
+	// Use a machine type that is NOT in the KCR ConfigMap → lookupVolumeSize returns plain error → OperationFailed
+	operation.ProvisioningParameters.Parameters.MachineType = ptr.String("unknown-machine-type")
+	instance.SubscriptionSecretName = cbName
+	assertInsertions(t, memoryStorage, instance, operation)
+
+	// ConfigMap exists but has no entry for "unknown-machine-type"
+	kcrConfigMap := &coreV1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "consumption-reporter-config", Namespace: "kcp-system"},
+		Data: map[string]string{
+			"nodemeterconfig.yaml": `
+meters:
+  node:
+    machine_types:
+      aws:
+        m6i.4xlarge:
+          default_volume_size: "84Gi"
+`,
+		},
+	}
+	cli := getClientForTests(t)
+	kcrK8sClient := fake.NewClientBuilder().WithObjects(kcrConfigMap).Build()
+	kcrProvider := provider.NewKCRVolumeProvider(kcrK8sClient, "consumption-reporter-config")
+
+	// Claimed CB (tenantName set, not shared)
+	claimedCB := newCreateRuntimeCBHelper(cbName, gardenerNS, map[string]string{
+		"hyperscalerType": "aws",
+		"tenantName":      instance.GlobalAccountID,
+	})
+	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
+
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
+
+	// when
+	op, repeat, _ := step.Run(operation, fixLogger())
+
+	// then
+	assert.Zero(t, repeat)
+	assert.Equal(t, domain.Failed, op.State)
+
+	// RED assertion: claimed CB must be dirty after OperationFailed — currently fails.
+	gotCB, err := fakeGardenerClient.Resource(kgardener.CredentialsBindingResource).Namespace(gardenerNS).Get(context.Background(), cbName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotCB.GetLabels()["dirty"])
+}
+
+func newCreateRuntimeCBHelper(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(labels)
+	u.SetGroupVersionKind(kgardener.CredentialsBindingGVK)
+	return u
 }

--- a/internal/process/provisioning/create_runtime_resource_step_test.go
+++ b/internal/process/provisioning/create_runtime_resource_step_test.go
@@ -104,7 +104,7 @@ func TestCreateRuntimeResourceStep_AllCustom(t *testing.T) {
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -149,7 +149,7 @@ func TestCreateRuntimeResourceStep_CreateACL(t *testing.T) {
 	}
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -208,7 +208,7 @@ func TestCreateRuntimeResourceStep_AllCustomWithOIDCList(t *testing.T) {
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -285,7 +285,7 @@ func TestCreateRuntimeResourceStep_HandleMultipleAdditionalOIDC(t *testing.T) {
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
 
@@ -338,7 +338,7 @@ func TestCreateRuntimeResourceStep_OIDC_MixedCustom(t *testing.T) {
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -368,7 +368,7 @@ func TestCreateRuntimeResourceStep_HandleEmptyOIDCList(t *testing.T) {
 	}
 	assertInsertions(t, memoryStorage, instance, operation)
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -413,7 +413,7 @@ func TestCreateRuntimeResourceStep_HandleNotNilOIDCWithoutListOrObject(t *testin
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -472,7 +472,7 @@ func TestCreateRuntimeResourceStep_HandleOIDCWithJwks(t *testing.T) {
 		}(),
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -575,7 +575,7 @@ func TestCreateRuntimeResourceStep_HandleAdditionalOIDCWithJWKS(t *testing.T) {
 		},
 	}
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
 
@@ -613,7 +613,7 @@ func TestCreateRuntimeResourceStep_FailureToleranceForTrial(t *testing.T) {
 
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -642,7 +642,7 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercial(t *testing.T) {
 
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -671,7 +671,7 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercialWithNoConfig(t *
 
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -700,7 +700,7 @@ func TestCreateRuntimeResourceStep_FailureToleranceForCommercialWithConfiguredNo
 
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, _, err := step.Run(operation, fixLogger())
@@ -731,7 +731,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_EnforceSeed(t *testin
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -779,7 +779,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DisableEnterpriseFilt
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -850,7 +850,7 @@ func TestCreateRuntimeResourceStep_NetworkFilter(t *testing.T) {
 			operation.ProvisioningParameters.ErsContext.LicenseType = ptr.String(testCase.licenseType)
 			operation.ProvisioningParameters.Parameters.IngressFiltering = testCase.ingressFilteringParameter
 			operation.CloudProvider = string(testCase.cloudProvider)
-			step := NewCreateRuntimeResourceStep(memoryStorage, cli, infrastructureManagerConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+			step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), infrastructureManagerConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 			_, repeat, err := step.Run(operation, fixLogger())
 
 			// then
@@ -893,7 +893,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_SingleZone_DefaultAdmin(t *testi
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -946,7 +946,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZoneWithNetworking(t *testi
 
 	cli := getClientForTests(t)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -997,7 +997,7 @@ func TestCreateRuntimeResourceStep_Defaults_AWS_MultiZone(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1049,7 +1049,7 @@ func TestCreateRuntimeResourceStep_DualStack(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1095,7 +1095,7 @@ func TestCreateRuntimeResourceStep_DualStackDisabled(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1132,7 +1132,7 @@ func TestCreateRuntimeResourceStep_DualStackNotSet(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1168,7 +1168,7 @@ func TestCreateRuntimeResourceStep_DualStackIgnoredForUnsupportedPlan(t *testing
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, newTestProviderSpecWithDualStack(), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1209,7 +1209,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1255,7 +1255,7 @@ func TestCreateRuntimeResourceStep_Defaults_Preview_SingleZone_WithRetry(t *test
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1331,7 +1331,7 @@ func TestCreateRuntimeResourceStep_SapConvergedCloud(t *testing.T) {
 			assertInsertions(t, memoryStorage, instance, operation)
 
 			cli := getClientForTests(t)
-			step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+			step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 			// when
 			gotOperation, repeat, err := step.Run(operation, fixLogger())
 
@@ -1385,7 +1385,7 @@ func TestCreateRuntimeResourceStep_Defaults_Freemium(t *testing.T) {
 			assertInsertions(t, memoryStorage, instance, operation)
 
 			cli := getClientForTests(t)
-			step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+			step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 			// when
 			gotOperation, repeat, err := step.Run(operation, fixLogger())
@@ -1446,7 +1446,7 @@ func TestCreateRuntimeResourceStep_AWS_ZonesDiscovery(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, true)), fixture.NewProviderSpecWithZonesDiscovery(t, true), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, true)), fixture.NewProviderSpecWithZonesDiscovery(t, true), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1491,7 +1491,7 @@ func TestCreateRuntimeResourceStep_Free_ZonesDiscovery(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, true)), fixture.NewProviderSpecWithZonesDiscovery(t, true), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, true)), fixture.NewProviderSpecWithZonesDiscovery(t, true), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1525,7 +1525,7 @@ func TestCreateRuntimeResourceStep_AdditionalWorkersNilHandling(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1558,7 +1558,7 @@ func TestCreateRuntimeResourceStep_AdditionalWorkersEmptyHandling(t *testing.T) 
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -1612,7 +1612,7 @@ func TestCreateRuntimeResourceStep_GvisorOnMainWorker(t *testing.T) {
 			assertInsertions(t, memoryStorage, instance, operation)
 
 			cli := getClientForTests(t)
-			step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+			step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 			// when
 			_, repeat, err := step.Run(operation, fixLogger())
@@ -1686,7 +1686,7 @@ func TestCreateRuntimeResourceStep_GvisorIsolation(t *testing.T) {
 
 			cli := getClientForTests(t)
 			providerSpec := fixture.NewProviderSpecWithZonesDiscovery(t, false)
-			step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, providerSpec), providerSpec, config.GlobalAccountsConfig{}, nil, false)
+			step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, providerSpec), providerSpec, config.GlobalAccountsConfig{}, nil, false)
 
 			// when
 			_, repeat, err := step.Run(operation, fixLogger())
@@ -1998,7 +1998,7 @@ meters:
 	cli := getClientForTests(t)
 	kcrK8sClient := fake.NewClientBuilder().WithObjects(kcrConfigMap).Build()
 	kcrProvider := provider.NewKCRVolumeProvider(kcrK8sClient, "consumption-reporter-config")
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -2052,7 +2052,7 @@ meters:
 	cli := getClientForTests(t)
 	kcrK8sClient := fake.NewClientBuilder().WithObjects(kcrConfigMap).Build()
 	kcrProvider := provider.NewKCRVolumeProvider(kcrK8sClient, "consumption-reporter-config")
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, false)), fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, workers.NewProvider(broker.InfrastructureManager{}, fixture.NewProviderSpecWithZonesDiscovery(t, false)), fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -2112,7 +2112,7 @@ aws:
 	cli := getClientForTests(t)
 	kcrK8sClient := fake.NewClientBuilder().WithObjects(kcrConfigMap).Build()
 	kcrProvider := provider.NewKCRVolumeProvider(kcrK8sClient, "consumption-reporter-config")
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, providerSpec, config.GlobalAccountsConfig{}, kcrProvider, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, providerSpec, config.GlobalAccountsConfig{}, kcrProvider, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -2146,7 +2146,7 @@ func TestCreateRuntimeResourceStep_AdditionalVolumeSizeGi(t *testing.T) {
 	assertInsertions(t, memoryStorage, instance, operation)
 
 	cli := getClientForTests(t)
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, nil, false)
 
 	// when
 	_, repeat, err := step.Run(operation, fixLogger())
@@ -2183,6 +2183,7 @@ func TestCreateRuntimeResourceStep_P3_CredentialsBindingMarkedDirtyOnOperationFa
 	instance, operation := fixInstanceAndOperation(broker.AWSPlanID, "eu-west-2", "platform-region", inputConfig, pkg.AWS)
 	// Use a machine type that is NOT in the KCR ConfigMap → lookupVolumeSize returns plain error → OperationFailed
 	operation.ProvisioningParameters.Parameters.MachineType = ptr.String("unknown-machine-type")
+	operation.ProvisioningParameters.Parameters.TargetSecret = ptr.String(cbName)
 	instance.SubscriptionSecretName = cbName
 	assertInsertions(t, memoryStorage, instance, operation)
 
@@ -2211,7 +2212,7 @@ meters:
 	})
 	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
 
-	step := NewCreateRuntimeResourceStep(memoryStorage, cli, inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
+	step := NewCreateRuntimeResourceStep(memoryStorage, cli, kgardener.NewClient(fakeGardenerClient, gardenerNS), inputConfig, defaultOIDSConfig, &workers.Provider{}, fixture.NewProviderSpecWithZonesDiscovery(t, false), config.GlobalAccountsConfig{}, kcrProvider, false)
 
 	// when
 	op, repeat, _ := step.Run(operation, fixLogger())

--- a/internal/process/provisioning/inject_btp_operator_credentials_step.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step.go
@@ -8,8 +8,8 @@ import (
 
 	btpmanagercredentials "github.com/kyma-project/kyma-environment-broker/internal/btpmanager/credentials"
 
-	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/google/uuid"
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/kyma-environment-broker/internal/process"

--- a/internal/process/provisioning/inject_btp_operator_credentials_step.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step.go
@@ -1,12 +1,14 @@
 package provisioning
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
 
 	btpmanagercredentials "github.com/kyma-project/kyma-environment-broker/internal/btpmanager/credentials"
 
+	kebgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/google/uuid"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
@@ -28,11 +30,13 @@ type K8sClientProvider interface {
 type InjectBTPOperatorCredentialsStep struct {
 	operationManager  *process.OperationManager
 	k8sClientProvider K8sClientProvider
+	gardenerClient    *kebgardener.Client
 }
 
-func NewInjectBTPOperatorCredentialsStep(os storage.Operations, k8sClientProvider K8sClientProvider) *InjectBTPOperatorCredentialsStep {
+func NewInjectBTPOperatorCredentialsStep(os storage.Operations, k8sClientProvider K8sClientProvider, gardenerClient *kebgardener.Client) *InjectBTPOperatorCredentialsStep {
 	step := &InjectBTPOperatorCredentialsStep{
 		k8sClientProvider: k8sClientProvider,
+		gardenerClient:    gardenerClient,
 	}
 	step.operationManager = process.NewOperationManager(os, step.Name(), kebError.BtpManagerDependency)
 	return step
@@ -46,6 +50,7 @@ func (s *InjectBTPOperatorCredentialsStep) Run(operation internal.Operation, log
 
 	if operation.RuntimeID == "" {
 		log.Error("Runtime ID is empty")
+		s.markCBDirty(operation, log)
 		return s.operationManager.OperationFailed(operation, "Runtime ID is empty", nil, log)
 	}
 	k8sClient, err := s.k8sClientProvider.K8sClientForRuntimeID(operation.RuntimeID)
@@ -81,4 +86,14 @@ func (s *InjectBTPOperatorCredentialsStep) Run(operation internal.Operation, log
 		return operation, updateSecretBackoff, nil
 	}
 	return operation, 0, nil
+}
+
+func (s *InjectBTPOperatorCredentialsStep) markCBDirty(operation internal.Operation, log *slog.Logger) {
+	cbName := ""
+	if operation.ProvisioningParameters.Parameters.TargetSecret != nil {
+		cbName = *operation.ProvisioningParameters.Parameters.TargetSecret
+	}
+	if err := s.gardenerClient.MarkCredentialsBindingDirty(context.Background(), cbName, log); err != nil {
+		log.Warn(fmt.Sprintf("failed to mark credentials binding dirty: %s", err))
+	}
 }

--- a/internal/process/provisioning/inject_btp_operator_credentials_step_test.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step_test.go
@@ -9,6 +9,7 @@ import (
 
 	btpoperatorcredentials "github.com/kyma-project/kyma-environment-broker/internal/btpmanager/credentials"
 
+	kgardener "github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apicorev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -158,3 +160,56 @@ func createExpectedSecretData(credentials *internal.ServiceManagerOperatorCreden
 		"cluster_id":   []byte(clusterID),
 	}
 }
+
+func TestInjectBTPOperatorCredentialsStep_P6_CredentialsBindingMarkedDirtyOnOperationFailed(t *testing.T) {
+	// P6 (RED): When InjectBTPOperatorCredentialsStep calls OperationFailed (empty RuntimeID),
+	// the claimed CredentialsBinding must be marked dirty=true.
+	// Currently fails because the step has no gardener client.
+
+	// given
+	const cbName = "aws-claimed"
+	const gardenerNS = "test"
+
+	memoryStorage := storage.NewMemoryStorage()
+
+	schm := internal.NewSchemeForTests(t)
+	err := apiextensionsv1.AddToScheme(schm)
+	assert.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(schm).Build()
+
+	operation := fixture.FixProvisioningOperation("op-p6", "inst-p6")
+	operation.RuntimeID = ""
+	operation.ProvisioningParameters.Parameters.TargetSecret = strPtr(cbName)
+
+	// Claimed CB
+	claimedCB := newInjectBTPCBHelper(cbName, gardenerNS, map[string]string{
+		"hyperscalerType": "aws",
+		"tenantName":      "some-ga",
+	})
+	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
+
+	step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient))
+
+	// when
+	op, _, _ := step.Run(operation, fixLogger())
+
+	// then
+	assert.Equal(t, domain.Failed, op.State)
+
+	// RED assertion: claimed CB must be dirty after OperationFailed — currently fails.
+	gotCB, err := fakeGardenerClient.Resource(kgardener.CredentialsBindingResource).Namespace(gardenerNS).Get(context.Background(), cbName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotCB.GetLabels()["dirty"])
+}
+
+func newInjectBTPCBHelper(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(labels)
+	u.SetGroupVersionKind(kgardener.CredentialsBindingGVK)
+	return u
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/process/provisioning/inject_btp_operator_credentials_step_test.go
+++ b/internal/process/provisioning/inject_btp_operator_credentials_step_test.go
@@ -38,7 +38,7 @@ func TestInjectBTPOperatorCredentialsStep(t *testing.T) {
 		operation := fixProvisioningOperationWithClusterIDAndCredentials(k8sClient)
 		expectedSecretData := createExpectedSecretData(operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, operation.ServiceManagerClusterID)
 
-		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient))
+		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient), kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""))
 
 		// when
 		_, _, err = step.Run(operation, fixLogger())
@@ -70,7 +70,7 @@ func TestInjectBTPOperatorCredentialsStep(t *testing.T) {
 		operation := fixture.FixProvisioningOperation("operation-id", "inst-id")
 		operation.RuntimeID = ""
 
-		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient))
+		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient), kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""))
 
 		// when
 		processedOperation, _, _ := step.Run(operation, fixLogger())
@@ -107,7 +107,7 @@ func TestInjectBTPOperatorCredentialsWhenSecretAlreadyExistsStep(t *testing.T) {
 		operation := fixProvisioningOperationWithClusterIDAndCredentials(k8sClient)
 		expectedSecretData := createExpectedSecretData(operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, operation.ServiceManagerClusterID)
 
-		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient))
+		step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient), kgardener.NewClient(kgardener.NewDynamicFakeClient(), ""))
 
 		// when
 		_, _, err = step.Run(operation, fixLogger())
@@ -189,7 +189,7 @@ func TestInjectBTPOperatorCredentialsStep_P6_CredentialsBindingMarkedDirtyOnOper
 	})
 	fakeGardenerClient := kgardener.NewDynamicFakeClient(claimedCB)
 
-	step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient))
+	step := NewInjectBTPOperatorCredentialsStep(memoryStorage.Operations(), kubeconfig.NewFakeK8sClientProvider(k8sClient), kgardener.NewClient(fakeGardenerClient, gardenerNS))
 
 	// when
 	op, _, _ := step.Run(operation, fixLogger())

--- a/internal/process/steps/runtime_resource.go
+++ b/internal/process/steps/runtime_resource.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/kyma-environment-broker/internal/broker"
 	kebError "github.com/kyma-project/kyma-environment-broker/internal/error"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
@@ -26,9 +27,10 @@ func NewCheckRuntimeResourceStep(os storage.Operations, k8sClient client.Client,
 	return step
 }
 
-func NewCheckRuntimeResourceProvisioningStep(os storage.Operations, k8sClient client.Client, runtimeResourceStateRetry internal.RetryTuple, changeDescriptionThreshold time.Duration) *checkRuntimeResourceProvisioning {
+func NewCheckRuntimeResourceProvisioningStep(os storage.Operations, k8sClient client.Client, gardenerClient *gardener.Client, runtimeResourceStateRetry internal.RetryTuple, changeDescriptionThreshold time.Duration) *checkRuntimeResourceProvisioning {
 	step := &checkRuntimeResourceProvisioning{
 		k8sClient:                  k8sClient,
+		gardenerClient:             gardenerClient,
 		runtimeResourceStateRetry:  runtimeResourceStateRetry,
 		changeDescriptionThreshold: changeDescriptionThreshold,
 	}
@@ -44,6 +46,7 @@ type checkRuntimeResource struct {
 
 type checkRuntimeResourceProvisioning struct {
 	k8sClient                  client.Client
+	gardenerClient             *gardener.Client
 	operationManager           *process.OperationManager
 	runtimeResourceStateRetry  internal.RetryTuple
 	changeDescriptionThreshold time.Duration
@@ -96,19 +99,23 @@ func (s *checkRuntimeResourceProvisioning) Run(operation internal.Operation, log
 	log.Info(fmt.Sprintf("Runtime resource state: %s", state))
 	if state == imv1.RuntimeStateReady {
 		return operation, 0, nil
-	} else {
-		if time.Since(operation.CreatedAt) > s.changeDescriptionThreshold {
-			var backoff time.Duration
-			operation, backoff, _ = s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
-				op.Description = ProvisioningTakesLongerMessage(s.runtimeResourceStateRetry.Timeout)
-			}, log)
-			if backoff != 0 {
-				log.Error("cannot save the operation")
-				return operation, 5 * time.Second, nil
-			}
-		}
-		return s.RetryOrFail(operation, log, runtime)
 	}
+	if state == imv1.RuntimeStateFailed {
+		log.Info(fmt.Sprintf("Runtime resource status: %v; failing operation", runtime.Status))
+		s.markCBDirty(operation, log)
+		return s.operationManager.OperationFailed(operation, fmt.Sprintf("Runtime resource in %s state", imv1.RuntimeStateFailed), nil, log)
+	}
+	if time.Since(operation.CreatedAt) > s.changeDescriptionThreshold {
+		var backoff time.Duration
+		operation, backoff, _ = s.operationManager.UpdateOperation(operation, func(op *internal.Operation) {
+			op.Description = ProvisioningTakesLongerMessage(s.runtimeResourceStateRetry.Timeout)
+		}, log)
+		if backoff != 0 {
+			log.Error("cannot save the operation")
+			return operation, 5 * time.Second, nil
+		}
+	}
+	return s.RetryOrFail(operation, log, runtime)
 }
 
 func (s *checkRuntimeResourceProvisioning) RetryOrFail(operation internal.Operation, log *slog.Logger, runtime *imv1.Runtime) (internal.Operation, time.Duration, error) {
@@ -128,12 +135,23 @@ func (s *checkRuntimeResourceProvisioning) RetryOrFail(operation internal.Operat
 			))
 		}
 		log.Error("failing operation and removing Runtime CR")
-		err = s.k8sClient.Delete(context.Background(), runtime)
-		if err != nil {
-			log.Warn(fmt.Sprintf("unable to delete Runtime resource %s/%s: %s", runtime.Name, runtime.Namespace, err))
+		s.markCBDirty(operation, log)
+		deleteErr := s.k8sClient.Delete(context.Background(), runtime)
+		if deleteErr != nil {
+			log.Warn(fmt.Sprintf("unable to delete Runtime resource %s/%s: %s", runtime.Name, runtime.Namespace, deleteErr))
 		}
 	}
 	return retryOperation, retry, err
+}
+
+func (s *checkRuntimeResourceProvisioning) markCBDirty(operation internal.Operation, log *slog.Logger) {
+	cbName := ""
+	if operation.ProvisioningParameters.Parameters.TargetSecret != nil {
+		cbName = *operation.ProvisioningParameters.Parameters.TargetSecret
+	}
+	if err := s.gardenerClient.MarkCredentialsBindingDirty(context.Background(), cbName, log); err != nil {
+		log.Warn(fmt.Sprintf("failed to mark credentials binding dirty: %s", err))
+	}
 }
 
 func (s *checkRuntimeResource) GetRuntimeResource(name string, namespace string) (*imv1.Runtime, error) {

--- a/internal/process/steps/runtime_resource_test.go
+++ b/internal/process/steps/runtime_resource_test.go
@@ -124,7 +124,7 @@ func TestCheckRuntimeResourceProvisioningStep(t *testing.T) {
 		existingRuntime := createRuntime(imv1.RuntimeStateReady)
 		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
 
-		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(gardener.NewDynamicFakeClient(), ""), internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 		// when
 		_, backoff, err := step.Run(operation, fixLogger())
@@ -145,7 +145,7 @@ func TestCheckRuntimeResourceProvisioningStep(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
 
 		// force immediate timeout
-		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: -1 * ProvisioningTimeoutForTesting, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(gardener.NewDynamicFakeClient(), ""), internal.RetryTuple{Timeout: -1 * ProvisioningTimeoutForTesting, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 		// when
 		op, backoff, _ := step.Run(operation, fixLogger())
@@ -170,7 +170,7 @@ func TestCheckRuntimeResourceProvisioningStep(t *testing.T) {
 		existingRuntime := createRuntime("In Progress")
 		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
 
-		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(gardener.NewDynamicFakeClient(), ""), internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 		// when
 		postOperation, backoff, err := step.Run(operation, fixLogger())
@@ -194,7 +194,7 @@ func TestCheckRuntimeResourceProvisioningStep(t *testing.T) {
 		existingRuntime := createRuntime("In Progress")
 		k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
 
-		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+		step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(gardener.NewDynamicFakeClient(), ""), internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 		// when
 		postOperation, backoff, err := step.Run(operation, fixLogger())
@@ -257,7 +257,7 @@ func TestCheckRuntimeResourceProvisioningStep_P4_CredentialsBindingMarkedDirtyOn
 	})
 	fakeGardenerClient := gardener.NewDynamicFakeClient(claimedCB)
 
-	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: -1 * ProvisioningTimeoutForTesting, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(fakeGardenerClient, gardenerNS), internal.RetryTuple{Timeout: -1 * ProvisioningTimeoutForTesting, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 	// when
 	op, backoff, _ := step.Run(operation, fixLogger())
@@ -299,7 +299,7 @@ func TestCheckRuntimeResourceProvisioningStep_P5_CredentialsBindingMarkedDirtyOn
 	})
 	fakeGardenerClient := gardener.NewDynamicFakeClient(claimedCB)
 
-	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, gardener.NewClient(fakeGardenerClient, gardenerNS), internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
 
 	// when
 	op, backoff, _ := step.Run(operation, fixLogger())

--- a/internal/process/steps/runtime_resource_test.go
+++ b/internal/process/steps/runtime_resource_test.go
@@ -1,16 +1,20 @@
 package steps
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/kyma-project/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/kyma-environment-broker/internal"
 	"github.com/kyma-project/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v12/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -223,4 +227,101 @@ func createFakeProvisioningOp(opID string) internal.Operation {
 	operation.RuntimeID = "runtime-id-000"
 	operation.ShootName = "c-12345"
 	return operation
+}
+
+func TestCheckRuntimeResourceProvisioningStep_P4_CredentialsBindingMarkedDirtyOnTimeout(t *testing.T) {
+	// P4 (RED): On provisioning timeout (OperationFailed), the claimed CredentialsBinding
+	// must be marked dirty=true.
+	// Currently fails because CheckRuntimeResourceProvisioningStep has no gardener client.
+
+	// given
+	const cbName = "aws-claimed"
+	const gardenerNS = "test"
+
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	os := storage.NewMemoryStorage().Operations()
+
+	operation := createFakeProvisioningOp("p4-timeout")
+	operation.CreatedAt = time.Now().Add(-1 * time.Hour)
+	operation.ProvisioningParameters.Parameters.TargetSecret = strPtr(cbName)
+	err = os.InsertOperation(operation)
+	assert.NoError(t, err)
+
+	existingRuntime := createRuntime("In Progress")
+	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+	claimedCB := newStepsCredentialsBinding(cbName, gardenerNS, map[string]string{
+		"hyperscalerType": "aws",
+		"tenantName":      "some-global-account",
+	})
+	fakeGardenerClient := gardener.NewDynamicFakeClient(claimedCB)
+
+	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: -1 * ProvisioningTimeoutForTesting, Interval: 2 * time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+
+	// when
+	op, backoff, _ := step.Run(operation, fixLogger())
+
+	// then
+	assert.Zero(t, backoff)
+	assert.Equal(t, domain.Failed, op.State)
+
+	// RED assertion: the claimed CB must be dirty after timeout — currently fails.
+	gotCB, err := fakeGardenerClient.Resource(gardener.CredentialsBindingResource).Namespace(gardenerNS).Get(context.Background(), cbName, v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotCB.GetLabels()["dirty"])
+}
+
+func TestCheckRuntimeResourceProvisioningStep_P5_CredentialsBindingMarkedDirtyOnRuntimeFailed(t *testing.T) {
+	// P5 (RED): When Runtime CR enters Failed state (OperationFailed), the claimed
+	// CredentialsBinding must be marked dirty=true.
+	// Currently fails because CheckRuntimeResourceProvisioningStep has no gardener client.
+
+	// given
+	const cbName = "aws-claimed"
+	const gardenerNS = "test"
+
+	err := imv1.AddToScheme(scheme.Scheme)
+	assert.NoError(t, err)
+	os := storage.NewMemoryStorage().Operations()
+
+	operation := createFakeProvisioningOp("p5-failed")
+	operation.ProvisioningParameters.Parameters.TargetSecret = strPtr(cbName)
+	err = os.InsertOperation(operation)
+	assert.NoError(t, err)
+
+	existingRuntime := createRuntime(imv1.RuntimeStateFailed)
+	k8sClient := fake.NewClientBuilder().WithRuntimeObjects(&existingRuntime).Build()
+
+	claimedCB := newStepsCredentialsBinding(cbName, gardenerNS, map[string]string{
+		"hyperscalerType": "aws",
+		"tenantName":      "some-global-account",
+	})
+	fakeGardenerClient := gardener.NewDynamicFakeClient(claimedCB)
+
+	step := NewCheckRuntimeResourceProvisioningStep(os, k8sClient, internal.RetryTuple{Timeout: ProvisioningTimeoutForTesting, Interval: time.Second}, ProvisioningTakesLongerThanUsualForTesting)
+
+	// when
+	op, backoff, _ := step.Run(operation, fixLogger())
+
+	// then
+	assert.Zero(t, backoff)
+	assert.Equal(t, domain.Failed, op.State)
+
+	// RED assertion: the claimed CB must be dirty after Runtime CR failure — currently fails.
+	gotCB, err := fakeGardenerClient.Resource(gardener.CredentialsBindingResource).Namespace(gardenerNS).Get(context.Background(), cbName, v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", gotCB.GetLabels()["dirty"])
+}
+
+func strPtr(s string) *string { return &s }
+
+// newStepsCredentialsBinding builds a fake CredentialsBinding for steps package tests.
+func newStepsCredentialsBinding(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetLabels(labels)
+	u.SetGroupVersionKind(gardener.CredentialsBindingGVK)
+	return u
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

**Gaps fixed:**
When a provisioning or deprovisioning operation fails before `FreeCredentialsBindingStep` executes, the claimed `CredentialsBinding` (identified by `tenantName` label) is left in a permanently stuck state — never returned to the pool. Five such gaps existed:
- P3: `CreateRuntimeResourceStep` fails with non-temporary error (e.g. unknown machine type)
- P4: `CheckRuntimeResourceProvisioningStep` times out
- P5: `CheckRuntimeResourceProvisioningStep` — Runtime CR enters `Failed` state
- P6: `InjectBTPOperatorCredentialsStep` fails due to empty `RuntimeID`
- D1: `CheckRuntimeResourceDeletionStep` times out

**Logic changes:**
- Add `MarkCredentialsBindingDirty(ctx, name, log)` to `gardener.Client` — idempotent, skips gracefully when name is empty
- `CreateRuntimeResourceStep`: mark CB dirty before `OperationFailed` on non-temporary error (P3)
- `checkRuntimeResourceProvisioning`: add `RuntimeStateFailed` fast-path to `Run`; mark CB dirty on timeout and on Runtime `Failed` state (P4, P5)
- `InjectBTPOperatorCredentialsStep`: mark CB dirty before `OperationFailed` on empty `RuntimeID` (P6)
- `CheckRuntimeResourceDeletionStep`: mark CB dirty (via `Instance.SubscriptionSecretName`) when `RetryOperation` times out (D1)
- `NewDeprovisioningProcessingQueue` now accepts `*gardener.Client` instead of `dynamic.Interface`

**Tests added:**
- P3 — `TestCreateRuntimeResourceStep_P3_CredentialsBindingMarkedDirtyOnOperationFailed`
- P4 — `TestCheckRuntimeResourceProvisioningStep_P4_CredentialsBindingMarkedDirtyOnTimeout`
- P5 — `TestCheckRuntimeResourceProvisioningStep_P5_CredentialsBindingMarkedDirtyOnRuntimeFailed`
- P6 — `TestInjectBTPOperatorCredentialsStep_P6_CredentialsBindingMarkedDirtyOnOperationFailed`
- D1 — `TestCheckRuntimeResourceDeletionStep_D1_CredentialsBindingMarkedDirtyOnTimeout`

**Related issue(s)**
See also #3489